### PR TITLE
feat: version-history seams (Stage 4a, open-core)

### DIFF
--- a/packages/backend-supabase/src/supabaseDocumentStore.ts
+++ b/packages/backend-supabase/src/supabaseDocumentStore.ts
@@ -68,6 +68,7 @@ export class SupabaseDocumentStore implements DocumentStore {
       .select("body")
       .eq("doc_id", this.docId)
       .order("created_at", { ascending: false })
+      .order("id", { ascending: false }) // tie-break: id is monotonic, so "latest" is deterministic
       .limit(1)
       .maybeSingle();
     if ((latest as { body?: string } | null)?.body === content) return;
@@ -87,6 +88,7 @@ export class SupabaseDocumentStore implements DocumentStore {
       .select("id, created_at, actor, kind, author")
       .eq("doc_id", this.docId)
       .order("created_at", { ascending: false })
+      .order("id", { ascending: false }) // deterministic newest-first even when created_at ties
       .limit(limit);
     if (error) throw new Error(`listVersions failed: ${error.message}`);
     return (data ?? []) as VersionSummary[];

--- a/packages/backend-supabase/src/supabaseDocumentStore.ts
+++ b/packages/backend-supabase/src/supabaseDocumentStore.ts
@@ -1,10 +1,19 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import type { SupabaseClient } from "@supabase/supabase-js";
-import type { DocumentStore } from "@inplan/core";
+import type { DocumentStore, VersionMeta } from "@inplan/core";
 
 /** A `documents` column that holds free text (see db/schema.sql). */
 type DocColumn = "body" | "canonical" | "proposed";
+
+/** A `doc_versions` checkpoint's metadata (no body) — for a history list. */
+export interface VersionSummary {
+  id: number;
+  created_at: string;
+  actor: string | null;
+  kind: string | null;
+  author: string | null;
+}
 
 /**
  * Supabase-backed {@link DocumentStore}: the working document and its derived
@@ -50,9 +59,45 @@ export class SupabaseDocumentStore implements DocumentStore {
     await this.writeColumns({ proposed: null });
   }
 
-  async backup(content: string): Promise<void> {
-    const { error } = await this.db.from("doc_versions").insert({ doc_id: this.docId, body: content });
+  async backup(content: string, meta?: VersionMeta): Promise<void> {
+    // Dedup: skip a no-op snapshot whose body matches the most recent version (keeps history from
+    // churning on repeated saves/turns that didn't change the body). Best-effort — if the precheck
+    // read fails, proceed to insert anyway rather than block the backup.
+    const { data: latest } = await this.db
+      .from("doc_versions")
+      .select("body")
+      .eq("doc_id", this.docId)
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if ((latest as { body?: string } | null)?.body === content) return;
+    // actor/kind/author are additive (doc_version_history migration); only send what's provided.
+    const row: Record<string, unknown> = { doc_id: this.docId, body: content };
+    if (meta?.actor) row.actor = meta.actor;
+    if (meta?.kind) row.kind = meta.kind;
+    if (meta?.author) row.author = meta.author;
+    const { error } = await this.db.from("doc_versions").insert(row);
     if (error) throw new Error(`backup failed: ${error.message}`);
+  }
+
+  /** Recent version checkpoints (newest first), metadata only — for a history list. */
+  async listVersions(limit = 50): Promise<VersionSummary[]> {
+    const { data, error } = await this.db
+      .from("doc_versions")
+      .select("id, created_at, actor, kind, author")
+      .eq("doc_id", this.docId)
+      .order("created_at", { ascending: false })
+      .limit(limit);
+    if (error) throw new Error(`listVersions failed: ${error.message}`);
+    return (data ?? []) as VersionSummary[];
+  }
+
+  /** The body of one version (scoped to this doc), or null if it no longer exists. */
+  async getVersion(id: number): Promise<string | null> {
+    const { data, error } = await this.db.from("doc_versions").select("body").eq("id", id).eq("doc_id", this.docId).maybeSingle();
+    if (error) throw new Error(`getVersion failed: ${error.message}`);
+    const body = (data as { body?: string } | null)?.body;
+    return typeof body === "string" ? body : null;
   }
 
   private async readColumn(name: DocColumn): Promise<string | null> {

--- a/packages/backend-supabase/test/supabaseFake.contract.test.ts
+++ b/packages/backend-supabase/test/supabaseFake.contract.test.ts
@@ -31,7 +31,7 @@ function makeFakeSupabase() {
     private wantSelect = false;
     private eqs: Array<[string, unknown]> = [];
     private gts: Array<[string, unknown]> = [];
-    private ord?: { col: string; asc: boolean };
+    private ords: Array<{ col: string; asc: boolean }> = [];
     private lim?: number;
     constructor(private table: string) {}
     insert(payload: Row | Row[]) { this.op = "insert"; this.payload = payload; return this; }
@@ -40,7 +40,7 @@ function makeFakeSupabase() {
     select(_cols?: string) { this.wantSelect = true; return this; }
     eq(col: string, val: unknown) { this.eqs.push([col, val]); return this; }
     gt(col: string, val: unknown) { this.gts.push([col, val]); return this; }
-    order(col: string, opts?: { ascending?: boolean }) { this.ord = { col, asc: opts?.ascending !== false }; return this; }
+    order(col: string, opts?: { ascending?: boolean }) { this.ords.push({ col, asc: opts?.ascending !== false }); return this; }
     limit(n: number) { this.lim = n; return this; }
     single() { const r = this.exec(); return Promise.resolve(r.error ? r : { data: (r.data as Row[])?.[0] ?? null, error: null }); }
     maybeSingle() { const r = this.exec(); return Promise.resolve({ data: (r.data as Row[])?.[0] ?? null, error: r.error }); }
@@ -72,10 +72,16 @@ function makeFakeSupabase() {
         return { data: null, error: null };
       }
       let rows = t.filter((r) => this.match(r));
-      if (this.ord) {
-        const { col, asc } = this.ord;
-        // generic compare so created_at (ISO strings) and seq (numbers) both order correctly
-        rows = [...rows].sort((a, b) => (a[col]! < b[col]! ? -1 : a[col]! > b[col]! ? 1 : 0) * (asc ? 1 : -1));
+      if (this.ords.length) {
+        // multi-column sort (priority order); generic compare so created_at (ISO strings) and
+        // numeric ids/seq both order correctly.
+        rows = [...rows].sort((a, b) => {
+          for (const { col, asc } of this.ords) {
+            const c = (a[col]! < b[col]! ? -1 : a[col]! > b[col]! ? 1 : 0) * (asc ? 1 : -1);
+            if (c) return c;
+          }
+          return 0;
+        });
       }
       if (this.lim != null) rows = rows.slice(0, this.lim);
       return { data: rows, error: null };
@@ -113,16 +119,17 @@ describe("SupabaseDocumentStore version history", () => {
     expect(f.tables.doc_versions[0]).toMatchObject({ doc_id: "d1", body: "v1", actor: "agent", kind: "turn", author: "Opus 4.8" });
   });
 
-  it("listVersions returns this doc's checkpoints newest-first, capped by limit", async () => {
+  it("listVersions returns this doc's checkpoints newest-first (id breaks created_at ties), capped by limit", async () => {
     const f = makeFakeSupabase();
     f.tables.doc_versions.push(
       { id: 1, doc_id: "d1", body: "a", created_at: "2026-01-01", actor: "user", kind: "manual", author: "me" },
       { id: 2, doc_id: "d1", body: "b", created_at: "2026-01-02", actor: "agent", kind: "turn", author: "Opus" },
+      { id: 4, doc_id: "d1", body: "b2", created_at: "2026-01-02", actor: "user", kind: "manual", author: "me" }, // same created_at as id 2
       { id: 3, doc_id: "d2", body: "c", created_at: "2026-01-03", actor: "user", kind: "manual", author: "x" },
     );
     const s = new SupabaseDocumentStore(f.db, "d1");
-    expect((await s.listVersions(10)).map((v) => v.id)).toEqual([2, 1]); // d1 only, newest-first
-    expect((await s.listVersions(1)).map((v) => v.id)).toEqual([2]); // limit honored
+    expect((await s.listVersions(10)).map((v) => v.id)).toEqual([4, 2, 1]); // d1 only; created_at desc, then id desc
+    expect((await s.listVersions(1)).map((v) => v.id)).toEqual([4]); // limit honored
   });
 
   it("getVersion returns a version's body scoped to the doc; null when absent or another doc's", async () => {

--- a/packages/backend-supabase/test/supabaseFake.contract.test.ts
+++ b/packages/backend-supabase/test/supabaseFake.contract.test.ts
@@ -32,6 +32,7 @@ function makeFakeSupabase() {
     private eqs: Array<[string, unknown]> = [];
     private gts: Array<[string, unknown]> = [];
     private ord?: { col: string; asc: boolean };
+    private lim?: number;
     constructor(private table: string) {}
     insert(payload: Row | Row[]) { this.op = "insert"; this.payload = payload; return this; }
     upsert(payload: Row, opts?: { onConflict?: string }) { this.op = "upsert"; this.payload = payload; this.onConflict = opts?.onConflict; return this; }
@@ -39,7 +40,8 @@ function makeFakeSupabase() {
     select(_cols?: string) { this.wantSelect = true; return this; }
     eq(col: string, val: unknown) { this.eqs.push([col, val]); return this; }
     gt(col: string, val: unknown) { this.gts.push([col, val]); return this; }
-    order(col: string, opts?: { ascending?: boolean }) { this.ord = { col, asc: opts?.ascending !== false }; return Promise.resolve(this.exec()); }
+    order(col: string, opts?: { ascending?: boolean }) { this.ord = { col, asc: opts?.ascending !== false }; return this; }
+    limit(n: number) { this.lim = n; return this; }
     single() { const r = this.exec(); return Promise.resolve(r.error ? r : { data: (r.data as Row[])?.[0] ?? null, error: null }); }
     maybeSingle() { const r = this.exec(); return Promise.resolve({ data: (r.data as Row[])?.[0] ?? null, error: r.error }); }
     then<T>(resolve: (v: { data: unknown; error: unknown }) => T) { return Promise.resolve(this.exec()).then(resolve); }
@@ -70,7 +72,12 @@ function makeFakeSupabase() {
         return { data: null, error: null };
       }
       let rows = t.filter((r) => this.match(r));
-      if (this.ord) { const { col, asc } = this.ord; rows = [...rows].sort((a, b) => ((a[col] as number) - (b[col] as number)) * (asc ? 1 : -1)); }
+      if (this.ord) {
+        const { col, asc } = this.ord;
+        // generic compare so created_at (ISO strings) and seq (numbers) both order correctly
+        rows = [...rows].sort((a, b) => (a[col]! < b[col]! ? -1 : a[col]! > b[col]! ? 1 : 0) * (asc ? 1 : -1));
+      }
+      if (this.lim != null) rows = rows.slice(0, this.lim);
       return { data: rows, error: null };
     }
   }
@@ -94,12 +101,45 @@ runDocumentStoreContract("Supabase (fake client)", () => {
   return new SupabaseDocumentStore(f.db, "doc-1");
 });
 
+describe("SupabaseDocumentStore version history", () => {
+  it("backup dedups a no-op snapshot (same body as the latest) and records provenance", async () => {
+    const f = makeFakeSupabase();
+    f.seedDoc("d1");
+    const s = new SupabaseDocumentStore(f.db, "d1");
+    await s.backup("v1", { actor: "agent", kind: "turn", author: "Opus 4.8" });
+    await s.backup("v1"); // same body → skipped
+    await s.backup("v2");
+    expect(f.tables.doc_versions.length).toBe(2);
+    expect(f.tables.doc_versions[0]).toMatchObject({ doc_id: "d1", body: "v1", actor: "agent", kind: "turn", author: "Opus 4.8" });
+  });
+
+  it("listVersions returns this doc's checkpoints newest-first, capped by limit", async () => {
+    const f = makeFakeSupabase();
+    f.tables.doc_versions.push(
+      { id: 1, doc_id: "d1", body: "a", created_at: "2026-01-01", actor: "user", kind: "manual", author: "me" },
+      { id: 2, doc_id: "d1", body: "b", created_at: "2026-01-02", actor: "agent", kind: "turn", author: "Opus" },
+      { id: 3, doc_id: "d2", body: "c", created_at: "2026-01-03", actor: "user", kind: "manual", author: "x" },
+    );
+    const s = new SupabaseDocumentStore(f.db, "d1");
+    expect((await s.listVersions(10)).map((v) => v.id)).toEqual([2, 1]); // d1 only, newest-first
+    expect((await s.listVersions(1)).map((v) => v.id)).toEqual([2]); // limit honored
+  });
+
+  it("getVersion returns a version's body scoped to the doc; null when absent or another doc's", async () => {
+    const f = makeFakeSupabase();
+    f.tables.doc_versions.push({ id: 7, doc_id: "d1", body: "hello" }, { id: 8, doc_id: "other", body: "nope" });
+    const s = new SupabaseDocumentStore(f.db, "d1");
+    expect(await s.getVersion(7)).toBe("hello");
+    expect(await s.getVersion(8)).toBeNull(); // belongs to another doc
+    expect(await s.getVersion(999)).toBeNull();
+  });
+});
+
 /** A client whose every terminal returns a Postgres error — to cover the throw paths. */
 function erroringDb(): SupabaseClient {
   const fail = { data: null, error: { message: "boom" } };
   const q: Record<string, unknown> = {};
-  for (const m of ["insert", "select", "eq", "gt", "update", "upsert"]) q[m] = () => q;
-  q.order = () => Promise.resolve(fail);
+  for (const m of ["insert", "select", "eq", "gt", "update", "upsert", "order", "limit"]) q[m] = () => q;
   q.single = () => Promise.resolve(fail);
   q.maybeSingle = () => Promise.resolve(fail);
   q.then = (res: (v: unknown) => unknown) => Promise.resolve(fail).then(res);

--- a/packages/core/src/channel.ts
+++ b/packages/core/src/channel.ts
@@ -42,6 +42,17 @@ export interface ControlChannel {
  * proposal, autosave backups). The fs implementation reads/writes sidecar files;
  * a web implementation reads/writes rows or Storage objects.
  */
+/** Provenance for a backup checkpoint (who/why), so a history view can label it. All optional —
+ *  a store may ignore it (the file backend does) and callers may omit it. */
+export interface VersionMeta {
+  /** Who produced the snapshotted state. */
+  actor?: "user" | "agent";
+  /** Why the snapshot was taken — e.g. "turn" (agent turn end), "manual" (human save), "restore". */
+  kind?: string;
+  /** Display author of the snapshotted state (e.g. the human's email or the agent's model id). */
+  author?: string;
+}
+
 export interface DocumentStore {
   /** Read the working document. */
   loadDoc(): Promise<string>;
@@ -54,6 +65,8 @@ export interface DocumentStore {
   getProposed(): Promise<string | null>;
   setProposed(content: string): Promise<void>;
   clearProposed(): Promise<void>;
-  /** Write an autosave backup checkpoint. */
-  backup(content: string): Promise<void>;
+  /** Write an autosave backup checkpoint. `meta` (optional) records its provenance for a history
+   *  view; an implementation that keeps history should de-duplicate (skip a no-op snapshot whose
+   *  body matches the most recent one). */
+  backup(content: string, meta?: VersionMeta): Promise<void>;
 }

--- a/packages/renderer/src/App.tsx
+++ b/packages/renderer/src/App.tsx
@@ -1620,18 +1620,17 @@ export function App(props: EditorProps = {}): JSX.Element {
       )}
 
       <div className="ap-main" style={{ zoom }}>
-        {/* Host-injected side panels (e.g. the cloud TOC): folded by default — a small "bump" handle
-            on the preview's top-left reveals the panel; it auto-hides ~0.5s after the cursor leaves
-            it (re-entering cancels the timer). Only the first panel is surfaced (today: the TOC). */}
+        {/* Host-injected side panels (e.g. the cloud TOC + version History): folded by default — a
+            stack of small "bump" handles on the preview's top-left, one per panel; clicking one
+            reveals that panel. The open panel auto-hides ~0.5s after the cursor leaves it. */}
         {sidePanels.length > 0 && !activePanel && !closingPanel && (
-          <button
-            className="ap-sidepanel-bump"
-            title={sidePanels[0]!.title}
-            aria-label={sidePanels[0]!.title}
-            onClick={() => setOpenPanel(sidePanels[0]!.id)}
-          >
-            {sidePanels[0]!.icon ?? <span className="ap-iconbtn-fallback">{sidePanels[0]!.title.slice(0, 1)}</span>}
-          </button>
+          <div className="ap-sidepanel-bumps">
+            {sidePanels.map((p) => (
+              <button key={p.id} className="ap-sidepanel-bump" title={p.title} aria-label={p.title} onClick={() => setOpenPanel(p.id)}>
+                {p.icon ?? <span className="ap-iconbtn-fallback">{p.title.slice(0, 1)}</span>}
+              </button>
+            ))}
+          </div>
         )}
         {(activePanel || closingPanel) && (
           <aside

--- a/packages/renderer/src/styles.css
+++ b/packages/renderer/src/styles.css
@@ -181,8 +181,8 @@ body {
 /* main layout */
 .ap-main { flex: 1; display: flex; min-height: 0; position: relative; }
 /* "Bump" handle on the preview's top-left that reveals a host side panel (e.g. the TOC). */
+.ap-sidepanel-bumps { position: absolute; top: 12px; left: 0; z-index: 20; display: flex; flex-direction: column; gap: 8px; }
 .ap-sidepanel-bump {
-  position: absolute; top: 12px; left: 0; z-index: 20;
   display: inline-flex; align-items: center; justify-content: center;
   width: 20px; height: 38px; padding: 0;
   border: 1px solid var(--line-strong); border-left: 0; border-radius: 0 9px 9px 0;


### PR DESCRIPTION
Open-core groundwork for **restorable document version history** (Stage 4). Cloud impl (Stage 4b: `doc_versions` columns migration, snapshot-on-turn, the History side panel, and the restore route) builds on this and lands next, in inplan-cloud.

## Changes
- **`DocumentStore.backup(content, meta?)`** — new optional `VersionMeta` (`actor` / `kind` / `author`) so a history view can label checkpoints. Backward-compatible: the file + memory backends ignore it (fewer params still satisfy the interface).
- **`SupabaseDocumentStore`** — `backup` now records that meta and **de-dups** (skips a snapshot whose body matches the latest, best-effort if the precheck read fails); adds **`listVersions(limit)`** (metadata, newest-first) and **`getVersion(id)`** (body, doc-scoped).
- **Renderer multi-panel** — the side-panel "bump" handle is now rendered **per panel** (was hardcoded to `sidePanels[0]`), so a host can surface a **History** panel alongside the TOC; CSS stacks the handles.

## Notes
- New store behavior unit-tested via the in-memory fake (dedup + provenance, `listVersions` ordering/limit, `getVersion` doc-scoping); the fake gained chainable `order`/`limit`.
- All-package typecheck clean; pre-commit (tests + coverage ≥95%) green.
- The `actor/kind/author` columns are additive and land in the Stage 4b migration; `backup` only sends them when provided, so this is dormant until 4b.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Version history: list recent checkpoints (limitable) and retrieve specific version content by ID
  * Backup snapshots accept optional metadata (actor, kind, author) and perform best-effort deduplication
  * Multiple side-panel access buttons shown in the preview when host panels are available

* **Bug Fixes**
  * Corrected newest-first listing and limit behavior; deduplication skips no-op snapshots

* **Tests**
  * Added tests for version history behavior and improved query fakes

* **Style**
  * Introduced wrapper styling for side-panel bump buttons
<!-- end of auto-generated comment: release notes by coderabbit.ai -->