### PR TITLE
feat(renderer): export lineSegments/isChange/DiffSegment

### DIFF
--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -14,6 +14,9 @@ export { TURN_MODE, resolveMode } from "./mode";
 export type { ModeDescriptor, ModePolicy } from "./mode";
 export { renderMarkdown } from "./markdown";
 export { isInternalDocLink, resolveDocPath } from "./links";
+// Line-diff utilities — pure (no DOM/state), reused by hosts to render version-vs-current diffs.
+export { lineSegments, isChange } from "./textdiff";
+export type { DiffSegment } from "./textdiff";
 export { ProfileMenu } from "./ProfileMenu";
 export { AgentIndicator } from "./AgentIndicator";
 // The English base catalog — hosts register it (and key their own locales off it).


### PR DESCRIPTION
Expose the renderer's pure LCS line-diff utilities (`lineSegments`, `isChange`, and the `DiffSegment` type) on the public `@inplan/renderer` surface.

These are already used internally by the review-diff view; hosts now need them to render **version-vs-current** diffs in a document-history side panel without re-implementing the LCS algorithm. They are pure functions — no DOM, no React state, no new dependencies.

- Additive re-export only; no behavior change.
- `textdiff.ts` is already covered by `renderer/test/textdiff.test.ts`.
- Renderer typecheck + full suite + coverage gate green locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The renderer's public API now exports line-diff utilities for text comparison, enabling external applications to reuse these helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->