### PR TITLE
feat: stage-5 open-core seam — event user attribution + quota-limit messaging

### DIFF
--- a/packages/backend-supabase/src/supabaseControlChannel.ts
+++ b/packages/backend-supabase/src/supabaseControlChannel.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import type { SupabaseClient } from "@supabase/supabase-js";
-import type { ControlChannel, LogEntry, NewLogEntry, WaitToken } from "@inplan/core";
+import type { AppendOptions, ControlChannel, LogEntry, NewLogEntry, WaitToken } from "@inplan/core";
 
 /** How long an editor heartbeat counts as "present" before it is considered stale. */
 const PRESENCE_TTL_MS = 15_000;
@@ -33,10 +33,18 @@ export class SupabaseControlChannel implements ControlChannel {
     private readonly consumerId: string = "default",
   ) {}
 
-  async append(event: NewLogEntry): Promise<LogEntry> {
+  async append(event: NewLogEntry, opts?: AppendOptions): Promise<LogEntry> {
     const { data, error } = await this.db
       .from("events")
-      .insert({ doc_id: this.docId, actor: event.actor, type: event.type, payload: event.payload ?? null })
+      .insert({
+        doc_id: this.docId,
+        actor: event.actor,
+        type: event.type,
+        payload: event.payload ?? null,
+        // Only set user_id when attributed — older deployments may not have the column, and an
+        // unattributed (agent-internal) event leaves it null.
+        ...(opts?.userId ? { user_id: opts.userId } : {}),
+      })
       .select("seq, ts, actor, type, payload")
       .single();
     if (error) throw new Error(`append failed: ${error.message}`);

--- a/packages/backend-supabase/test/supabaseFake.contract.test.ts
+++ b/packages/backend-supabase/test/supabaseFake.contract.test.ts
@@ -180,6 +180,15 @@ describe("SupabaseControlChannel error + presence paths", () => {
     f.tables.cursors.push({ doc_id: "d", consumer_id: "agent" }); // row exists, no seq
     expect(await new SupabaseControlChannel(f.db, "d", "agent").getCursor()).toBe(0);
   });
+
+  it("append writes user_id only when attributed (omits the column otherwise)", async () => {
+    const f = makeFakeSupabase();
+    const c = new SupabaseControlChannel(f.db, "d", "agent");
+    await c.append({ actor: "user", type: "turn_ended" }, { userId: "u-42" });
+    await c.append({ actor: "agent", type: "agent_message" }); // unattributed (agent-internal)
+    expect(f.tables.events[0]).toMatchObject({ doc_id: "d", actor: "user", type: "turn_ended", user_id: "u-42" });
+    expect(f.tables.events[1]).not.toHaveProperty("user_id");
+  });
 });
 
 describe("SupabaseDocumentStore error paths", () => {

--- a/packages/core/src/channel.ts
+++ b/packages/core/src/channel.ts
@@ -13,6 +13,13 @@ import type { LogEntry, NewLogEntry } from "./controlLog";
 /** A unique token identifying one waiter, for the single-waiter lock. */
 export type WaitToken = string;
 
+/** Optional metadata for an {@link ControlChannel.append}. `userId` attributes the event to a
+ *  human (used by metered backends for per-user usage accounting); backends with nowhere to store
+ *  it ignore it. */
+export interface AppendOptions {
+  userId?: string;
+}
+
 /**
  * Wake signal + audit trail + single-waiter lock for one document. The fs
  * implementation wraps the JSONL log, the cursor/lock sidecars, and a file
@@ -20,8 +27,10 @@ export type WaitToken = string;
  * cursor, and a Postgres advisory lock.
  */
 export interface ControlChannel {
-  /** Append one event; resolves to the stored entry (with assigned `seq`/`ts`). */
-  append(event: NewLogEntry): Promise<LogEntry>;
+  /** Append one event; resolves to the stored entry (with assigned `seq`/`ts`). `opts.userId`
+   *  attributes the event to a human (metered backends use it for usage accounting); backends
+   *  without a place to store it ignore the option. */
+  append(event: NewLogEntry, opts?: AppendOptions): Promise<LogEntry>;
   /** Entries appended after `cursor` (a `seq`), plus the new cursor. O(new). */
   readSince(cursor: number): Promise<{ entries: LogEntry[]; cursor: number }>;
   /** Subscribe to change notifications (push). Returns an unsubscribe fn. */

--- a/packages/renderer/src/AgentIndicator.tsx
+++ b/packages/renderer/src/AgentIndicator.tsx
@@ -95,6 +95,9 @@ export function AgentIndicator({
 
   const label = labelFor(location, model);
   const quotaText = quota ? ` · ${Math.round(quota.usedPct * 100)}%${quota.overage ? ` ${t("agent.over")}` : ""}` : "";
+  // Capped plans (no overage) warn as they approach the cap and report when turns are paused. The
+  // hard limit itself is enforced server-side — this is just the heads-up in the indicator.
+  const quotaWarn: "at" | "near" | null = quota && !quota.overage ? (quota.usedPct >= 1 ? "at" : quota.usedPct >= 0.8 ? "near" : null) : null;
   return (
     <div className="ap-agent" ref={ref}>
       <button className="ap-agent-btn" title={`${t("agent.title", { label })}${quotaText}`} aria-label={t("agent.connectionLabel", { label })} aria-expanded={open} onClick={() => setOpen((v) => !v)}>
@@ -109,6 +112,11 @@ export function AgentIndicator({
               : t("agent.none")}
             {quota && (
               <div className="ap-agent-quota">{`${t("agent.plan", { pct: Math.round(quota.usedPct * 100) })}${quota.overage ? ` ${t("agent.overIncluded")}` : ""}`}</div>
+            )}
+            {quotaWarn && (
+              <div className={`ap-agent-quota-warn ap-agent-quota-${quotaWarn}`} role="status">
+                {t(quotaWarn === "at" ? "agent.atLimit" : "agent.nearLimit")}
+              </div>
             )}
           </div>
           {policy && onSetPolicy && (

--- a/packages/renderer/src/i18n.tsx
+++ b/packages/renderer/src/i18n.tsx
@@ -156,6 +156,8 @@ export const EN: Catalog = {
   "agent.plan": "Plan {pct}%",
   "agent.overIncluded": "— over included",
   "agent.over": "(over)",
+  "agent.nearLimit": "Approaching your usage limit",
+  "agent.atLimit": "Usage limit reached — turns are paused until your plan resets or you upgrade",
   "agent.connection": "Agent connection",
   "agent.localCmdHint": "Paste this to your coding agent:",
   "agent.localCmdBody": "Collaborate with me on my inplan plan. Check the CLI with `inplan --version` (if missing, install it: `npm i -g inplan`), sign in with `inplan login`, then run `{cmd}` and work with me through the comments.",

--- a/packages/renderer/src/styles.css
+++ b/packages/renderer/src/styles.css
@@ -130,6 +130,9 @@ body {
 .ap-agent-menu { position: absolute; top: 34px; right: 0; z-index: 40; width: 220px; background: var(--bg); border: 1px solid var(--line); border-radius: 10px; box-shadow: var(--shadow); padding: 8px; }
 .ap-agent-detail { font-size: 12px; padding: 2px 6px 6px; border-bottom: 1px solid var(--line); margin-bottom: 6px; }
 .ap-agent-quota { font-size: 11px; color: var(--muted); margin-top: 2px; }
+.ap-agent-quota-warn { font-size: 11px; margin-top: 4px; line-height: 1.35; }
+.ap-agent-quota-near { color: #b7791f; }
+.ap-agent-quota-at { color: #c0392b; font-weight: 600; }
 .ap-agent-policy { display: flex; flex-direction: column; gap: 2px; }
 .ap-agent-policy-opt { display: flex; align-items: center; gap: 7px; text-align: left; border: 0; background: none; padding: 5px 6px; font: inherit; font-size: 12px; cursor: pointer; border-radius: 6px; color: var(--muted); }
 .ap-agent-policy-opt:hover { background: var(--accent-soft); }

--- a/packages/renderer/test/AgentIndicator.test.tsx
+++ b/packages/renderer/test/AgentIndicator.test.tsx
@@ -48,6 +48,29 @@ describe("AgentIndicator", () => {
     expect(document.body.textContent).toContain("over included");
   });
 
+  it("warns when a capped plan approaches the limit (≥80%, under cap)", () => {
+    render(<AgentIndicator location="cloud" model="Opus" quota={{ usedPct: 0.85, overage: false }} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(document.querySelector(".ap-agent-quota-near")?.textContent).toContain("Approaching your usage limit");
+    expect(document.querySelector(".ap-agent-quota-at")).toBeNull();
+  });
+
+  it("reports a paused state when a capped plan is at/over the limit", () => {
+    render(<AgentIndicator location="cloud" model="Opus" quota={{ usedPct: 1, overage: false }} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(document.querySelector(".ap-agent-quota-at")?.textContent).toContain("Usage limit reached");
+    expect(document.querySelector(".ap-agent-quota-near")).toBeNull();
+  });
+
+  it("shows no limit warning under 80% or when overage is allowed", () => {
+    const { rerender } = render(<AgentIndicator location="cloud" model="Opus" quota={{ usedPct: 0.5, overage: false }} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(document.querySelector(".ap-agent-quota-warn")).toBeNull();
+    // Over the cap but on an overage-allowed plan → never warns/pauses.
+    rerender(<AgentIndicator location="cloud" model="Opus" quota={{ usedPct: 1.2, overage: true }} />);
+    expect(document.querySelector(".ap-agent-quota-warn")).toBeNull();
+  });
+
   it("uses the BYO-key tint when the user brings their own key", () => {
     render(<AgentIndicator location="cloud" model="Opus" byoKey quota={{ usedPct: 0.2, overage: false }} />);
     const pie = screen.getByRole("button").querySelector(".ap-agent-pie") as HTMLElement;

--- a/packages/renderer/test/AgentIndicator.test.tsx
+++ b/packages/renderer/test/AgentIndicator.test.tsx
@@ -65,9 +65,13 @@ describe("AgentIndicator", () => {
   it("shows no limit warning under 80% or when overage is allowed", () => {
     const { rerender } = render(<AgentIndicator location="cloud" model="Opus" quota={{ usedPct: 0.5, overage: false }} />);
     fireEvent.click(screen.getByRole("button"));
+    expect(document.body.textContent).toContain("Plan 50%"); // menu is open
     expect(document.querySelector(".ap-agent-quota-warn")).toBeNull();
-    // Over the cap but on an overage-allowed plan → never warns/pauses.
+    // Over the cap but on an overage-allowed plan → never warns/pauses. rerender keeps the same
+    // instance (open state preserved), so the menu stays open — assert the visible quota to prove
+    // it, keeping the no-warn check meaningful (re-clicking would toggle the menu shut).
     rerender(<AgentIndicator location="cloud" model="Opus" quota={{ usedPct: 1.2, overage: true }} />);
+    expect(document.body.textContent).toContain("Plan 120%");
     expect(document.querySelector(".ap-agent-quota-warn")).toBeNull();
   });
 


### PR DESCRIPTION
Open-core groundwork for managed-agent **usage metering** (Stage 5). Lands before the cloud impl, since cloud CI builds the renderer/core/backend-supabase from open-core `main`.

## Changes
- **`ControlChannel.append(event, opts?)`** gains an optional `{ userId }`. `SupabaseControlChannel` writes `events.user_id` **only when supplied** — deployments without the column, and agent-internal (unattributed) events, leave it null. fs/memory backends are unchanged (fewer params still satisfy the interface). This is the seam the cloud uses to attribute a turn's token usage to the human who triggered it.
- **`AgentIndicator`** surfaces a **near-limit** warning (≥80% of a capped plan) and a **paused-state** notice at/over the cap, derived from the existing `quota` prop; overage-allowed plans never warn. New i18n keys `agent.nearLimit` / `agent.atLimit`.

> The indicator text is only a heads-up — the **hard limit is enforced server-side** in the cloud agent runtime (Stage 5b `checkBudget`, which skips the turn and emits a localized 'limit reached' message).

## Cross-repo note
Adding the two `agent.*` keys to the renderer `enCatalog` will make the **cloud** i18n parity test red until Stage 5b ports the 14 editor-locale translations — the known open-core↔cloud i18n coupling. Merge order: this PR, then promptly 5b.

## Tests
- `supabaseFake.contract.test.ts`: append writes `user_id` when attributed, omits the column otherwise.
- `AgentIndicator.test.tsx`: near-limit (≥80%), paused (≥100%), and no-warning (under 80% / overage) cases.
- Full suite + coverage gate (≥95%) green locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quota usage warnings show when agents approach (≥80%) or reach (≥100%) plan limits.
* **Copy / Localization**
  * Added English messages: "Approaching your usage limit" and "Usage limit reached — turns are paused until your plan resets or you upgrade".
* **Style**
  * New styles for quota warning states (near/at).
* **Tests**
  * Added tests validating quota warning behavior.
* **Chore**
  * Backend now supports optional user attribution when present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->