### PR TITLE
release: 0.1.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6593,7 +6593,7 @@
     },
     "packages/cli": {
       "name": "@inplan/cli",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@inplan/backend-supabase": "0.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inplan/cli",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "private": true,
   "description": "inplan CLI: open / wait / signal orchestration over the document core.",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
Version bump for the npm release. Open-core changes shipped since 0.1.13 (bundled into the `inplan` package's renderer/core):

- **renderer**: `lineSegments`/`isChange`/`DiffSegment` exported (version-vs-current diffs); multi side-panel support (`Api.sidePanels`); **AgentIndicator** near-limit / at-limit quota messaging + `agent.nearLimit`/`agent.atLimit` i18n keys.
- **core / backend-supabase**: `ControlChannel.append(event, { userId })` → writes `events.user_id`; `doc_versions` backup **provenance** (actor/kind/author) + dedup + `listVersions`/`getVersion`.

On merge: tag `v0.1.14` → `release.yml` publishes `inplan@0.1.14` to npm via OIDC + provenance.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/5?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CLI package version updated to 0.1.14

<!-- end of auto-generated comment: release notes by coderabbit.ai -->