### PR TITLE
fix(renderer): collab 'accept proposal' must write the binding (source + persistence)

### DIFF
--- a/packages/renderer/src/App.tsx
+++ b/packages/renderer/src/App.tsx
@@ -1088,11 +1088,12 @@ export function App(props: EditorProps = {}): JSX.Element {
     (segs: DiffSegment[], accepted: boolean[]) => {
       if (!proposal || editingLocked) return; // can't apply while the agent holds the turn
       const body = applySegments(segs, accepted);
+      const prevDoc = docRef.current;
       // Merge comments rather than overwrite with the proposal's stale snapshot:
       // keep everything in the live doc (incl. comments the human added during
       // review) and append any agent-proposed comments not already present, so
       // accepting a proposal never discards review-time comments.
-      const live = docRef.current.comments;
+      const live = prevDoc.comments;
       const have = new Set(live.map((c) => c.id));
       const merged = [...live, ...proposal.next.comments.filter((c) => !have.has(c.id))];
       // Safety net: a span comment whose anchor link didn't survive into the
@@ -1107,15 +1108,22 @@ export function App(props: EditorProps = {}): JSX.Element {
       savedRef.current = serialized;
       setDirty(false);
       const acceptedCount = accepted.filter(Boolean).length;
-      // Decision made → persist canonical *silently* (accepting a proposal must
-      // not end your turn) and discard the parked proposal. The apply save advances the
-      // checkpoint too (keeps it in sync with savedRef so the Save dot stays accurate).
-      void hostApi().save(serialized, { kind: "apply", cadence }).then(() => setCheckpoint(serialized));
+      // Decision made → push the accepted doc to the collaborative owners (comments → store, body →
+      // the binding that owns the SOURCE pane + the shared/persisted doc). WITHOUT this, a collab
+      // accept updated only the React preview: the binding-owned source stayed stale and the change
+      // reverted on reload, because save({apply}) is a no-op in the unified-Yjs model (the server is
+      // the sole writer of documents.body, from the binding). File-backed editors have no binding, so
+      // they fall back to a silent canonical save (accepting a proposal must not end the turn).
+      if (syncExternalDoc(finalDoc, prevDoc.comments, prevDoc.body)) {
+        setCheckpoint(serialized);
+      } else {
+        void hostApi().save(serialized, { kind: "apply", cadence }).then(() => setCheckpoint(serialized));
+      }
       void hostApi().clearProposal();
       void hostApi().logAction(acceptedCount === accepted.length ? "revision_accepted_all" : acceptedCount === 0 ? "revision_rejected_all" : "revision_hunk_accepted", { accepted: acceptedCount, total: accepted.length });
       setStatus(`applied agent revision (${acceptedCount}/${accepted.length} hunks)`);
     },
-    [proposal, cadence, editingLocked],
+    [proposal, cadence, editingLocked, syncExternalDoc],
   );
 
   // --- inline review state (shared by the preview + source panes and the bar) ---

--- a/packages/renderer/test/App.applyProposalBinding.test.tsx
+++ b/packages/renderer/test/App.applyProposalBinding.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment happy-dom
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Regression: in COLLAB mode (a binding owns the source + the shared/persisted doc), accepting an
+// agent Review proposal must push the accepted body to the binding — not just React state. The bug:
+// applyProposal called setDoc (preview) + save({apply}) (a no-op in the unified-Yjs model) but never
+// wrote the binding, so the source pane stayed stale and the change reverted on reload. Here we inject
+// a binding + comment store and assert the accepted body is handed to binding.setText.
+
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { forwardRef, useImperativeHandle } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createMemoryApi, type MemoryAgent } from "../src/memoryApi";
+import { createMemoryCommentStore } from "../src/commentStore";
+import { setHostApi } from "../src/api";
+
+vi.mock("../src/SourceEditor", () => ({
+  SourceEditor: forwardRef(function SourceEditorStub(_props: unknown, ref: React.Ref<unknown>) {
+    useImperativeHandle(ref, () => ({ scrollToLine() {}, selectRange() {} }));
+    return null;
+  }),
+}));
+
+const DOC = "# Plan\n\nHello world.\n\n<!--inplan v1\n[]\n-->\n";
+let agent: MemoryAgent;
+let bound = ""; // the binding's shared text (unified: the bare body)
+const setText = vi.fn((s: string) => { bound = s; });
+
+beforeEach(() => {
+  document.body.innerHTML = '<div id="root"></div>';
+  setText.mockClear();
+  bound = "# Plan\n\nHello world.\n";
+  const session = createMemoryApi({ content: DOC });
+  // Merge a collab binding + comment store onto the memory api (what the desktop/web collab host does).
+  setHostApi({ ...session.api, commentStore: createMemoryCommentStore([]), binding: { extensions: [], getText: () => bound, setText } });
+  (window as unknown as { api: unknown }).api = session.api;
+  agent = session.agent;
+});
+afterEach(cleanup);
+
+describe("App applyProposal (collab binding path)", () => {
+  it("accepting a proposal writes the accepted body to the binding (source + persistence), not just the preview", async () => {
+    const { App } = await import("../src/App");
+    render(<App />);
+    await waitFor(() => expect(document.body.textContent).toContain("Hello world."));
+
+    await act(async () => {
+      agent.proposeRevision("# Plan\n\nHello CHANGED body.\n\n<!--inplan v1\n[]\n-->\n");
+    });
+    await waitFor(() => expect(document.body.textContent).toContain("Agent proposed changes"));
+
+    await act(async () => screen.getByRole("button", { name: /accept all/i }).click());
+    await act(async () => screen.getByRole("button", { name: /^apply$/i }).click());
+
+    await waitFor(() => expect(document.body.textContent).not.toContain("Agent proposed changes"));
+    // The accepted body reached the binding (the collab source-of-truth), as the BARE body (unified).
+    expect(setText).toHaveBeenCalled();
+    const lastWrite = setText.mock.calls.at(-1)![0];
+    expect(lastWrite).toContain("Hello CHANGED body.");
+    expect(lastWrite).not.toContain("<!--inplan"); // bare body, not the serialized doc
+    expect(bound).toContain("Hello CHANGED body.");
+  });
+});


### PR DESCRIPTION
## Bug (reported on inplan.ai, Turn+Review)
After finishing a turn, the agent's revision arrives as a **Review proposal**. Accepting + applying it updated **only the preview** — the **source pane stayed stale and the change reverted on reload**.

## Root cause
`applyProposal` (App.tsx) did `setDoc` (React/preview) + `hostApi().save({kind:'apply'})`, but **never pushed the accepted body to the collaborative binding**. In the unified-Yjs model the binding owns the source pane **and** is the sole writer of the shared/persisted doc, and `save({apply})` is a **no-op** there (the collab server persists `documents.body` from the binding). So the accepted body never reached the source or storage.

## Fix
Route the accepted doc through the existing **`syncExternalDoc`** (comments → store, body → binding) — the same path `apply()` / undo / redo use — and fall back to a silent canonical save only for the **file-backed** editor (no binding). Accepting still must not end the turn / wake the agent (binding writes append no control event).

## Tests
- New `App.applyProposalBinding.test.tsx`: injects a binding + comment store and asserts the accepted **bare body** reaches `binding.setText` (fails without the fix — `setText` is never called).
- Existing `App.applyMerge.test.tsx` (file-backed) still covers the no-binding path; full renderer suite + coverage gate green.
- Reproduced + verified end-to-end in inplan-cloud e2e (a parked-proposal accept now updates the source pane and survives reload).

Pairs with the inplan-cloud e2e in melly-lgtm/inplan-cloud#74.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/6?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proposal application to correctly merge comments from the current document state when accepting changes.
  * Enhanced collaborative owner synchronization when applying accepted proposals with proper fallback handling.

* **Tests**
  * Added regression test for proposal application flow in collaborative mode to ensure content is properly persisted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->