### PR TITLE
fix(renderer): external/agent body change writes the collab binding (source + persistence)

### DIFF
--- a/packages/renderer/src/App.tsx
+++ b/packages/renderer/src/App.tsx
@@ -312,6 +312,7 @@ export function App(props: EditorProps = {}): JSX.Element {
     // can't stack ipcRenderer listeners and double-handle events.
     const subs: Array<(() => void) | void> = [
       hostApi().onExternalChange(({ content }) => {
+        const prevDoc = docRef.current;
         const parsed = parse(content);
         // Store-backed (plugin): comments are owned by the external store, not the rewritten
         // body — keep them from the store so an agent/body refresh can't blank/stale the rail.
@@ -320,6 +321,13 @@ export function App(props: EditorProps = {}): JSX.Element {
         setDoc(next);
         savedRef.current = serialize(next);
         setDirty(false);
+        // Collab: the binding owns the SOURCE pane (the controlled value is ignored once a binding is
+        // present), so an external/agent body change must also be pushed to the binding — otherwise it
+        // updates only the preview and the source stays stale (and a server edit that didn't broadcast,
+        // e.g. a version-history restore, reverts on reload). Idempotent: a no-op when a provider
+        // broadcast already delivered the body (normal auto-accept turns). File-backed editors have no
+        // binding and keep using the controlled value.
+        syncExternalDoc(next, prevDoc.comments, prevDoc.body);
         setStatus(t("msg.agentUpdated"));
       }),
       // Review-mode body changes arrive parked, as a proposal to accept/reject.

--- a/packages/renderer/test/App.applyProposalBinding.test.tsx
+++ b/packages/renderer/test/App.applyProposalBinding.test.tsx
@@ -60,4 +60,22 @@ describe("App applyProposal (collab binding path)", () => {
     expect(lastWrite).not.toContain("<!--inplan"); // bare body, not the serialized doc
     expect(bound).toContain("Hello CHANGED body.");
   });
+
+  it("an external auto-accept body change is pushed to the binding (source), not just the preview", async () => {
+    const { App } = await import("../src/App");
+    render(<App />);
+    await waitFor(() => expect(document.body.textContent).toContain("Hello world."));
+
+    // The agent auto-accepts a rewrite (fires onExternalChange) — e.g. a cloud turn, or a server-side
+    // restore that emits DocumentEdited. The body must reach the binding-owned source, not just React.
+    await act(async () => {
+      agent.externalChange("# Plan\n\nEXTERNAL CHANGE applied.\n\n<!--inplan v1\n[]\n-->\n");
+    });
+
+    await waitFor(() => expect(setText).toHaveBeenCalled());
+    const lastWrite = setText.mock.calls.at(-1)![0];
+    expect(lastWrite).toContain("EXTERNAL CHANGE applied.");
+    expect(lastWrite).not.toContain("<!--inplan"); // bare body (unified)
+    expect(document.body.textContent).toContain("EXTERNAL CHANGE applied."); // preview too
+  });
 });


### PR DESCRIPTION
Follow-up to #6 (same family). `onExternalChange` — the handler for auto-accept agent turns **and** server-side edits like version-history restore — only `setDoc`'d the React **preview**. In collab mode the binding owns the **source** pane (the controlled value is ignored) and is the persisted doc, so the source stayed stale; and a server edit that doesn't broadcast (restore via `openDirectConnection`) **reverted on reload**.

**Fix:** route the external doc through the existing `syncExternalDoc` (comments → store, body → binding) — same path as edit/undo/accept. **Idempotent**: a no-op when a provider broadcast already delivered the body (normal cloud auto-accept turns); file-backed editors have no binding and keep the controlled value.

**Verified locally end-to-end** (no deploy needed): with the paired inplan-cloud change, the inplan-cloud e2e now shows a **version-history restore live-updating an already-open editor's source + preview** (previously required a reload) — full suite 18/18.

**Tests:** `App.applyProposalBinding.test.tsx` gains an external-change case asserting the body reaches `binding.setText`. Renderer suite + coverage gate green.

Pairs with inplan-cloud (restore emits a DocumentEdited event so connected editors react).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/7?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * External document changes now properly synchronize to collaborative bindings, preventing stale source pane content after external or agent-driven rewrites.

* **Tests**
  * Added regression test verifying externally triggered document changes are correctly persisted in collaborative mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->