### PR TITLE
feat(renderer): read-only docs via DocPayload.readOnly

### DIFF
--- a/packages/renderer/src/App.tsx
+++ b/packages/renderer/src/App.tsx
@@ -173,6 +173,10 @@ export function App(props: EditorProps = {}): JSX.Element {
   const t = useT();
   const [loaded, setLoaded] = useState(false);
   const [doc, setDoc] = useState<ParsedDocument>(EMPTY);
+  // Host-declared read-only doc (e.g. the cloud archived it over the active-doc cap): editing +
+  // turn handoff are blocked; the doc stays viewable + downloadable. Set from the load/navigate
+  // payload (per-doc, so it follows in-window navigation).
+  const [readOnly, setReadOnly] = useState(false);
   const [cadence, setCadence] = useState<Cadence>("turn");
   // Available modes: the built-in TURN plus any a plugin advertises via extraModes. The active
   // mode's descriptor drives lock/autosave/apply/Finish-turn behaviour.
@@ -295,8 +299,9 @@ export function App(props: EditorProps = {}): JSX.Element {
 
     hostApi()
       .load()
-      .then(({ content, path }) => {
+      .then(({ content, path, readOnly: ro }) => {
         docPathRef.current = path;
+        setReadOnly(!!ro);
         const parsed = parse(content);
         // With an external comment store (plugin) comments are owned by the store, not the
         // serialized body — source them from the store; its observer keeps them in sync.
@@ -349,12 +354,13 @@ export function App(props: EditorProps = {}): JSX.Element {
       hostApi().onAgentMessage?.((msg) => setAgentMessages((prev) => [...prev, msg])),
       // Desktop only: the window followed a link to another doc — reset to it (a fresh
       // load), clearing any in-flight proposal/turn state, then re-show a parked proposal.
-      hostApi().onNavigated?.(({ content, path }) => {
+      hostApi().onNavigated?.(({ content, path, readOnly: ro }) => {
         // Undo/redo is per-doc: stash the leaving doc's stacks so returning restores them, and load
         // the destination's own (empty on first visit). Per-doc still holds — an undo can never pull
         // another doc's content — but the history now survives navigation instead of being dropped.
         if (docPathRef.current) historyByDoc.current.set(docPathRef.current, { undo: history.current, redo: future.current });
         docPathRef.current = path;
+        setReadOnly(!!ro); // the destination doc may have its own read-only state
         const parsed = parse(content);
         const d = commentStore ? { ...parsed, comments: commentStore.list() } : parsed;
         setDoc(d);
@@ -507,7 +513,12 @@ export function App(props: EditorProps = {}): JSX.Element {
     return () => document.removeEventListener("keydown", onKey);
   }, [composer, findOpen, proposal, reviewOpen, undo, redo]);
 
-  const editingLocked = mode.locksEditor && agentThinking;
+  // The agent holds the turn (Turn mode, thinking) — this is the lock that offers "take back control".
+  const agentLocked = mode.locksEditor && agentThinking;
+  // Any reason editing is blocked: the agent's turn, OR a host-declared read-only doc. Used to gate
+  // all mutation (body edits, comments, accept/apply, finish turn). Read-only is NOT agent-turn, so
+  // it must not surface the take-back affordance (see canTakeBack below).
+  const editingLocked = agentLocked || readOnly;
 
   // Stuck-lock escape: while the editor is locked (the agent holds the turn), the
   // status bar reveals a "take back control" button on hover over "Agent is
@@ -1513,6 +1524,12 @@ export function App(props: EditorProps = {}): JSX.Element {
         </div>
       )}
 
+      {readOnly && (
+        <div className="ap-banner ap-banner--readonly" role="status">
+          {t("banner.readOnly")}
+        </div>
+      )}
+
       {proposal && !reviewOpen && (
         <div className="ap-banner">
           {t("banner.proposalPending")}{" "}
@@ -1852,7 +1869,7 @@ export function App(props: EditorProps = {}): JSX.Element {
         dirty={dirty && serialize(doc) !== checkpoint}
         agentThinking={agentThinking}
         messages={agentMessages}
-        canTakeBack={editingLocked}
+        canTakeBack={agentLocked}
         onTakeBack={takeBackControl}
       />
     </div>

--- a/packages/renderer/src/api.ts
+++ b/packages/renderer/src/api.ts
@@ -66,6 +66,10 @@ export type Acceptance = "auto" | "review";
 export interface DocPayload {
   path: string;
   content: string;
+  /** When true, the editor opens read-only: the body + comments can't be edited and the turn
+   *  can't be handed off — the doc is viewable + downloadable only. Used by hosts that archive
+   *  a doc (e.g. the cloud deactivates a doc over the plan's active-doc cap). Absent = editable. */
+  readOnly?: boolean;
 }
 
 export interface SaveOptions {

--- a/packages/renderer/src/i18n.tsx
+++ b/packages/renderer/src/i18n.tsx
@@ -219,6 +219,7 @@ export const EN: Catalog = {
   "banner.apply": "Apply",
   "banner.laterLower": "later",
   "banner.locked": "— locked while the agent works; finish handing back to act",
+  "banner.readOnly": "This document is archived — view and download only. Reactivate it to edit.",
   // find / replace bar
   "find.toggleReplace": "toggle replace",
   "find.replace": "Replace",

--- a/packages/renderer/src/memoryApi.ts
+++ b/packages/renderer/src/memoryApi.ts
@@ -28,8 +28,9 @@ export interface MemoryAgent {
   suggestReload(): void;
   /** The agent relayed a human-facing note (fires onAgentMessage). */
   message(text: string): void;
-  /** Desktop-style in-window navigation to another doc (fires onNavigated). */
-  navigate(content: string, path?: string): void;
+  /** Desktop-style in-window navigation to another doc (fires onNavigated). Carries the
+   *  destination's read-only state (defaults to the session's, so a read-only session stays so). */
+  navigate(content: string, path?: string, readOnly?: boolean): void;
   /** The full control log so far (for assertions). */
   log(): Promise<LogEntry[]>;
 }
@@ -167,10 +168,10 @@ export function createMemoryApi(opts: { content: string; settings?: Settings; ba
       void channel.append({ actor: "agent", type: LogEventType.AgentMessage, payload: { text }, ts });
       for (const cb of messages) cb({ text, ts });
     },
-    navigate(content: string, path = "memory://doc2") {
+    navigate(content: string, path = "memory://doc2", readOnly = opts.readOnly === true) {
       void store.saveDoc(content);
       void store.setCanonical(content);
-      for (const cb of navigated) cb({ path, content });
+      for (const cb of navigated) cb({ path, content, ...(readOnly ? { readOnly: true } : {}) });
     },
     async log(): Promise<LogEntry[]> {
       return (await channel.readSince(0)).entries;

--- a/packages/renderer/src/memoryApi.ts
+++ b/packages/renderer/src/memoryApi.ts
@@ -43,7 +43,7 @@ export interface MemorySession {
   isClosed(): boolean;
 }
 
-export function createMemoryApi(opts: { content: string; settings?: Settings; backButton?: boolean }): MemorySession {
+export function createMemoryApi(opts: { content: string; settings?: Settings; backButton?: boolean; readOnly?: boolean }): MemorySession {
   const store = new MemoryDocumentStore(opts.content);
   const channel = new MemoryControlChannel();
   let settings: Settings = opts.settings ?? { autoResolve: true };
@@ -69,7 +69,7 @@ export function createMemoryApi(opts: { content: string; settings?: Settings; ba
   const api: Api = {
     async load(): Promise<DocPayload> {
       if ((await store.getCanonical()) === null) await store.setCanonical(opts.content);
-      return { path: "memory://doc", content: await store.loadDoc() };
+      return { path: "memory://doc", content: await store.loadDoc(), ...(opts.readOnly ? { readOnly: true } : {}) };
     },
     async save(content: string, options: SaveOptions): Promise<void> {
       if (options.kind === "backup") {

--- a/packages/renderer/src/memoryApi.ts
+++ b/packages/renderer/src/memoryApi.ts
@@ -47,6 +47,10 @@ export interface MemorySession {
 export function createMemoryApi(opts: { content: string; settings?: Settings; backButton?: boolean; readOnly?: boolean }): MemorySession {
   const store = new MemoryDocumentStore(opts.content);
   const channel = new MemoryControlChannel();
+  // Current doc identity — navigate() updates these so a later load() (e.g. on remount) reflects
+  // the navigated destination, not the original, staying consistent with the onNavigated payload.
+  let currentPath = "memory://doc";
+  let currentReadOnly = opts.readOnly === true;
   let settings: Settings = opts.settings ?? { autoResolve: true };
   let closed = false;
   const telemetryEvents: MemorySession["telemetryEvents"] = [];
@@ -70,7 +74,7 @@ export function createMemoryApi(opts: { content: string; settings?: Settings; ba
   const api: Api = {
     async load(): Promise<DocPayload> {
       if ((await store.getCanonical()) === null) await store.setCanonical(opts.content);
-      return { path: "memory://doc", content: await store.loadDoc(), ...(opts.readOnly ? { readOnly: true } : {}) };
+      return { path: currentPath, content: await store.loadDoc(), ...(currentReadOnly ? { readOnly: true } : {}) };
     },
     async save(content: string, options: SaveOptions): Promise<void> {
       if (options.kind === "backup") {
@@ -171,6 +175,8 @@ export function createMemoryApi(opts: { content: string; settings?: Settings; ba
     navigate(content: string, path = "memory://doc2", readOnly = opts.readOnly === true) {
       void store.saveDoc(content);
       void store.setCanonical(content);
+      currentPath = path;
+      currentReadOnly = readOnly;
       for (const cb of navigated) cb({ path, content, ...(readOnly ? { readOnly: true } : {}) });
     },
     async log(): Promise<LogEntry[]> {

--- a/packages/renderer/src/styles.css
+++ b/packages/renderer/src/styles.css
@@ -193,6 +193,8 @@ body {
 /* banner */
 .ap-banner { background: var(--accent-soft); border-bottom: 1px solid var(--line); padding: 9px 14px; display: flex; gap: 10px; align-items: center; }
 .ap-banner-reload { background: #f6ecdd; }
+/* Archived/read-only doc notice — muted amber, no action (view + download only). */
+.ap-banner--readonly { background: #f6ecdd; color: var(--amber); font-size: 13px; }
 
 /* main layout */
 .ap-main { flex: 1; display: flex; min-height: 0; position: relative; }

--- a/packages/renderer/test/App.readOnly.test.tsx
+++ b/packages/renderer/test/App.readOnly.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment happy-dom
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// A host can open a doc read-only (DocPayload.readOnly) — e.g. the cloud archives a doc over the
+// plan's active-doc cap. The editor then blocks editing + turn handoff and shows an archived
+// banner, but stays viewable (and the host's Download action still works). SourceEditor is stubbed
+// (CodeMirror needs layout APIs happy-dom lacks); we assert the gating App owns via the top bar.
+
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { forwardRef, useImperativeHandle } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createMemoryApi } from "../src/memoryApi";
+
+vi.mock("../src/SourceEditor", () => ({
+  SourceEditor: forwardRef(function SourceEditorStub(_props: unknown, ref: React.Ref<unknown>) {
+    useImperativeHandle(ref, () => ({ scrollToLine() {}, selectRange() {} }));
+    return null;
+  }),
+}));
+
+const DOC = "# Plan\n\nArchived body.\n\n<!--inplan v1\n[]\n-->\n";
+
+beforeEach(() => {
+  document.body.innerHTML = '<div id="root"></div>';
+});
+afterEach(cleanup);
+
+describe("App read-only doc (DocPayload.readOnly)", () => {
+  it("blocks editing and shows the archived banner when the host opens a doc read-only", async () => {
+    (window as unknown as { api: unknown }).api = createMemoryApi({ content: DOC, readOnly: true }).api;
+    const { App } = await import("../src/App");
+    await act(async () => void render(<App />));
+    await waitFor(() => expect(document.body.textContent).toContain("Archived body."));
+
+    // The archived banner is shown (view + download only)…
+    expect(document.querySelector(".ap-banner--readonly")).toBeTruthy();
+    expect(document.body.textContent).toContain("archived");
+    // …and mutation is blocked: "Comment on Doc/Text" is disabled (the shared editingLocked gate).
+    const addComment = screen.getByRole("button", { name: /comment on (text|doc)/i }) as HTMLButtonElement;
+    expect(addComment.disabled).toBe(true);
+  });
+
+  it("an editable doc (no readOnly) shows no archived banner and allows commenting", async () => {
+    (window as unknown as { api: unknown }).api = createMemoryApi({ content: DOC }).api;
+    const { App } = await import("../src/App");
+    await act(async () => void render(<App />));
+    await waitFor(() => expect(document.body.textContent).toContain("Archived body."));
+
+    expect(document.querySelector(".ap-banner--readonly")).toBeNull();
+    const addComment = screen.getByRole("button", { name: /comment on (text|doc)/i }) as HTMLButtonElement;
+    expect(addComment.disabled).toBe(false);
+  });
+});


### PR DESCRIPTION
Open-core seam for the cloud's **active-doc cap deactivation** flow (the cap-modal that archives a doc over the plan limit). A deactivated doc must open **view + download only**; the editor needs to know, so `DocPayload` gains an optional `readOnly` flag.

## Change
- `DocPayload.readOnly?: boolean` — when true, the editor opens read-only.
- `App` reads it from the **load** and **onNavigated** payloads (per-doc, so it follows in-window navigation), and folds it into `editingLocked` so **every** existing mutation gate honors it: body edits (`SourceEditor editable`), comment creation, the per-hunk + all-changes review switches, Apply, Finish turn, context-menu mutations.
- It's **split from the agent-turn lock** (`agentLocked = mode.locksEditor && agentThinking`): read-only must not surface the "take back control" affordance, so `StatusBar canTakeBack` keys on `agentLocked`, not the combined lock.
- A muted "This document is archived — view and download only" banner (`banner.readOnly`). Download stays available via the host's profile-menu action.

## Why a seam PR
The cloud consumes this: `supabaseApi.load()` will set `readOnly: !active`, and the web cap-modal deactivates a doc to make room. That cloud work depends on this field existing in the renderer it builds from `main`, so this lands first.

## Tests
`App.readOnly.test.tsx`: a read-only doc shows the archived banner + disables commenting; an editable doc does neither. `createMemoryApi` gains a `readOnly` option. Full suite + ≥95% coverage gate green.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/10?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Documents can be marked read-only/archived: view/download only, editing and turn controls are disabled and a clear read-only banner appears. The editor’s read-only state follows host-provided flags during load/navigation. The “take back control” affordance remains available when an agent holds the editor regardless of read-only.

* **Tests**
  * Added tests validating read-only banner, disabled comment/edit controls, and view-only behavior.

* **Documentation**
  * Added localized banner text for read-only/archived documents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->