### PR TITLE
feat(renderer): gate Instant/Finish-turn on agent availability (event-driven agent parity)

### DIFF
--- a/packages/renderer/src/App.tsx
+++ b/packages/renderer/src/App.tsx
@@ -2041,10 +2041,12 @@ function TopBar(props: {
   const { cadence, acceptance, panes, onMode } = props;
   const profile = useProfile();
   const t = useT();
-  // In a presence-aware host (web/cloud), no attached agent ⇒ Instant + Finish-turn
-  // are disabled (there's nothing to hand the turn to). The desktop's local agent is
-  // implicit, so it isn't presence-aware and these stay enabled.
-  const noAgent = profile?.presenceAware === true && profile.agentLocation == null;
+  // In a presence-aware host (web/cloud), Instant + Finish-turn need an agent to hand the turn to.
+  // The managed cloud agent is event-driven (not a presence peer), so "available" means: the host
+  // flagged `agentAvailable` (entitled + auto policy), OR an agent is connected (`agentLocation`, e.g.
+  // a local CLI). Only when neither holds is there genuinely no agent. The desktop's local agent is
+  // implicit (not presence-aware), so these stay enabled there.
+  const noAgent = profile?.presenceAware === true && profile.agentAvailable !== true && profile.agentLocation == null;
   const noAgentTitle = noAgent ? t("topbar.noAgent") : undefined;
   return (
     <header className="ap-topbar">

--- a/packages/renderer/src/api.ts
+++ b/packages/renderer/src/api.ts
@@ -128,12 +128,20 @@ export interface ProfileState {
   /** Host-injected menu actions, rendered in order. */
   actions: ProfileMenuItem[];
   /**
-   * True when this host derives agent attachment from live presence (the web/cloud):
-   * then a null `agentLocation` means *no agent is connected*, so the editor disables
-   * Instant mode + Finish-turn (nothing to hand the turn to). On the desktop the local
-   * agent is implicit (no presence room), so this is omitted and those stay enabled.
+   * True when this host derives agent attachment from live presence (the web/cloud).
+   * Combined with {@link agentAvailable}, this decides whether Instant mode + Finish-turn
+   * are enabled. On the desktop the local agent is implicit (no presence room), so this
+   * is omitted and those controls stay enabled.
    */
   presenceAware?: boolean;
+  /**
+   * True when an agent is *available* for this doc even if not connected as a presence peer —
+   * i.e. the managed cloud agent is entitled + the doc's policy is `auto`, OR a local agent is
+   * connected. The cloud agent is event-driven (it doesn't sit in the presence room), so a null
+   * `agentLocation` no longer means "no agent": Instant + Finish-turn enable when `agentAvailable`
+   * is true. Hosts that don't set this fall back to the `agentLocation != null` check.
+   */
+  agentAvailable?: boolean;
   /** The doc's current agent-provisioning policy. Present + `onSetAgentPolicy` ⇒ the
    *  menu-bar agent indicator renders the connection picker. */
   agentPolicy?: AgentPolicy;


### PR DESCRIPTION
Open-core half of the cloud's event-driven managed-agent rework (the seam change the cloud PR consumes).

## Why
The cloud managed agent is becoming **event-driven** — it reacts to control-channel events (Supabase Realtime) and runs one turn, rather than sitting in the Yjs presence room as a persistent peer. Consequence: `agentLocation` is no longer set for the cloud agent, so the old gate `noAgent = presenceAware && agentLocation == null` left **Instant mode + Finish-turn permanently disabled** in the cloud.

## Change
- `ProfileState.agentAvailable?: boolean` — the host flags that an agent is *available* for this doc (managed agent entitled + `agent_policy='auto'`, **or** a local agent connected), even when no agent is a presence peer.
- `noAgent` is now `presenceAware && !agentAvailable && agentLocation == null` — disabled only when there's genuinely nothing to hand a turn to. Hosts that don't set `agentAvailable` fall back to the prior `agentLocation` check (desktop unaffected — it isn't presence-aware).

No new i18n keys. Renderer: typecheck clean, **351 tests pass**. The cloud PR (event-driven trigger + `agentAvailable` wiring) builds the renderer from `main`, so this merges first.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/11?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent availability detection for presence-aware hosts, resulting in more accurate enable/disable behavior for Instant mode and Finish-turn controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->