### PR TITLE
feat: Aside/memo comments — a comment the agent ignores (composer switch + grammar)

### DIFF
--- a/packages/core/src/anchors.ts
+++ b/packages/core/src/anchors.ts
@@ -51,3 +51,14 @@ export function anchorLinkCounts(body: string): Map<string, number> {
   }
   return counts;
 }
+
+/** Matches a full anchored span — `[text](#cmt-id)` — capturing the link text + the id. */
+const ANCHORED_SPAN_RE = /\[([^\]]*)\]\(#(cmt-[0-9a-z]+)\)/gi;
+
+/** Unwrap the anchor links for `ids` — `[text](#cmt-id)` → `text` — leaving every other anchor intact.
+ *  Used to hide a removed comment's span from a projection (e.g. {@link docForAgent} excludes a memo's
+ *  comment AND unwraps its body anchor so no dangling link remains). Ids match case-insensitively. */
+export function unwrapAnchors(body: string, ids: Set<string>): string {
+  if (ids.size === 0) return body;
+  return body.replace(ANCHORED_SPAN_RE, (full, text: string, id: string) => (ids.has(id.toLowerCase()) ? text : full));
+}

--- a/packages/core/src/anchors.ts
+++ b/packages/core/src/anchors.ts
@@ -60,5 +60,6 @@ const ANCHORED_SPAN_RE = /\[([^\]]*)\]\(#(cmt-[0-9a-z]+)\)/gi;
  *  comment AND unwraps its body anchor so no dangling link remains). Ids match case-insensitively. */
 export function unwrapAnchors(body: string, ids: Set<string>): string {
   if (ids.size === 0) return body;
-  return body.replace(ANCHORED_SPAN_RE, (full, text: string, id: string) => (ids.has(id.toLowerCase()) ? text : full));
+  const lower = new Set([...ids].map((id) => id.toLowerCase())); // normalize the input too — matching is case-insensitive
+  return body.replace(ANCHORED_SPAN_RE, (full, text: string, id: string) => (lower.has(id.toLowerCase()) ? text : full));
 }

--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import type { Comment, ParsedDocument } from "./types";
+import { unwrapAnchors } from "./anchors";
 
 /** Opening delimiter of the comment data block. */
 export const BLOCK_OPEN = "<!--inplan";
@@ -137,7 +138,7 @@ export function orderComments(comments: Comment[]): Comment[] {
 /** Canonical field order for a serialized comment. A round-trip through a shared map loses
  *  the original key order, so the canonical projection must re-impose one or the JSON bytes
  *  differ between peers. Matches the Comment interface declaration order. */
-const COMMENT_KEY_ORDER: (keyof Comment)[] = ["id", "parentId", "anchor", "text", "author", "date", "resolved", "may_resolve", "question", "selected"];
+const COMMENT_KEY_ORDER: (keyof Comment)[] = ["id", "parentId", "anchor", "text", "author", "date", "resolved", "may_resolve", "question", "selected", "agent"];
 
 function canonicalizeComment(c: Comment): Comment {
   const out: Record<string, unknown> = {};
@@ -154,6 +155,17 @@ function canonicalizeComment(c: Comment): Comment {
  *  local .md write). */
 export function serializeCanonical(doc: ParsedDocument): string {
   return serialize({ ...doc, comments: orderComments(doc.comments).map(canonicalizeComment) });
+}
+
+/** The document as the AGENT should see it: **memo** comments (`agent === false`, "leave a memo") and
+ *  their replies are removed, and any span-memo body anchor is unwrapped so no dangling `[text](#cmt-id)`
+ *  link remains. A memo is thus excluded from the agent's context entirely. Returns `doc` unchanged when
+ *  there are no memos. The stored/human-facing doc is untouched — this is only the agent's projection. */
+export function docForAgent(doc: ParsedDocument): ParsedDocument {
+  const memoIds = new Set(doc.comments.filter((c) => c.agent === false).map((c) => c.id));
+  if (memoIds.size === 0) return doc;
+  const comments = doc.comments.filter((c) => !memoIds.has(c.id) && !(c.parentId !== undefined && memoIds.has(c.parentId)));
+  return { ...doc, body: unwrapAnchors(doc.body, memoIds), comments };
 }
 
 export class ParseError extends Error {

--- a/packages/core/src/document.ts
+++ b/packages/core/src/document.ts
@@ -164,7 +164,20 @@ export function serializeCanonical(doc: ParsedDocument): string {
 export function docForAgent(doc: ParsedDocument): ParsedDocument {
   const memoIds = new Set(doc.comments.filter((c) => c.agent === false).map((c) => c.id));
   if (memoIds.size === 0) return doc;
-  const comments = doc.comments.filter((c) => !memoIds.has(c.id) && !(c.parentId !== undefined && memoIds.has(c.parentId)));
+  // Exclude the memo roots AND every descendant transitively (reply, reply-of-reply, …) so a deep
+  // thread under a memo can't leak into the agent's context. Iterate to a fixpoint.
+  const excluded = new Set(memoIds);
+  for (let grew = true; grew; ) {
+    grew = false;
+    for (const c of doc.comments) {
+      if (c.parentId !== undefined && excluded.has(c.parentId) && !excluded.has(c.id)) {
+        excluded.add(c.id);
+        grew = true;
+      }
+    }
+  }
+  const comments = doc.comments.filter((c) => !excluded.has(c.id));
+  // Only memo roots carry a body anchor (replies don't), so unwrap memoIds.
   return { ...doc, body: unwrapAnchors(doc.body, memoIds), comments };
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -39,6 +39,11 @@ export interface Comment {
   question?: Question;
   /** Answer replies: the chosen choice labels (length 1 for multiple choice, 0..n for multiple selection). */
   selected?: string[];
+  /** Whether this comment is addressed to the agent. Absent/true = "talk to the agent" (it feeds the
+   *  agent's context + wakes a turn); `false` = a **memo** ("leave a memo") the agent ignores — excluded
+   *  from what the agent reads ({@link docForAgent}) and never a wake event. Lets a human jot a note for
+   *  teammates (or themselves) without summoning the agent, in instant or turn mode. */
+  agent?: boolean;
 }
 
 /** A parsed document: the Markdown body plus the structured comments. */

--- a/packages/core/test/docForAgent.test.ts
+++ b/packages/core/test/docForAgent.test.ts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, it, expect } from "vitest";
+import { docForAgent, unwrapAnchors, serializeCanonical, parse, type ParsedDocument } from "../src";
+
+describe("unwrapAnchors", () => {
+  it("unwraps only the listed ids; leaves other anchors + non-matching text intact", () => {
+    const body = "See [here](#cmt-aaa111) and [there](#cmt-bbb222).";
+    expect(unwrapAnchors(body, new Set(["cmt-aaa111"]))).toBe("See here and [there](#cmt-bbb222).");
+    expect(unwrapAnchors(body, new Set())).toBe(body); // no-op
+  });
+  it("matches ids case-insensitively", () => {
+    expect(unwrapAnchors("[x](#cmt-AbC123)", new Set(["cmt-abc123"]))).toBe("x");
+  });
+});
+
+describe("docForAgent", () => {
+  const doc: ParsedDocument = {
+    body: "Intro. A [flagged span](#cmt-span01) and a normal [span](#cmt-keep01).",
+    comments: [
+      { id: "cmt-doc001", anchor: "doc", author: "h", date: "2026-06-13T00:00:00Z", resolved: false, text: "a memo to teammates", agent: false },
+      { id: "cmt-rep001", parentId: "cmt-doc001", author: "h", date: "2026-06-13T00:01:00Z", resolved: false, text: "reply on the memo" },
+      { id: "cmt-span01", author: "h", date: "2026-06-13T00:02:00Z", resolved: false, text: "a span memo", agent: false },
+      { id: "cmt-keep01", author: "h", date: "2026-06-13T00:03:00Z", resolved: false, text: "talk to the agent" },
+    ],
+  };
+
+  it("removes memos + their replies and unwraps span-memo anchors; keeps agent-facing comments", () => {
+    const agentDoc = docForAgent(doc);
+    expect(agentDoc.comments.map((c) => c.id)).toEqual(["cmt-keep01"]); // memo, its reply, and the span memo gone
+    expect(agentDoc.body).toBe("Intro. A flagged span and a normal [span](#cmt-keep01)."); // span-memo anchor unwrapped, kept one intact
+  });
+
+  it("returns the doc unchanged when there are no memos", () => {
+    const clean: ParsedDocument = { body: "x", comments: [{ id: "cmt-keep01", anchor: "doc", author: "h", date: "2026-06-13T00:00:00Z", resolved: false, text: "hi" }] };
+    expect(docForAgent(clean)).toBe(clean);
+  });
+});
+
+describe("comment.agent round-trips through serialize/parse", () => {
+  it("preserves agent:false (a memo) across a canonical serialize → parse", () => {
+    const doc: ParsedDocument = {
+      body: "Body.",
+      comments: [{ id: "cmt-memo01", anchor: "doc", author: "h", date: "2026-06-13T00:00:00Z", resolved: false, text: "memo", agent: false }],
+    };
+    const round = parse(serializeCanonical(doc));
+    expect(round.comments[0]!.agent).toBe(false);
+  });
+});

--- a/packages/core/test/docForAgent.test.ts
+++ b/packages/core/test/docForAgent.test.ts
@@ -9,8 +9,9 @@ describe("unwrapAnchors", () => {
     expect(unwrapAnchors(body, new Set(["cmt-aaa111"]))).toBe("See here and [there](#cmt-bbb222).");
     expect(unwrapAnchors(body, new Set())).toBe(body); // no-op
   });
-  it("matches ids case-insensitively", () => {
-    expect(unwrapAnchors("[x](#cmt-AbC123)", new Set(["cmt-abc123"]))).toBe("x");
+  it("matches ids case-insensitively in BOTH the body and the id set", () => {
+    expect(unwrapAnchors("[x](#cmt-AbC123)", new Set(["cmt-abc123"]))).toBe("x"); // upper in body
+    expect(unwrapAnchors("[y](#cmt-def456)", new Set(["CMT-DEF456"]))).toBe("y"); // upper in the set
   });
 });
 
@@ -29,6 +30,20 @@ describe("docForAgent", () => {
     const agentDoc = docForAgent(doc);
     expect(agentDoc.comments.map((c) => c.id)).toEqual(["cmt-keep01"]); // memo, its reply, and the span memo gone
     expect(agentDoc.body).toBe("Intro. A flagged span and a normal [span](#cmt-keep01)."); // span-memo anchor unwrapped, kept one intact
+  });
+
+  it("removes a memo's descendants transitively (reply-of-reply chains can't leak)", () => {
+    const nested: ParsedDocument = {
+      body: "Body.",
+      comments: [
+        { id: "cmt-memo00", anchor: "doc", author: "h", date: "2026-06-13T00:00:00Z", resolved: false, text: "memo root", agent: false },
+        { id: "cmt-rep1", parentId: "cmt-memo00", author: "h", date: "2026-06-13T00:01:00Z", resolved: false, text: "reply" },
+        { id: "cmt-rep2", parentId: "cmt-rep1", author: "h", date: "2026-06-13T00:02:00Z", resolved: false, text: "reply of reply" },
+        { id: "cmt-rep3", parentId: "cmt-rep2", author: "h", date: "2026-06-13T00:03:00Z", resolved: false, text: "reply of reply of reply" },
+        { id: "cmt-keep", anchor: "doc", author: "h", date: "2026-06-13T00:04:00Z", resolved: false, text: "unrelated" },
+      ],
+    };
+    expect(docForAgent(nested).comments.map((c) => c.id)).toEqual(["cmt-keep"]); // entire memo subtree gone
   });
 
   it("returns the doc unchanged when there are no memos", () => {

--- a/packages/renderer/src/App.tsx
+++ b/packages/renderer/src/App.tsx
@@ -782,7 +782,11 @@ export function App(props: EditorProps = {}): JSX.Element {
 
   // --- comment actions ---
   const addComment = useCallback(
-    (text: string, target: string | null, span?: SourceSpan | null, question?: Question) => {
+    (text: string, target: string | null, span?: SourceSpan | null, question?: Question, talkToAgent = true) => {
+      // `talkToAgent === false` → a memo the agent ignores: the comment carries `agent:false`, and the
+      // control event payload echoes it so the cloud agent can skip the wake (it never reacts to a memo).
+      const agent = talkToAgent ? undefined : false;
+      const memoPayload = talkToAgent ? {} : { agent: false };
       if (target) {
         // Guard against an un-anchorable or OVERLAPPING span (nested links would
         // corrupt the doc) even if the UI's disabled state was bypassed. `span` (the
@@ -792,17 +796,17 @@ export function App(props: EditorProps = {}): JSX.Element {
           setStatus(blocker === "overlap" ? t("topbar.cantOverlap") : t("msg.cantAnchor"));
           return;
         }
-        const res = addSpanComment(docRef.current, target, { text, author: userAuthorRef.current, question }, span ?? undefined);
+        const res = addSpanComment(docRef.current, target, { text, author: userAuthorRef.current, question, agent }, span ?? undefined);
         if (!res) {
           setStatus(t("msg.cantAnchor"));
           return;
         }
-        apply(res.doc, { type: "comment_created", payload: { id: res.id } });
+        apply(res.doc, { type: "comment_created", payload: { id: res.id, ...memoPayload } });
         hostApi().telemetry?.("comment_created", { kind: "span" }); // activation funnel; never the text
         setFocused(res.id);
       } else {
-        const res = addDocComment(docRef.current, { text, author: userAuthorRef.current, question });
-        apply(res.doc, { type: "comment_created", payload: { id: res.id, anchor: "doc" } });
+        const res = addDocComment(docRef.current, { text, author: userAuthorRef.current, question, agent });
+        apply(res.doc, { type: "comment_created", payload: { id: res.id, anchor: "doc", ...memoPayload } });
         hostApi().telemetry?.("comment_created", { kind: "doc" });
         setFocused(res.id);
       }
@@ -1566,8 +1570,8 @@ export function App(props: EditorProps = {}): JSX.Element {
           target={composer.target}
           pos={composer.pos}
           disabled={editingLocked}
-          onSubmit={(text) => {
-            addComment(text, composer.target, composer.span);
+          onSubmit={(text, talkToAgent) => {
+            addComment(text, composer.target, composer.span, undefined, talkToAgent);
             setComposer(null);
           }}
           onClose={() => setComposer(null)}

--- a/packages/renderer/src/ComposerPopover.tsx
+++ b/packages/renderer/src/ComposerPopover.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useT } from "./i18n";
 import { MOD_KEY } from "./platform";
+import { IconComment, IconMemo } from "./Icons";
 
 /**
  * Floating comment composer. Multi-line textarea that grows to 8 lines;
@@ -19,11 +20,14 @@ export function ComposerPopover({
   target: string | null;
   pos: { x: number; y: number };
   disabled: boolean;
-  onSubmit: (text: string) => void;
+  onSubmit: (text: string, talkToAgent: boolean) => void;
   onClose: () => void;
 }): JSX.Element {
   const t = useT();
   const [text, setText] = useState("");
+  // The comment's audience: talk to the agent (default — feeds + wakes the agent) or leave a memo
+  // (the agent ignores it). A bistate switch: conversation on the left, memo on the right.
+  const [talkToAgent, setTalkToAgent] = useState(true);
   const [p, setP] = useState(pos);
   const box = useRef<HTMLDivElement>(null);
   const ta = useRef<HTMLTextAreaElement>(null);
@@ -62,7 +66,7 @@ export function ComposerPopover({
   };
 
   const submit = () => {
-    if (text.trim()) onSubmit(text.trim());
+    if (text.trim()) onSubmit(text.trim(), talkToAgent);
   };
 
   return (
@@ -89,6 +93,33 @@ export function ComposerPopover({
         }}
       />
       <div className="ap-row">
+        {/* Audience switch: conversation (talk to the agent — default) ⇄ memo (the agent ignores it). */}
+        <span className="ap-agent-toggle" role="radiogroup" aria-label={t("composer.audience")}>
+          <button
+            type="button"
+            className={`ap-agent-opt${talkToAgent ? " active" : ""}`}
+            role="radio"
+            aria-checked={talkToAgent}
+            title={t("composer.talkToAgent")}
+            aria-label={t("composer.talkToAgent")}
+            disabled={disabled}
+            onClick={() => setTalkToAgent(true)}
+          >
+            <IconComment />
+          </button>
+          <button
+            type="button"
+            className={`ap-agent-opt${!talkToAgent ? " active" : ""}`}
+            role="radio"
+            aria-checked={!talkToAgent}
+            title={t("composer.leaveMemo")}
+            aria-label={t("composer.leaveMemo")}
+            disabled={disabled}
+            onClick={() => setTalkToAgent(false)}
+          >
+            <IconMemo />
+          </button>
+        </span>
         <button onClick={submit} disabled={disabled || !text.trim()}>
           {t("composer.comment")}
         </button>

--- a/packages/renderer/src/Icons.tsx
+++ b/packages/renderer/src/Icons.tsx
@@ -51,6 +51,15 @@ export const IconComment = (): JSX.Element => (
     <line x1="9" y1="10" x2="15" y2="10" />
   </Glyph>
 );
+/** A lined note/memo page — the "leave a memo" side of the composer's agent toggle. */
+export const IconMemo = (): JSX.Element => (
+  <Glyph>
+    <path d="M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z" />
+    <polyline points="14 3 14 9 20 9" />
+    <line x1="8" y1="13" x2="16" y2="13" />
+    <line x1="8" y1="17" x2="13" y2="17" />
+  </Glyph>
+);
 export const IconSave = (): JSX.Element => (
   <Glyph>
     <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z" />

--- a/packages/renderer/src/docOps.ts
+++ b/packages/renderer/src/docOps.ts
@@ -359,6 +359,8 @@ export interface NewCommentFields {
   text: string;
   author: string;
   question?: Question;
+  /** `false` = a memo the agent ignores ("leave a memo"). Absent/true = "talk to the agent". */
+  agent?: boolean;
 }
 
 /** Wrap the selected body span in an anchor link and add a span comment. `span` is the
@@ -369,14 +371,14 @@ export function addSpanComment(doc: ParsedDocument, selectedText: string, fields
   if (!range) return null;
   const id = genId(takenIds(doc));
   const body = wrapSpanWithComment(doc.body, range.start, range.end, id); // balances crossed inline markup
-  const comment: Comment = { id, author: fields.author, date: nowIso(), resolved: false, text: fields.text, ...(fields.question ? { question: fields.question } : {}) };
+  const comment: Comment = { id, author: fields.author, date: nowIso(), resolved: false, text: fields.text, ...(fields.question ? { question: fields.question } : {}), ...(fields.agent === false ? { agent: false } : {}) };
   return { doc: { body, comments: [...doc.comments, comment] }, id };
 }
 
 /** Add a document-level comment. */
 export function addDocComment(doc: ParsedDocument, fields: NewCommentFields): { doc: ParsedDocument; id: string } {
   const id = genId(takenIds(doc));
-  const comment: Comment = { id, anchor: "doc", author: fields.author, date: nowIso(), resolved: false, text: fields.text, ...(fields.question ? { question: fields.question } : {}) };
+  const comment: Comment = { id, anchor: "doc", author: fields.author, date: nowIso(), resolved: false, text: fields.text, ...(fields.question ? { question: fields.question } : {}), ...(fields.agent === false ? { agent: false } : {}) };
   return { doc: { ...doc, comments: [...doc.comments, comment] }, id };
 }
 

--- a/packages/renderer/src/i18n.tsx
+++ b/packages/renderer/src/i18n.tsx
@@ -148,6 +148,9 @@ export const EN: Catalog = {
   "composer.placeholder": "Add a comment…  ({mod}+Enter to submit)",
   "composer.comment": "Comment",
   "composer.cancel": "cancel",
+  "composer.audience": "Comment audience",
+  "composer.talkToAgent": "Talk to the agent",
+  "composer.leaveMemo": "Leave a memo",
   // agent connection indicator
   "agent.connectCloud": "Connect a cloud agent",
   "agent.waitLocal": "Wait for my local agent",

--- a/packages/renderer/src/styles.css
+++ b/packages/renderer/src/styles.css
@@ -257,6 +257,16 @@ body {
 .ap-muted { color: var(--muted); }
 .ap-row { display: flex; gap: 6px; align-items: center; margin-top: 6px; }
 
+/* Composer audience switch: conversation (talk to the agent) ⇄ memo (the agent ignores it). A small
+   two-icon pill; the active side is filled with the accent, the other is muted. Margin-right pushes
+   the Comment/cancel buttons to the right. */
+.ap-agent-toggle { display: inline-flex; align-items: center; gap: 2px; padding: 2px; border: 1px solid var(--line-strong); border-radius: 999px; background: var(--surface, #fff); margin-right: auto; }
+.ap-agent-opt { display: inline-flex; align-items: center; justify-content: center; width: 28px; height: 22px; padding: 0; border: 0; border-radius: 999px; background: transparent; color: var(--ink-faint, #a8a08c); cursor: pointer; transition: background 0.12s ease, color 0.12s ease; }
+.ap-agent-opt svg { width: 14px; height: 14px; }
+.ap-agent-opt:hover:not(:disabled):not(.active) { color: var(--accent); background: var(--accent-soft); }
+.ap-agent-opt.active { background: var(--accent); color: #fbfaf6; }
+.ap-agent-opt:disabled { opacity: 0.5; cursor: default; }
+
 textarea, input[type="text"], input[type="email"], input[type="number"], select {
   font: inherit; color: var(--fg); background: var(--bg);
   border: 1px solid var(--line-strong); border-radius: 7px; padding: 7px 9px;

--- a/packages/renderer/test/ComposerPopover.test.tsx
+++ b/packages/renderer/test/ComposerPopover.test.tsx
@@ -25,7 +25,7 @@ describe("ComposerPopover", () => {
     render(<ComposerPopover {...base} onSubmit={onSubmit} />);
     fireEvent.change(textarea(), { target: { value: "  a remark  " } });
     fireEvent.keyDown(textarea(), { key: "Enter", metaKey: true });
-    expect(onSubmit).toHaveBeenCalledWith("a remark");
+    expect(onSubmit).toHaveBeenCalledWith("a remark", true); // default audience = talk to the agent
   });
 
   it("Comment button is disabled until there's text, then submits", () => {
@@ -35,7 +35,21 @@ describe("ComposerPopover", () => {
     fireEvent.change(textarea(), { target: { value: "hi" } });
     expect(commentBtn().disabled).toBe(false);
     fireEvent.click(commentBtn());
-    expect(onSubmit).toHaveBeenCalledWith("hi");
+    expect(onSubmit).toHaveBeenCalledWith("hi", true);
+  });
+
+  it("the audience switch defaults to 'talk to the agent'; choosing 'leave a memo' submits agent=false", () => {
+    const onSubmit = vi.fn();
+    render(<ComposerPopover {...base} onSubmit={onSubmit} />);
+    const memo = screen.getByRole("radio", { name: /leave a memo/i });
+    const talk = screen.getByRole("radio", { name: /talk to the agent/i });
+    expect(talk.getAttribute("aria-checked")).toBe("true"); // conversation is the default
+    expect(memo.getAttribute("aria-checked")).toBe("false");
+    fireEvent.change(textarea(), { target: { value: "note to self" } });
+    fireEvent.click(memo); // switch to memo
+    expect(memo.getAttribute("aria-checked")).toBe("true");
+    fireEvent.click(commentBtn());
+    expect(onSubmit).toHaveBeenCalledWith("note to self", false); // memo → the agent ignores it
   });
 
   it("shows the OS-specific modifier in the placeholder, not the dual 'Cmd/Ctrl'", () => {


### PR DESCRIPTION
Phase 3 of the agent rework (open-core half). Lets a human leave a comment for teammates (or themselves) **without summoning the agent** — in instant or turn mode. The cloud half (trigger wake-skip + `docForAgent` projection + locale catalogs) is a follow-up inplan-cloud PR.

## UX
The comment composer gains a bistate **audience switch**: **conversation — "Talk to the agent"** (default, left) ⇄ **memo — "Leave a memo"** (right). A memo carries `comment.agent: false`.

## Change
- **core:** `Comment.agent?: boolean` (absent/true = talk; `false` = memo). New **`docForAgent(doc)`** — the doc as the agent should see it: strips memo comments **+ their replies** and unwraps any span-memo body anchor (new **`unwrapAnchors`**) so no dangling `[text](#cmt-id)` remains. `agent` added to the canonical comment key order (deterministic bytes). `agent:false` round-trips through serialize/parse.
- **renderer:** the `ComposerPopover` switch (`IconComment`/`IconMemo`, `role=radiogroup`, conversation default); `addComment` threads the flag into the comment **and echoes `agent:false` in the `comment_created` event payload** so the cloud agent can skip the wake; `NewCommentFields.agent`; 3 composer i18n keys.

## Tests
core+renderer **649 pass** — 5 new (`docForAgent`/`unwrapAnchors`/`agent` round-trip) + the memo composer test (audience default + memo→`agent:false`).

## Follow-up (inplan-cloud)
`AgentTrigger.wakesAgent` skips `payload.agent === false`; the trigger's `getBody` projects via `docForAgent`; add the 3 keys to the 15 editor locale catalogs (parity test). Stacks after this merges (cloud CI builds the renderer from `main`).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/12?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Composer audience toggle to send comments to the agent or leave personal memos; memos are ignored by the agent and won't trigger responses.
  * Memo icon added to the UI.
  * Agent-facing view now strips memo comments and rewrites memo-style anchored references in document text.

* **Styles**
  * New styling for the composer audience toggle.

* **Tests**
  * Added tests covering memo behavior, anchor unwrapping, and submission flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->