### PR TITLE
test: comprehensive editor unit/component matrix (+142 tests)

### DIFF
--- a/packages/core/test/grammar.matrix.test.ts
+++ b/packages/core/test/grammar.matrix.test.ts
@@ -1,0 +1,428 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, it, expect } from "vitest";
+import {
+  parse,
+  serialize,
+  serializeCanonical,
+  orderComments,
+  docForAgent,
+  checkIntegrity,
+  unwrapAnchors,
+  extractAnchorIds,
+  type Comment,
+  type ParsedDocument,
+} from "../src";
+
+/** Compact comment factory mirroring the rest of the core suite. */
+const c = (id: string, over: Partial<Comment> = {}): Comment => ({
+  id,
+  text: `text ${id}`,
+  author: "Tester <t@inplan.ai>",
+  date: "2026-06-08T00:00:00Z",
+  resolved: false,
+  ...over,
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// parse ↔ serialize round-trip, all comment fields
+// ───────────────────────────────────────────────────────────────────────────
+describe("parse ↔ serialize round-trip preserves every comment field", () => {
+  it("preserves agent:false, may_resolve, question, selected, parentId, anchor across a full round-trip", () => {
+    const doc: ParsedDocument = {
+      version: 1,
+      body: "# Plan\n\nUse [Postgres](#cmt-span01) for storage.",
+      comments: [
+        // span comment (anchored to a body link)
+        { id: "cmt-span01", author: "Dana <dana@example.com>", date: "2026-05-28T13:34:00Z", resolved: false, text: "Why not SQLite?" },
+        // question payload (agent -> human)
+        {
+          id: "cmt-ques01",
+          anchor: "doc",
+          author: "Opus 4.8 <claude@inplan.ai>",
+          date: "2026-05-28T13:35:00Z",
+          resolved: false,
+          text: "Which targets?",
+          question: { multiSelect: true, choices: [{ label: "macOS", description: "" }, { label: "Windows", description: "primary" }] },
+        },
+        // answer reply carrying `selected`
+        { id: "cmt-ans001", parentId: "cmt-ques01", author: "Dana <dana@example.com>", date: "2026-05-28T13:36:00Z", resolved: false, text: "go simple", selected: ["macOS"] },
+        // reply carrying may_resolve (agent's resolve suggestion)
+        { id: "cmt-rep001", parentId: "cmt-span01", author: "Opus 4.8 <claude@inplan.ai>", date: "2026-05-28T13:40:00Z", resolved: false, text: "Adopted Postgres.", may_resolve: true },
+        // a memo (agent:false) and a doc-level comment
+        { id: "cmt-memo01", anchor: "doc", author: "Dana <dana@example.com>", date: "2026-05-28T13:41:00Z", resolved: true, text: "note to self", agent: false },
+      ],
+    };
+    expect(parse(serialize(doc))).toEqual(doc);
+  });
+
+  it("round-trips a single-select question (multiSelect:false) and an empty selected[]", () => {
+    const doc: ParsedDocument = {
+      version: 1,
+      body: "Pick [one](#cmt-qq0001).",
+      comments: [
+        { id: "cmt-qq0001", author: "Agent <agent@inplan>", date: "2026-06-01T00:00:00Z", resolved: false, text: "Choose:", question: { multiSelect: false, choices: [{ label: "A" }] } },
+        { id: "cmt-aa0001", parentId: "cmt-qq0001", author: "You", date: "2026-06-01T00:00:01Z", resolved: false, text: "none", selected: [] },
+      ],
+    };
+    expect(parse(serialize(doc))).toEqual(doc);
+  });
+
+  it("round-trips a document with no comments (empty data block)", () => {
+    const doc: ParsedDocument = { version: 1, body: "# Just a body\n\nNo comments.", comments: [] };
+    expect(parse(serialize(doc))).toEqual(doc);
+  });
+
+  it("round-trips an empty body (serialize emits a leading newline, parse strips trailing space)", () => {
+    const doc: ParsedDocument = { version: 1, body: "", comments: [] };
+    const round = parse(serialize(doc));
+    expect(round.body).toBe("");
+    expect(round.comments).toEqual([]);
+  });
+
+  it("round-trips unicode + emoji in body and comment text", () => {
+    const doc: ParsedDocument = {
+      version: 1,
+      body: "# 計画 🚀\n\nUse [데이터베이스](#cmt-uni001) — café ☕.",
+      comments: [{ id: "cmt-uni001", author: "박 <p@example.com>", date: "2026-06-01T00:00:00Z", resolved: false, text: "왜 안 돼요? 🤔" }],
+    };
+    expect(parse(serialize(doc))).toEqual(doc);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// version marker
+// ───────────────────────────────────────────────────────────────────────────
+describe("the <!--inplan vN--> version marker", () => {
+  it("serialize stamps v1 on the marker", () => {
+    expect(serialize({ body: "b", comments: [] })).toContain("<!--inplan v1");
+  });
+
+  it("serialize honors an explicit version on the doc", () => {
+    expect(serialize({ version: 7, body: "b", comments: [] })).toContain("<!--inplan v7");
+  });
+
+  it("parse reads an explicit version token without consuming the JSON", () => {
+    const doc = parse('text\n\n<!--inplan v2\n[ { "id": "cmt-ver002", "author": "x", "date": "d", "resolved": false, "text": "v2" } ]\n-->\n');
+    expect(doc.version).toBe(2);
+    expect(doc.comments.map((x) => x.id)).toEqual(["cmt-ver002"]);
+  });
+
+  it("parse defaults a version-less legacy block to version 1", () => {
+    const doc = parse('text\n\n<!--inplan\n[ { "id": "cmt-leg001", "author": "x", "date": "d", "resolved": false, "text": "legacy" } ]\n-->\n');
+    expect(doc.version).toBe(1);
+    expect(doc.comments.map((x) => x.id)).toEqual(["cmt-leg001"]);
+  });
+
+  it("parse defaults to version 1 for a document with no data block at all", () => {
+    expect(parse("# plain markdown\n").version).toBe(1);
+  });
+
+  it("a multi-digit version round-trips through serialize → parse", () => {
+    expect(parse(serialize({ version: 12, body: "b", comments: [] })).version).toBe(12);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// fenced-code example block must NOT be mistaken for the real data block
+// ───────────────────────────────────────────────────────────────────────────
+describe("a fenced-code example block is not mistaken for the real data block", () => {
+  it("ignores an <!--inplan block inside a fence and uses the real one below it", () => {
+    const md = [
+      "# Doc documenting its own format",
+      "",
+      "```markdown",
+      "<!--inplan",
+      '[ { "id": "cmt-examp1", "author": "x", "date": "d", "resolved": false, "text": "example only" } ]',
+      "-->",
+      "```",
+      "",
+      "Body with [a span](#cmt-real01).",
+      "",
+      "<!--inplan v1",
+      '[ { "id": "cmt-real01", "author": "Dana", "date": "d", "resolved": false, "text": "the real comment" } ]',
+      "-->",
+      "",
+    ].join("\n");
+    const doc = parse(md);
+    expect(doc.comments.map((x) => x.id)).toEqual(["cmt-real01"]);
+    expect(doc.body).toContain("```markdown");
+    expect(doc.body).toContain("# Doc documenting its own format");
+  });
+
+  it("ignores a tilde-fenced (~~~) example block too", () => {
+    const md = ["~~~", "<!--inplan", "[]", "-->", "~~~", "", "Real [span](#cmt-real02).", "", "<!--inplan", '[ { "id": "cmt-real02", "author": "x", "date": "d", "resolved": false, "text": "r" } ]', "-->", ""].join("\n");
+    const doc = parse(md);
+    expect(doc.comments.map((x) => x.id)).toEqual(["cmt-real02"]);
+    expect(doc.body).toContain("~~~");
+  });
+
+  it("treats a document whose only <!--inplan lives inside a fence as having no data block", () => {
+    const md = ["Some prose.", "", "```", "<!--inplan", '[ { "id": "cmt-x" } ]', "-->", "```", ""].join("\n");
+    const doc = parse(md);
+    expect(doc.comments).toEqual([]);
+    expect(doc.body).toContain("<!--inplan"); // the fenced example stays in the body
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// serializeCanonical: byte-identical regardless of input order
+// ───────────────────────────────────────────────────────────────────────────
+describe("serializeCanonical is byte-identical regardless of input order", () => {
+  const comments: Comment[] = [
+    c("cmt-rep1b0", { parentId: "cmt-root01", date: "2026-06-08T00:00:05Z" }),
+    c("cmt-root02", { date: "2026-06-08T00:00:03Z" }),
+    c("cmt-rep1a0", { parentId: "cmt-root01", date: "2026-06-08T00:00:02Z" }),
+    c("cmt-root01", { date: "2026-06-08T00:00:01Z" }),
+  ];
+
+  it("produces identical bytes for any input permutation", () => {
+    const a = serializeCanonical({ body: "# B\n\nx", comments });
+    const b = serializeCanonical({ body: "# B\n\nx", comments: [...comments].reverse() });
+    const cc = serializeCanonical({ body: "# B\n\nx", comments: [comments[2]!, comments[0]!, comments[3]!, comments[1]!] });
+    expect(b).toBe(a);
+    expect(cc).toBe(a);
+  });
+
+  it("re-serializing a reparsed canonical doc is a fixpoint", () => {
+    const text = serializeCanonical({ body: "# B\n\nx", comments });
+    expect(serializeCanonical(parse(text))).toBe(text);
+  });
+
+  it("imposes a canonical FIELD order independent of source key order", () => {
+    const a: Comment = { resolved: false, text: "t", id: "cmt-aaa111", author: "x", date: "2026-06-08T00:00:01Z" } as Comment;
+    const b: Comment = { id: "cmt-aaa111", date: "2026-06-08T00:00:01Z", author: "x", text: "t", resolved: false };
+    expect(serializeCanonical({ body: "b", comments: [a] })).toBe(serializeCanonical({ body: "b", comments: [b] }));
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// orderComments: stable depth-first (date,id) walk
+// ───────────────────────────────────────────────────────────────────────────
+describe("orderComments is a stable depth-first (date, id) walk", () => {
+  it("orders roots by (date, id), grouping replies under their parent in (date, id) order", () => {
+    const ordered = orderComments([
+      c("cmt-rep1b0", { parentId: "cmt-root01", date: "2026-06-08T00:00:05Z" }),
+      c("cmt-root02", { date: "2026-06-08T00:00:03Z" }),
+      c("cmt-rep1a0", { parentId: "cmt-root01", date: "2026-06-08T00:00:02Z" }),
+      c("cmt-root01", { date: "2026-06-08T00:00:01Z" }),
+    ]);
+    expect(ordered.map((x) => x.id)).toEqual(["cmt-root01", "cmt-rep1a0", "cmt-rep1b0", "cmt-root02"]);
+  });
+
+  it("tiebreaks equal dates by id and is order-independent", () => {
+    const items = [
+      c("cmt-zzz999", { date: "2026-06-08T00:00:02Z" }),
+      c("cmt-aaa111", { date: "2026-06-08T00:00:02Z" }),
+      c("cmt-mmm555", { date: "2026-06-08T00:00:01Z" }),
+    ];
+    const a = orderComments(items).map((x) => x.id);
+    expect(a).toEqual(orderComments([...items].reverse()).map((x) => x.id));
+    expect(a).toEqual(["cmt-mmm555", "cmt-aaa111", "cmt-zzz999"]);
+  });
+
+  it("treats an orphan reply (absent parent) as a root, dropping/duplicating nothing", () => {
+    const ordered = orderComments([
+      c("cmt-orph01", { parentId: "cmt-gone00", date: "2026-06-08T00:00:09Z" }),
+      c("cmt-root01", { date: "2026-06-08T00:00:01Z" }),
+    ]);
+    expect(ordered).toHaveLength(2);
+    expect(new Set(ordered.map((x) => x.id))).toEqual(new Set(["cmt-orph01", "cmt-root01"]));
+  });
+
+  it("survives a 2-cycle, emitting each comment exactly once", () => {
+    const ordered = orderComments([
+      c("cmt-aaa111", { parentId: "cmt-bbb222" }),
+      c("cmt-bbb222", { parentId: "cmt-aaa111" }),
+    ]);
+    expect(ordered).toHaveLength(2);
+    expect(new Set(ordered.map((x) => x.id))).toEqual(new Set(["cmt-aaa111", "cmt-bbb222"]));
+  });
+
+  it("survives a 3-cycle and emits each member once", () => {
+    const ordered = orderComments([
+      c("cmt-aaa111", { parentId: "cmt-ccc333" }),
+      c("cmt-bbb222", { parentId: "cmt-aaa111" }),
+      c("cmt-ccc333", { parentId: "cmt-bbb222" }),
+    ]);
+    expect(ordered).toHaveLength(3);
+    expect(new Set(ordered.map((x) => x.id))).toEqual(new Set(["cmt-aaa111", "cmt-bbb222", "cmt-ccc333"]));
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(orderComments([])).toEqual([]);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// integrity
+// ───────────────────────────────────────────────────────────────────────────
+describe("checkIntegrity accepts valid documents and rejects malformed ones", () => {
+  it("accepts a valid doc: unique span links, doc comment + reply with no links, parent present", () => {
+    const doc: ParsedDocument = {
+      body: "Use [Postgres](#cmt-span01) here.",
+      comments: [
+        { id: "cmt-span01", author: "h", date: "d1", resolved: false, text: "span" },
+        { id: "cmt-rep001", parentId: "cmt-span01", author: "h", date: "d2", resolved: false, text: "reply" },
+        { id: "cmt-doc001", anchor: "doc", author: "h", date: "d3", resolved: false, text: "doc-level" },
+      ],
+    };
+    const r = checkIntegrity(doc);
+    expect(r.ok).toBe(true);
+    expect(r.errors).toEqual([]);
+  });
+
+  it("flags a dangling link (anchor with no matching comment)", () => {
+    const r = checkIntegrity({ body: "[x](#cmt-gone00)", comments: [] });
+    expect(r.ok).toBe(false);
+    expect(r.errors.map((e) => e.code)).toContain("dangling_link");
+  });
+
+  it("flags duplicate comment ids", () => {
+    const r = checkIntegrity({
+      body: "[a](#cmt-dup001)",
+      comments: [
+        { id: "cmt-dup001", author: "h", date: "d", resolved: false, text: "one" },
+        { id: "cmt-dup001", author: "h", date: "d", resolved: false, text: "two" },
+      ],
+    });
+    expect(r.ok).toBe(false);
+    expect(r.errors.map((e) => e.code)).toContain("duplicate_id");
+  });
+
+  it("flags a span comment whose in-body link is missing", () => {
+    const r = checkIntegrity({ body: "no link here", comments: [{ id: "cmt-span01", author: "h", date: "d", resolved: false, text: "span" }] });
+    expect(r.errors.map((e) => e.code)).toContain("span_missing_link");
+  });
+
+  it("flags a span comment with duplicate (more than one) in-body links", () => {
+    const r = checkIntegrity({ body: "[a](#cmt-span01) and again [b](#cmt-span01)", comments: [{ id: "cmt-span01", author: "h", date: "d", resolved: false, text: "span" }] });
+    expect(r.errors.map((e) => e.code)).toContain("span_duplicate_link");
+  });
+
+  it("flags a non-span comment (doc/reply) that wrongly carries a link", () => {
+    const r = checkIntegrity({
+      body: "[a](#cmt-doc001)",
+      comments: [{ id: "cmt-doc001", anchor: "doc", author: "h", date: "d", resolved: false, text: "doc" }],
+    });
+    expect(r.errors.map((e) => e.code)).toContain("nonspan_has_link");
+  });
+
+  it("flags a reply whose parent is missing", () => {
+    const r = checkIntegrity({ body: "x", comments: [{ id: "cmt-rep001", parentId: "cmt-gone00", author: "h", date: "d", resolved: false, text: "orphan" }] });
+    expect(r.errors.map((e) => e.code)).toContain("missing_parent");
+  });
+
+  it("flags a malformed comment id", () => {
+    const r = checkIntegrity({ body: "[a](#cmt-bad)", comments: [{ id: "BAD_ID", author: "h", date: "d", resolved: false, text: "x" }] });
+    expect(r.errors.map((e) => e.code)).toContain("malformed_id");
+  });
+
+  it("flags a link that targets a non-span (doc-level) comment", () => {
+    const r = checkIntegrity({
+      body: "[a](#cmt-doc001)",
+      comments: [{ id: "cmt-doc001", anchor: "doc", author: "h", date: "d", resolved: false, text: "doc" }],
+    });
+    expect(r.errors.map((e) => e.code)).toContain("link_targets_nonspan");
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// unwrapAnchors edge cases
+// ───────────────────────────────────────────────────────────────────────────
+describe("unwrapAnchors edge cases", () => {
+  it("unwraps only listed ids, leaving other anchors intact", () => {
+    const body = "See [here](#cmt-aaa111) and [there](#cmt-bbb222).";
+    expect(unwrapAnchors(body, new Set(["cmt-aaa111"]))).toBe("See here and [there](#cmt-bbb222).");
+  });
+
+  it("is a no-op for an empty id set", () => {
+    const body = "[x](#cmt-aaa111)";
+    expect(unwrapAnchors(body, new Set())).toBe(body);
+  });
+
+  it("matches case-insensitively in BOTH the body and the id set", () => {
+    expect(unwrapAnchors("[x](#cmt-AbC123)", new Set(["cmt-abc123"]))).toBe("x");
+    expect(unwrapAnchors("[y](#cmt-def456)", new Set(["CMT-DEF456"]))).toBe("y");
+  });
+
+  it("does not unwrap on a partial / non-matching id", () => {
+    const body = "[x](#cmt-abc123)";
+    expect(unwrapAnchors(body, new Set(["cmt-abc"]))).toBe(body); // partial prefix is not a match
+    expect(unwrapAnchors(body, new Set(["cmt-abc1234"]))).toBe(body); // longer is not a match
+    expect(unwrapAnchors(body, new Set(["cmt-zzz999"]))).toBe(body); // unrelated id
+  });
+
+  it("unwraps every occurrence of a repeated anchor", () => {
+    expect(unwrapAnchors("[a](#cmt-aaa111) x [b](#cmt-aaa111)", new Set(["cmt-aaa111"]))).toBe("a x b");
+  });
+
+  it("returns the body unchanged when no anchors are present", () => {
+    expect(unwrapAnchors("plain text, no anchors", new Set(["cmt-aaa111"]))).toBe("plain text, no anchors");
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// extractAnchorIds (supporting integrity / anchoring grammar)
+// ───────────────────────────────────────────────────────────────────────────
+describe("extractAnchorIds", () => {
+  it("collects distinct, lowercased ids and ignores anchors inside code", () => {
+    const body = "Real [a](#cmt-AAA111) and [b](#cmt-bbb222). `inline [c](#cmt-ccc333)` and:\n```\n[d](#cmt-ddd444)\n```\n";
+    expect(extractAnchorIds(body)).toEqual(new Set(["cmt-aaa111", "cmt-bbb222"]));
+  });
+
+  it("returns an empty set for a body with no anchors", () => {
+    expect(extractAnchorIds("nothing here")).toEqual(new Set());
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// docForAgent
+// ───────────────────────────────────────────────────────────────────────────
+describe("docForAgent removes memo subtrees and unwraps span-memo anchors", () => {
+  const doc: ParsedDocument = {
+    body: "Intro. A [flagged span](#cmt-span01) and a normal [span](#cmt-keep01).",
+    comments: [
+      { id: "cmt-doc001", anchor: "doc", author: "h", date: "2026-06-13T00:00:00Z", resolved: false, text: "memo to teammates", agent: false },
+      { id: "cmt-rep001", parentId: "cmt-doc001", author: "h", date: "2026-06-13T00:01:00Z", resolved: false, text: "reply on the memo" },
+      { id: "cmt-span01", author: "h", date: "2026-06-13T00:02:00Z", resolved: false, text: "a span memo", agent: false },
+      { id: "cmt-keep01", author: "h", date: "2026-06-13T00:03:00Z", resolved: false, text: "talk to the agent" },
+    ],
+  };
+
+  it("drops memos + their replies and unwraps the span-memo anchor; keeps agent-facing comments", () => {
+    const agentDoc = docForAgent(doc);
+    expect(agentDoc.comments.map((x) => x.id)).toEqual(["cmt-keep01"]);
+    expect(agentDoc.body).toBe("Intro. A flagged span and a normal [span](#cmt-keep01).");
+  });
+
+  it("removes a memo's descendants transitively (deep reply chains can't leak)", () => {
+    const nested: ParsedDocument = {
+      body: "Body.",
+      comments: [
+        { id: "cmt-memo00", anchor: "doc", author: "h", date: "2026-06-13T00:00:00Z", resolved: false, text: "memo root", agent: false },
+        { id: "cmt-rep1", parentId: "cmt-memo00", author: "h", date: "2026-06-13T00:01:00Z", resolved: false, text: "reply" },
+        { id: "cmt-rep2", parentId: "cmt-rep1", author: "h", date: "2026-06-13T00:02:00Z", resolved: false, text: "reply2" },
+        { id: "cmt-rep3", parentId: "cmt-rep2", author: "h", date: "2026-06-13T00:03:00Z", resolved: false, text: "reply3" },
+        { id: "cmt-keep", anchor: "doc", author: "h", date: "2026-06-13T00:04:00Z", resolved: false, text: "unrelated" },
+      ],
+    };
+    expect(docForAgent(nested).comments.map((x) => x.id)).toEqual(["cmt-keep"]);
+  });
+
+  it("is a referential no-op (returns the same object) when there are no memos", () => {
+    const clean: ParsedDocument = { body: "x", comments: [{ id: "cmt-keep01", anchor: "doc", author: "h", date: "d", resolved: false, text: "hi" }] };
+    expect(docForAgent(clean)).toBe(clean);
+  });
+
+  it("treats absent/true agent as agent-facing (not a memo)", () => {
+    const d: ParsedDocument = {
+      body: "[a](#cmt-aaa111) [b](#cmt-bbb222)",
+      comments: [
+        { id: "cmt-aaa111", author: "h", date: "d", resolved: false, text: "no agent field" },
+        { id: "cmt-bbb222", author: "h", date: "d", resolved: false, text: "agent true", agent: true },
+      ],
+    };
+    expect(docForAgent(d)).toBe(d); // no memos → identical reference, body untouched
+  });
+});

--- a/packages/renderer/test/App.findReplace.matrix.test.tsx
+++ b/packages/renderer/test/App.findReplace.matrix.test.tsx
@@ -218,6 +218,7 @@ describe("App find bar — match-count matrix (memory-backed)", () => {
   });
 
   it("agent is wired up by the memory session (sanity)", () => {
+    mount(DOC); // self-contained: don't rely on a prior test having set the shared `agent`
     expect(agent).toBeTruthy();
   });
 });

--- a/packages/renderer/test/App.findReplace.matrix.test.tsx
+++ b/packages/renderer/test/App.findReplace.matrix.test.tsx
@@ -1,0 +1,223 @@
+// @vitest-environment happy-dom
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// A behavior matrix for the find bar's N/M match count against the real <App/>
+// with a memory-backed window.api. Exercises the count text the bar renders
+// (`${Math.min(idx+1, n)}/${n}` or "0/0") across: match counts, the
+// case-insensitive ("Aa") toggle, no-match queries, the preview/editor/comments
+// scopes, clearing the query, comment-only matches, and special-regex chars
+// (escapeRegExp makes them literal — no crash).
+//
+// SourceEditor (CodeMirror) is stubbed — it needs layout APIs happy-dom only
+// stubs, and the find flow under test lives in App, not the editor.
+
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { forwardRef, useImperativeHandle } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createMemoryApi, type MemoryAgent } from "../src/memoryApi";
+
+vi.mock("../src/SourceEditor", () => ({
+  SourceEditor: forwardRef(function SourceEditorStub(_props: unknown, ref: React.Ref<unknown>) {
+    useImperativeHandle(ref, () => ({ scrollToLine() {}, selectRange() {} }));
+    return null;
+  }),
+}));
+
+// Build a serialized inplan document: a body plus a comment data block holding
+// the given comments (each needs at least id/text/author). The find bar counts
+// comment matches straight off doc.comments, so this is enough to drive it.
+function makeDoc(body: string, comments: Array<{ id: string; text: string }> = []): string {
+  const json = JSON.stringify(comments.map((c) => ({ id: c.id, text: c.text, author: "tester" })), null, 2);
+  return `${body}\n\n<!--inplan v1\n${json}\n-->\n`;
+}
+
+// "alpha" appears 3 times in the body; "Alpha" (capital) appears once. The body
+// also carries a "." so a literal "." query is meaningful, and a unicode word.
+const BODY = "# Plan\n\nalpha beta alpha gamma alpha delta. Alpha café (x).\n";
+// "zephyr" lives only in a comment, never in the body.
+const DOC = makeDoc(BODY, [{ id: "c1", text: "zephyr note about alpha" }]);
+
+let agent: MemoryAgent;
+
+function mount(content: string) {
+  document.body.innerHTML = '<div id="root"></div>';
+  const session = createMemoryApi({ content });
+  (window as unknown as { api: unknown }).api = session.api;
+  agent = session.agent;
+}
+
+afterEach(cleanup);
+
+async function openFindBar(content: string) {
+  mount(content);
+  const { App } = await import("../src/App");
+  render(<App />);
+  await waitFor(() => expect(document.body.textContent).toContain("alpha beta alpha"));
+  expect(screen.queryByPlaceholderText(/Find/)).toBeNull();
+  fireEvent.keyDown(document.body, { key: "f", metaKey: true });
+  const input = await waitFor(() => screen.getByPlaceholderText("Find…"));
+  return input;
+}
+
+async function type(input: HTMLElement, value: string) {
+  await act(async () => {
+    fireEvent.change(input, { target: { value } });
+  });
+}
+
+// jest-dom matchers aren't wired into this suite; read .checked off the element.
+function checkbox(name: RegExp): HTMLInputElement {
+  return screen.getByRole("checkbox", { name }) as HTMLInputElement;
+}
+
+describe("App find bar — match-count matrix (memory-backed)", () => {
+  it("renders N/M for a query with multiple body matches (1/3, case-sensitive)", async () => {
+    const input = await openFindBar(DOC);
+    await type(input, "alpha");
+    // Default scope is preview (= body) and case-sensitive, so capital "Alpha"
+    // is NOT counted: exactly three lowercase "alpha".
+    await waitFor(() => expect(document.body.textContent).toContain("1/3"));
+    expect(document.body.textContent).not.toContain("1/4");
+  });
+
+  it("shows 1/1 for a query with a single body match", async () => {
+    const input = await openFindBar(DOC);
+    await type(input, "gamma");
+    await waitFor(() => expect(document.body.textContent).toContain("1/1"));
+  });
+
+  it("shows 0/0 when nothing matches", async () => {
+    const input = await openFindBar(DOC);
+    await type(input, "nonexistent-token");
+    await waitFor(() => expect(document.body.textContent).toContain("0/0"));
+  });
+
+  it("counts are case-sensitive by default and case-insensitive once Aa is toggled", async () => {
+    const input = await openFindBar(DOC);
+    // Capital "Alpha" appears once; lowercase "alpha" three times.
+    await type(input, "Alpha");
+    await waitFor(() => expect(document.body.textContent).toContain("1/1"));
+
+    // Toggle the case checkbox (label text "Aa"). Now "Alpha" matches all four
+    // (3 lowercase + 1 capital).
+    const aa = screen.getByRole("checkbox", { name: /aa/i });
+    await act(async () => {
+      fireEvent.click(aa);
+    });
+    await waitFor(() => expect(document.body.textContent).toContain("1/4"));
+
+    // Toggling back restores the case-sensitive count.
+    await act(async () => {
+      fireEvent.click(aa);
+    });
+    await waitFor(() => expect(document.body.textContent).toContain("1/1"));
+  });
+
+  it("clearing the query resets the count to 0/0", async () => {
+    const input = await openFindBar(DOC);
+    await type(input, "alpha");
+    await waitFor(() => expect(document.body.textContent).toContain("1/3"));
+    await type(input, "");
+    await waitFor(() => expect(document.body.textContent).toContain("0/0"));
+  });
+
+  it("preview and editor scopes both search the body (mutually exclusive, same count)", async () => {
+    const input = await openFindBar(DOC);
+    await type(input, "alpha");
+    // Default = preview scope → body matches.
+    await waitFor(() => expect(document.body.textContent).toContain("1/3"));
+
+    // Switch to the editor scope; preview turns off (preview ⊕ editor) but the
+    // body is still what's scanned, so the count is unchanged.
+    const editor = screen.getByRole("checkbox", { name: /editor/i });
+    await act(async () => {
+      fireEvent.click(editor);
+    });
+    await waitFor(() => expect(checkbox(/editor/i).checked).toBe(true));
+    expect(checkbox(/preview/i).checked).toBe(false);
+    await waitFor(() => expect(document.body.textContent).toContain("1/3"));
+  });
+
+  it("with NO body/comment scope active there are 0 matches even though the body contains the query", async () => {
+    const input = await openFindBar(DOC);
+    await type(input, "alpha");
+    await waitFor(() => expect(document.body.textContent).toContain("1/3"));
+
+    // Turn off preview without enabling editor/comments → nothing is scanned.
+    const preview = screen.getByRole("checkbox", { name: /preview/i });
+    await act(async () => {
+      fireEvent.click(preview);
+    });
+    await waitFor(() => expect(checkbox(/preview/i).checked).toBe(false));
+    await waitFor(() => expect(document.body.textContent).toContain("0/0"));
+  });
+
+  it("comments scope adds comment matches; a comment-only word matches only when comments are searched", async () => {
+    const input = await openFindBar(DOC);
+    // "zephyr" lives in the comment, not the body → 0/0 under the default
+    // (preview/body) scope.
+    await type(input, "zephyr");
+    await waitFor(() => expect(document.body.textContent).toContain("0/0"));
+
+    // Enable the comments scope → the comment match is now counted.
+    const comments = screen.getByRole("checkbox", { name: /comments/i });
+    await act(async () => {
+      fireEvent.click(comments);
+    });
+    await waitFor(() => expect(checkbox(/comments/i).checked).toBe(true));
+    await waitFor(() => expect(document.body.textContent).toContain("1/1"));
+  });
+
+  it("preview + comments together sum body and comment matches", async () => {
+    const input = await openFindBar(DOC);
+    // "alpha": 3 in the body, 1 in the comment ("...about alpha").
+    await type(input, "alpha");
+    await waitFor(() => expect(document.body.textContent).toContain("1/3"));
+
+    const comments = screen.getByRole("checkbox", { name: /comments/i });
+    await act(async () => {
+      fireEvent.click(comments);
+    });
+    await waitFor(() => expect(checkbox(/comments/i).checked).toBe(true));
+    await waitFor(() => expect(document.body.textContent).toContain("1/4"));
+  });
+
+  it("special regex chars are treated literally (no crash, accurate count)", async () => {
+    const input = await openFindBar(DOC);
+    // "." would match every char as a regex; escapeRegExp makes it literal.
+    // The body has exactly two literal "." characters ("delta." and "(x).").
+    await type(input, ".");
+    await waitFor(() => expect(document.body.textContent).toContain("1/2"));
+
+    // "(x)" — parens are regex metacharacters; treated literally it matches the
+    // single "(x)" substring in the body.
+    await type(input, "(x)");
+    await waitFor(() => expect(document.body.textContent).toContain("1/1"));
+
+    // A query of only metacharacters that appears nowhere → 0/0, still no crash.
+    await type(input, "[unmatched");
+    await waitFor(() => expect(document.body.textContent).toContain("0/0"));
+  });
+
+  it("a whitespace-only query is still counted literally", async () => {
+    const input = await openFindBar(DOC);
+    // The body has multiple single spaces; a single-space query is a real
+    // (non-empty) literal query, so it produces a positive count rather than 0/0.
+    await type(input, " ");
+    // The (trimmed) body "# Plan\n\nalpha beta alpha gamma alpha delta. Alpha
+    // café (x)." contains exactly 9 space characters (1 in "# Plan" + 8 in the
+    // text line) → 1/9, never 0/0.
+    await waitFor(() => expect(document.body.textContent).toContain("1/9"));
+    expect(document.body.textContent).not.toContain("0/0");
+  });
+
+  it("unicode in the body is matched literally", async () => {
+    const input = await openFindBar(DOC);
+    await type(input, "café");
+    await waitFor(() => expect(document.body.textContent).toContain("1/1"));
+  });
+
+  it("agent is wired up by the memory session (sanity)", () => {
+    expect(agent).toBeTruthy();
+  });
+});

--- a/packages/renderer/test/App.review.matrix.test.tsx
+++ b/packages/renderer/test/App.review.matrix.test.tsx
@@ -1,0 +1,240 @@
+// @vitest-environment happy-dom
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// App-level "matrix" integration test for the Review controls, exercising the
+// accept/reject decision surface end-to-end against a memory-backed window.api:
+//   - a parked proposal shows the diff with N hunks
+//   - the tri-switch defaults to ALL ACCEPTED (aria-checked=true) and cycling it
+//     flips accept/reject (aria-checked false)
+//   - a per-hunk Switch toggles exactly one hunk (the tri goes mixed)
+//   - Apply with all accepted writes the proposed body
+//   - Reject-all then Apply discards (body unchanged)
+//   - the pencil edits a hunk and Apply uses the edited text
+//   - Review-next steps the cursor through the hunks
+//
+// Mirrors App.reviewDiff.test.tsx for setup/style. SourceEditor (CodeMirror) is
+// stubbed because it needs layout APIs happy-dom doesn't provide, and the review
+// flow under test lives in App, not the editor.
+
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { forwardRef, useImperativeHandle } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createMemoryApi, type MemoryAgent } from "../src/memoryApi";
+
+vi.mock("../src/SourceEditor", () => ({
+  SourceEditor: forwardRef(function SourceEditorStub(_props: unknown, ref: React.Ref<unknown>) {
+    useImperativeHandle(ref, () => ({ scrollToLine() {}, selectRange() {} }));
+    return null;
+  }),
+}));
+
+const DOC = "# Plan\n\nAlpha line.\n\nBeta line.\n\n<!--inplan v1\n[]\n-->\n";
+// Two distinct body edits => two change hunks.
+const REVISED = "# Plan\n\nAlpha CHANGED.\n\nBeta CHANGED.\n\n<!--inplan v1\n[]\n-->\n";
+// A single body edit => exactly one change hunk (singular wording boundary).
+const REVISED_ONE = "# Plan\n\nAlpha CHANGED.\n\nBeta line.\n\n<!--inplan v1\n[]\n-->\n";
+
+let agent: MemoryAgent;
+
+type Win = {
+  api: { getProposal(): Promise<string | null> };
+};
+
+function mount(content: string) {
+  document.body.innerHTML = '<div id="root"></div>';
+  const session = createMemoryApi({ content });
+  (window as unknown as { api: unknown }).api = session.api;
+  agent = session.agent;
+}
+afterEach(cleanup);
+
+const tri = (): HTMLElement => screen.getByRole("checkbox", { name: /accept or reject all changes/i });
+
+describe("App review decision matrix (memory-backed)", () => {
+  beforeEach(() => mount(DOC));
+
+  async function renderAndPropose(revision = REVISED) {
+    const { App } = await import("../src/App");
+    render(<App />);
+    await waitFor(() => expect(document.body.textContent).toContain("Alpha line."));
+    await act(async () => {
+      agent.proposeRevision(revision);
+    });
+    await waitFor(() => expect(document.body.textContent).toContain("Agent proposed changes"));
+  }
+
+  it("a parked proposal shows the diff with N hunks (one switch per hunk)", async () => {
+    await renderAndPropose();
+
+    // The bar announces the change count; two body edits => two changes.
+    expect(document.body.textContent).toContain("2 changes shown inline below");
+    // Each hunk renders an accept switch in BOTH diff panes (shared state), so we
+    // expect a per-index switch to exist for change 1 and change 2 but not change 3.
+    expect(screen.getAllByRole("switch", { name: /accept change 1/ }).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByRole("switch", { name: /accept change 2/ }).length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryAllByRole("switch", { name: /accept change 3/ }).length).toBe(0);
+  });
+
+  it("a single-hunk proposal uses the singular '1 change' wording", async () => {
+    await renderAndPropose(REVISED_ONE);
+    expect(document.body.textContent).toContain("1 change shown inline below");
+    expect(document.body.textContent).not.toContain("changes shown inline below");
+    expect(screen.getAllByRole("switch", { name: /accept change 1/ }).length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryAllByRole("switch", { name: /accept change 2/ }).length).toBe(0);
+  });
+
+  it("the tri-switch defaults to ALL ACCEPTED (aria-checked=true) and one click flips it to reject (false)", async () => {
+    await renderAndPropose();
+    // Default: every hunk accepted → tri reports checked.
+    expect(tri().getAttribute("aria-checked")).toBe("true");
+    expect(document.querySelector(".ap-tri--accept")).toBeTruthy();
+
+    // Cycle once: accept → reject. aria-checked becomes false.
+    await act(async () => fireEvent.click(tri()));
+    expect(tri().getAttribute("aria-checked")).toBe("false");
+    expect(document.querySelector(".ap-tri--reject")).toBeTruthy();
+    expect(document.body.textContent).not.toContain("will be accepted");
+
+    // Cycle again: reject → accept.
+    await act(async () => fireEvent.click(tri()));
+    expect(tri().getAttribute("aria-checked")).toBe("true");
+    expect(document.querySelector(".ap-tri--accept")).toBeTruthy();
+  });
+
+  it("a per-hunk Switch toggles exactly one hunk and drives the tri-switch to mixed", async () => {
+    await renderAndPropose();
+    // All accepted to start.
+    const hunk1Before = screen.getAllByRole("switch", { name: /accept change 1/ })[0] as HTMLInputElement;
+    const hunk2Before = screen.getAllByRole("switch", { name: /accept change 2/ })[0] as HTMLInputElement;
+    expect(hunk1Before.checked).toBe(true);
+    expect(hunk2Before.checked).toBe(true);
+
+    // Reject ONLY change 1.
+    await act(async () => fireEvent.click(hunk1Before));
+
+    const hunk1 = screen.getAllByRole("switch", { name: /accept change 1/ })[0] as HTMLInputElement;
+    const hunk2 = screen.getAllByRole("switch", { name: /accept change 2/ })[0] as HTMLInputElement;
+    expect(hunk1.checked).toBe(false); // the one we toggled
+    expect(hunk2.checked).toBe(true); // untouched
+    // Mixed selection: the tri reports aria-checked="mixed".
+    expect(tri().getAttribute("aria-checked")).toBe("mixed");
+    expect(document.querySelector(".ap-tri--mixed")).toBeTruthy();
+    // The per-hunk status labels reflect the split.
+    expect(document.body.textContent).toContain("will be rejected");
+    expect(document.body.textContent).toContain("will be accepted");
+
+    // One click on the mixed tri resolves the whole set back to accept.
+    await act(async () => fireEvent.click(tri()));
+    expect(document.querySelector(".ap-tri--accept")).toBeTruthy();
+    expect((screen.getAllByRole("switch", { name: /accept change 1/ })[0] as HTMLInputElement).checked).toBe(true);
+  });
+
+  it("Apply with all accepted writes the proposed body and clears the proposal", async () => {
+    await renderAndPropose();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^Apply$/ }));
+    });
+
+    await waitFor(() => expect(document.body.textContent).not.toContain("Agent proposed changes"));
+    // Both accepted hunks landed in the applied (preview) body.
+    expect(document.body.textContent).toContain("Alpha CHANGED.");
+    expect(document.body.textContent).toContain("Beta CHANGED.");
+    expect(document.body.textContent).not.toContain("Alpha line.");
+    expect(document.body.textContent).not.toContain("Beta line.");
+    // Decision made → proposal discarded.
+    expect(await (window as unknown as Win).api.getProposal()).toBeNull();
+  });
+
+  it("Reject-all then Apply discards the proposal and leaves the body unchanged", async () => {
+    await renderAndPropose();
+    // accept → reject (one click rejects every hunk).
+    await act(async () => fireEvent.click(tri()));
+    expect(document.querySelector(".ap-tri--reject")).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^Apply$/ }));
+    });
+
+    await waitFor(() => expect(document.body.textContent).not.toContain("Agent proposed changes"));
+    // Original body intact; nothing from the proposal survived.
+    expect(document.body.textContent).toContain("Alpha line.");
+    expect(document.body.textContent).toContain("Beta line.");
+    expect(document.body.textContent).not.toContain("CHANGED");
+    expect(await (window as unknown as Win).api.getProposal()).toBeNull();
+  });
+
+  it("the pencil edits a hunk's proposed text and Apply uses the EDITED text", async () => {
+    await renderAndPropose();
+
+    // Open the inline editor for change 1; it is seeded with the agent's proposed text.
+    await act(async () => {
+      fireEvent.click(screen.getAllByRole("button", { name: /edit change 1/ })[0]!);
+    });
+    const ta = screen.getByRole("textbox", { name: /edit change 1/ }) as HTMLTextAreaElement;
+    expect(ta.value).toContain("Alpha CHANGED.");
+
+    await act(async () => {
+      fireEvent.change(ta, { target: { value: "Alpha EDITED." } });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /save edit/i }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^Apply$/ }));
+    });
+
+    await waitFor(() => expect(document.body.textContent).not.toContain("Agent proposed changes"));
+    // The human's edit wins over the agent's proposal for hunk 1; hunk 2 still applies.
+    expect(document.body.textContent).toContain("Alpha EDITED.");
+    expect(document.body.textContent).not.toContain("Alpha CHANGED.");
+    expect(document.body.textContent).toContain("Beta CHANGED.");
+  });
+
+  it("an edited hunk that is then REJECTED contributes neither the edit nor the proposal", async () => {
+    await renderAndPropose();
+    // Edit change 1.
+    await act(async () => {
+      fireEvent.click(screen.getAllByRole("button", { name: /edit change 1/ })[0]!);
+    });
+    await act(async () => {
+      fireEvent.change(screen.getByRole("textbox", { name: /edit change 1/ }), { target: { value: "Alpha EDITED." } });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /save edit/i }));
+    });
+    // Now reject change 1 entirely.
+    await act(async () => fireEvent.click(screen.getAllByRole("switch", { name: /accept change 1/ })[0]!));
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^Apply$/ }));
+    });
+
+    await waitFor(() => expect(document.body.textContent).not.toContain("Agent proposed changes"));
+    // Rejected hunk keeps the ORIGINAL line; the saved edit is discarded with the rejection.
+    expect(document.body.textContent).toContain("Alpha line.");
+    expect(document.body.textContent).not.toContain("Alpha EDITED.");
+    expect(document.body.textContent).not.toContain("Alpha CHANGED.");
+    // The other hunk was left accepted.
+    expect(document.body.textContent).toContain("Beta CHANGED.");
+  });
+
+  it("'Review next' steps the cursor through the hunks and wraps around", async () => {
+    await renderAndPropose();
+
+    const reviewNext = (): HTMLElement => screen.getByRole("button", { name: /^Review next/ });
+    // No cursor position shown until the first step.
+    expect(reviewNext().textContent).not.toMatch(/\d+\/\d+/);
+
+    // Step 1 → 1/2.
+    await act(async () => fireEvent.click(reviewNext()));
+    await waitFor(() => expect(screen.getByRole("button", { name: /Review next \(1\/2\)/ })).toBeTruthy());
+
+    // Step 2 → 2/2.
+    await act(async () => fireEvent.click(reviewNext()));
+    await waitFor(() => expect(screen.getByRole("button", { name: /Review next \(2\/2\)/ })).toBeTruthy());
+
+    // Step 3 wraps back to 1/2.
+    await act(async () => fireEvent.click(reviewNext()));
+    await waitFor(() => expect(screen.getByRole("button", { name: /Review next \(1\/2\)/ })).toBeTruthy());
+  });
+});

--- a/packages/renderer/test/clipboard.matrix.test.ts
+++ b/packages/renderer/test/clipboard.matrix.test.ts
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Matrix coverage for carrying span-comment threads through copy/cut/paste. The clipboard
+// module exposes the primitives, not a single copy()/paste() — so we model a copy as
+//   anchorIdsIn(text) -> threadsFor(ids, all) -> buildClipHtml(text, threads)
+// and a paste as
+//   readClipHtml(html) -> remapComments(payload.comments, taken) -> rewriteAnchors(text, idMap)
+// and assert the end-to-end invariants (fresh ids, no collisions, threads preserved).
+
+import type { Comment } from "@inplan/core";
+import { describe, expect, it } from "vitest";
+import { anchorIdsIn, buildClipHtml, readClipHtml, remapComments, rewriteAnchors, threadsFor } from "../src/clipboard";
+
+const c = (over: Partial<Comment> & { id: string }): Comment => ({
+  author: "Human <h@x>",
+  date: "2026-06-08T00:00:00Z",
+  resolved: false,
+  text: "",
+  ...over,
+});
+
+/** Model the copy side: pick the carried threads for the anchors in `text`, then serialize. */
+function copy(text: string, all: Comment[]): { text: string; html: string } {
+  const ids = anchorIdsIn(text);
+  const threads = threadsFor(ids, all);
+  return { text, html: buildClipHtml(text, threads) };
+}
+
+/** Model the paste side: deserialize, re-ID against `taken`, rewrite the fragment's hrefs. */
+function paste(clip: { text: string; html: string }, taken: Set<string>): { text: string; comments: Comment[] } | null {
+  const payload = readClipHtml(clip.html);
+  if (!payload) return null;
+  const { comments, idMap } = remapComments(payload.comments, taken);
+  return { text: rewriteAnchors(clip.text, idMap), comments };
+}
+
+describe("copy carries an anchored thread", () => {
+  const all: Comment[] = [
+    c({ id: "cmt-root1", text: "root one" }),
+    c({ id: "cmt-rep1a", parentId: "cmt-root1", text: "reply" }),
+    c({ id: "cmt-rep1b", parentId: "cmt-rep1a", text: "nested reply" }),
+    c({ id: "cmt-other", text: "unrelated" }),
+  ];
+
+  it("carries the anchored root plus its replies (transitively)", () => {
+    const clip = copy("look [here](#cmt-root1) please", all);
+    const payload = readClipHtml(clip.html)!;
+    expect(payload.comments.map((x) => x.id)).toEqual(["cmt-root1", "cmt-rep1a", "cmt-rep1b"]);
+    expect(payload.comments.map((x) => x.id)).not.toContain("cmt-other");
+  });
+
+  it("keeps the visible Markdown (anchor links intact) in the clip text", () => {
+    const clip = copy("look [here](#cmt-root1) please", all);
+    expect(clip.text).toBe("look [here](#cmt-root1) please");
+    expect(clip.html).toContain("look [here](#cmt-root1) please".replace(/&/g, "&amp;"));
+  });
+});
+
+describe("paste re-anchors with fresh ids", () => {
+  const all: Comment[] = [
+    c({ id: "cmt-root1", text: "root one" }),
+    c({ id: "cmt-rep1a", parentId: "cmt-root1", text: "reply" }),
+  ];
+
+  it("mints fresh ids that collide with neither existing comments nor the source ids", () => {
+    const clip = copy("see [x](#cmt-root1)", all);
+    // The thread is pasted back into the SAME doc, so the source ids are already taken.
+    const taken = new Set(all.map((x) => x.id));
+    const out = paste(clip, taken)!;
+
+    const newIds = out.comments.map((x) => x.id);
+    expect(new Set(newIds).size).toBe(newIds.length); // all distinct
+    for (const id of newIds) {
+      expect(taken.has(id)).toBe(false); // no collision with existing
+      expect(/^cmt-[0-9a-z]+$/.test(id)).toBe(true); // well-formed
+    }
+    // The reply still points at the (new) root id, preserving the thread shape.
+    expect(out.comments[1]!.parentId).toBe(out.comments[0]!.id);
+  });
+
+  it("rewrites the fragment's anchor href to the new root id", () => {
+    const clip = copy("see [x](#cmt-root1)", all);
+    const taken = new Set(all.map((x) => x.id));
+    const out = paste(clip, taken)!;
+
+    const newRoot = out.comments[0]!.id;
+    expect(out.text).toBe(`see [x](#${newRoot})`);
+    expect(out.text).not.toContain("cmt-root1");
+  });
+
+  it("preserves all non-id fields through the round-trip", () => {
+    const rich = c({ id: "cmt-root1", text: "café — naïve 🙂", author: "Opus 4.8 <claude@inplan.ai>", resolved: true });
+    const clip = copy("note [x](#cmt-root1)", [rich]);
+    const out = paste(clip, new Set(["cmt-root1"]))!;
+    const pasted = out.comments[0]!;
+    expect(pasted.text).toBe("café — naïve 🙂");
+    expect(pasted.author).toBe("Opus 4.8 <claude@inplan.ai>");
+    expect(pasted.resolved).toBe(true);
+    expect(pasted.id).not.toBe("cmt-root1");
+  });
+});
+
+describe("copy text with no anchor", () => {
+  const all: Comment[] = [c({ id: "cmt-root1", text: "root" })];
+
+  it("carries no comments when the selection has no anchor link", () => {
+    const clip = copy("just some plain prose, no links", all);
+    const payload = readClipHtml(clip.html)!;
+    expect(payload.comments).toEqual([]);
+  });
+
+  it("pastes back the plain text unchanged with an empty comment set", () => {
+    const clip = copy("plain prose", all);
+    const out = paste(clip, new Set(["cmt-root1"]))!;
+    expect(out.text).toBe("plain prose");
+    expect(out.comments).toEqual([]);
+  });
+
+  it("carries nothing for an empty or whitespace-only selection", () => {
+    expect(readClipHtml(copy("", all).html)!.comments).toEqual([]);
+    expect(readClipHtml(copy("   \n\t ", all).html)!.comments).toEqual([]);
+  });
+});
+
+describe("partial selection of an anchored span", () => {
+  const all: Comment[] = [
+    c({ id: "cmt-aaa111", text: "thread A" }),
+    c({ id: "cmt-rep1", parentId: "cmt-aaa111", text: "reply" }),
+  ];
+
+  it("drops a thread whose opening label bracket was clipped off (dangling href)", () => {
+    // The user selected from the middle of the anchored span: "](#cmt-aaa111) tail".
+    const clip = copy("part of label](#cmt-aaa111) and a tail", all);
+    const payload = readClipHtml(clip.html)!;
+    // No FULL_ANCHOR match -> no thread carried, so a paste can't produce a dangling link
+    // pointing at a non-existent (re-IDed) comment.
+    expect(payload.comments).toEqual([]);
+  });
+
+  it("drops a thread whose closing paren was clipped off (truncated href)", () => {
+    const clip = copy("look [here](#cmt-aaa111", all); // missing trailing ")"
+    expect(readClipHtml(clip.html)!.comments).toEqual([]);
+  });
+
+  it("carries the thread when the WHOLE anchor survives even if surrounding text is partial", () => {
+    const clip = copy("[here](#cmt-aaa111) plus a few trailing", all);
+    expect(readClipHtml(clip.html)!.comments.map((x) => x.id)).toEqual(["cmt-aaa111", "cmt-rep1"]);
+  });
+});
+
+describe("multiple anchored spans in one selection", () => {
+  const all: Comment[] = [
+    c({ id: "cmt-root1", text: "one" }),
+    c({ id: "cmt-rep1", parentId: "cmt-root1", text: "r1" }),
+    c({ id: "cmt-root2", text: "two" }),
+    c({ id: "cmt-rep2", parentId: "cmt-root2", text: "r2" }),
+    c({ id: "cmt-other", text: "untouched" }),
+  ];
+
+  it("carries every anchored thread, in document order, excluding unrelated comments", () => {
+    const clip = copy("a [x](#cmt-root1) mid [y](#cmt-root2) end", all);
+    const payload = readClipHtml(clip.html)!;
+    expect(payload.comments.map((x) => x.id)).toEqual(["cmt-root1", "cmt-rep1", "cmt-root2", "cmt-rep2"]);
+    expect(payload.comments.map((x) => x.id)).not.toContain("cmt-other");
+  });
+
+  it("re-IDs both threads to distinct fresh ids and rewrites both hrefs accordingly", () => {
+    const clip = copy("a [x](#cmt-root1) mid [y](#cmt-root2) end", all);
+    const taken = new Set(all.map((x) => x.id));
+    const out = paste(clip, taken)!;
+
+    const newIds = out.comments.map((x) => x.id);
+    expect(new Set(newIds).size).toBe(4); // all four distinct
+    for (const id of newIds) expect(taken.has(id)).toBe(false);
+
+    // Replies stay attached to their respective (new) roots.
+    const [nRoot1, nRep1, nRoot2, nRep2] = newIds;
+    expect(out.comments[1]!.parentId).toBe(nRoot1);
+    expect(out.comments[3]!.parentId).toBe(nRoot2);
+    expect(nRep1).not.toBe(nRep2);
+
+    // Both fragment hrefs were rewritten to their respective roots.
+    expect(out.text).toBe(`a [x](#${nRoot1}) mid [y](#${nRoot2}) end`);
+    expect(out.text).not.toContain("cmt-root1");
+    expect(out.text).not.toContain("cmt-root2");
+  });
+
+  it("handles a selection anchoring the same comment twice without duplicating the carried thread", () => {
+    const clip = copy("[a](#cmt-root1) and again [b](#cmt-root1)", all);
+    const payload = readClipHtml(clip.html)!;
+    // threadsFor de-dupes via a Set, so the root appears once.
+    expect(payload.comments.map((x) => x.id)).toEqual(["cmt-root1", "cmt-rep1"]);
+
+    // Both hrefs rewrite to the single new id.
+    const out = paste(clip, new Set(all.map((x) => x.id)))!;
+    const newRoot = out.comments[0]!.id;
+    expect(out.text).toBe(`[a](#${newRoot}) and again [b](#${newRoot})`);
+  });
+});
+
+describe("pasting the same clipboard twice yields distinct ids each time", () => {
+  const all: Comment[] = [
+    c({ id: "cmt-root1", text: "root" }),
+    c({ id: "cmt-rep1", parentId: "cmt-root1", text: "reply" }),
+  ];
+
+  it("the second paste does not collide with the first paste's minted ids", () => {
+    const clip = copy("see [x](#cmt-root1)", all);
+
+    // First paste into the live doc.
+    const taken = new Set(all.map((x) => x.id));
+    const first = paste(clip, taken)!;
+    // Those ids are now live too; reflect that in `taken` for the second paste.
+    for (const x of first.comments) taken.add(x.id);
+
+    const second = paste(clip, taken)!;
+
+    const firstIds = first.comments.map((x) => x.id);
+    const secondIds = second.comments.map((x) => x.id);
+    // No overlap between the two pastes, and none reuse the originals.
+    for (const id of secondIds) {
+      expect(firstIds).not.toContain(id);
+      expect(id).not.toBe("cmt-root1");
+      expect(id).not.toBe("cmt-rep1");
+    }
+    // Each paste rewrites its fragment to its own root id.
+    expect(first.text).toBe(`see [x](#${first.comments[0]!.id})`);
+    expect(second.text).toBe(`see [x](#${second.comments[0]!.id})`);
+    expect(first.text).not.toBe(second.text);
+  });
+});
+
+describe("round-trips a question + answer thread", () => {
+  const all: Comment[] = [
+    c({
+      id: "cmt-q1",
+      author: "Opus 4.8 <claude@inplan.ai>",
+      text: "Which approach?",
+      question: { multiSelect: false, choices: [{ label: "A", description: "first" }, { label: "B" }] },
+    }),
+    c({ id: "cmt-a1", parentId: "cmt-q1", text: "going with A", selected: ["A"] }),
+  ];
+
+  it("preserves the question payload and the answer's selected choices, with fresh linked ids", () => {
+    const clip = copy("decision: [q](#cmt-q1)", all);
+    const out = paste(clip, new Set(all.map((x) => x.id)))!;
+
+    expect(out.comments).toHaveLength(2);
+    const [q, a] = out.comments;
+
+    // Question structure preserved verbatim.
+    expect(q!.question).toEqual({ multiSelect: false, choices: [{ label: "A", description: "first" }, { label: "B" }] });
+    expect(q!.text).toBe("Which approach?");
+
+    // Answer preserved; selected choices survive; parent re-linked to the new question id.
+    expect(a!.text).toBe("going with A");
+    expect(a!.selected).toEqual(["A"]);
+    expect(a!.parentId).toBe(q!.id);
+
+    // Fresh ids on both, and the fragment href points at the new question id.
+    expect(q!.id).not.toBe("cmt-q1");
+    expect(a!.id).not.toBe("cmt-a1");
+    expect(out.text).toBe(`decision: [q](#${q!.id})`);
+  });
+});
+
+describe("foreign / plain-text clipboard falls through", () => {
+  it("returns null for HTML with no inplan marker (native paste, no comments)", () => {
+    expect(readClipHtml("<p>copied from a browser</p>")).toBeNull();
+  });
+
+  it("returns null for a malformed (non-base64) payload", () => {
+    expect(readClipHtml('<span data-inplan-clip="@@not-base64@@"></span>')).toBeNull();
+  });
+});

--- a/packages/renderer/test/docOps.comments.matrix.test.ts
+++ b/packages/renderer/test/docOps.comments.matrix.test.ts
@@ -1,0 +1,323 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+import {
+  addAnswer,
+  addDocComment,
+  addReply,
+  addSpanComment,
+  setResolved,
+  spanCommentBlocker,
+} from "../src/docOps";
+import {
+  isDocComment,
+  isReply,
+  isSpanComment,
+  parse,
+  serialize,
+  type ParsedDocument,
+  type Question,
+} from "@inplan/core";
+
+const author = "You <you@inplan.ai>";
+
+// --- span comment: where it can / can't anchor --------------------------------
+
+describe("addSpanComment — anchoring matrix", () => {
+  it("anchors a plain verbatim selection and records the comment", () => {
+    const doc: ParsedDocument = { body: "Pick the storage backend now.", comments: [] };
+    const res = addSpanComment(doc, "storage backend", { text: "why?", author });
+    expect(res).not.toBeNull();
+    expect(res!.doc.body).toBe("Pick the [storage backend](#" + res!.id + ") now.");
+    expect(res!.doc.comments).toHaveLength(1);
+    const c = res!.doc.comments[0]!;
+    expect(c.id).toBe(res!.id);
+    expect(c.text).toBe("why?");
+    expect(c.author).toBe(author);
+    expect(c.resolved).toBe(false);
+    expect(c.anchor).toBeUndefined(); // span comment, not doc-level
+    expect(c.parentId).toBeUndefined();
+    expect(isSpanComment(c)).toBe(true);
+  });
+
+  it("returns null when the selection text is not present (not-found)", () => {
+    const doc: ParsedDocument = { body: "nothing here", comments: [] };
+    expect(addSpanComment(doc, "missing phrase", { text: "x", author })).toBeNull();
+  });
+
+  it("anchors across inline markup (preview text lacks the asterisks)", () => {
+    const doc: ParsedDocument = { body: "toggle showing resolved *and* orphaned comments", comments: [] };
+    const res = addSpanComment(doc, "showing resolved and orphaned", { text: "hi", author });
+    expect(res).not.toBeNull();
+    expect(res!.doc.body).toContain("[showing resolved *and* orphaned](#" + res!.id + ")");
+  });
+
+  it("anchors a multi-line span (collapsed whitespace across a newline)", () => {
+    const doc: ParsedDocument = { body: "tasks are stored locally\nin a single file", comments: [] };
+    const res = addSpanComment(doc, "stored locally in a single file", { text: "note", author });
+    expect(res).not.toBeNull();
+    // The anchored label preserves the original newline between "locally" and "in".
+    expect(res!.doc.body).toContain("[stored locally\nin a single file](#" + res!.id + ")");
+    expect(res!.doc.comments).toHaveLength(1);
+  });
+
+  it("a duplicate identical phrase: the SourceSpan picks the clicked occurrence", () => {
+    // "the plan" occurs twice; line 0 and line 2.
+    const body = "the plan is good\n\nrewrite the plan soon";
+    const doc: ParsedDocument = { body, comments: [] };
+    const second = body.lastIndexOf("the plan");
+
+    // No span ⇒ first occurrence is anchored.
+    const first = addSpanComment(doc, "the plan", { text: "first", author })!;
+    expect(first.doc.body.indexOf("[the plan](#")).toBeLessThan(second);
+
+    // With the span of line 2, the SECOND occurrence is anchored.
+    const scoped = addSpanComment(doc, "the plan", { text: "second", author }, { startLine: 2, endLine: 2 })!;
+    expect(scoped.doc.body.indexOf("[the plan](#")).toBeGreaterThan(body.indexOf("good"));
+  });
+});
+
+// --- spanCommentBlocker -------------------------------------------------------
+
+describe("spanCommentBlocker", () => {
+  const plain: ParsedDocument = { body: "Pick the storage backend now.", comments: [] };
+
+  it("returns null for an anchorable selection", () => {
+    expect(spanCommentBlocker(plain.body, "storage backend")).toBeNull();
+  });
+
+  it("returns null for an empty / whitespace-only selection (treated as doc-level)", () => {
+    expect(spanCommentBlocker(plain.body, "")).toBeNull();
+    expect(spanCommentBlocker(plain.body, "   \n\t ")).toBeNull();
+  });
+
+  it("returns 'not-found' when the selection isn't in the body", () => {
+    expect(spanCommentBlocker(plain.body, "nope")).toBe("not-found");
+  });
+
+  it("returns 'overlap' when the selection intersects an existing anchor", () => {
+    // Anchor "storage backend" first, then select a SUBSPAN ("backend") that still maps to
+    // a source range inside the anchor label — wrapping it would nest links, so it's blocked.
+    const res = addSpanComment(plain, "storage backend", { text: "first", author })!;
+    expect(spanCommentBlocker(res.doc.body, "backend")).toBe("overlap");
+    // A non-overlapping selection elsewhere is fine.
+    expect(spanCommentBlocker(res.doc.body, "Pick")).toBeNull();
+  });
+
+  it("addSpanComment over an existing anchor is reported as overlap by the blocker", () => {
+    const res = addSpanComment(plain, "storage backend", { text: "first", author })!;
+    // The blocker is the gate the UI consults before offering a span comment.
+    expect(spanCommentBlocker(res.doc.body, "storage backend")).toBe("overlap");
+  });
+});
+
+// --- doc-level comments -------------------------------------------------------
+
+describe("addDocComment", () => {
+  it("adds a doc-level comment without touching the body", () => {
+    const doc: ParsedDocument = { body: "Some plan body.", comments: [] };
+    const res = addDocComment(doc, { text: "overall thought", author });
+    expect(res.doc.body).toBe("Some plan body."); // body unchanged — no anchor link
+    expect(res.doc.comments).toHaveLength(1);
+    const c = res.doc.comments[0]!;
+    expect(c.anchor).toBe("doc");
+    expect(isDocComment(c)).toBe(true);
+    expect(isSpanComment(c)).toBe(false);
+    expect(c.text).toBe("overall thought");
+    expect(c.resolved).toBe(false);
+  });
+
+  it("carries a question payload on a doc-level comment", () => {
+    const question: Question = { multiSelect: false, choices: [{ label: "A" }, { label: "B", description: "the b option" }] };
+    const res = addDocComment({ body: "x", comments: [] }, { text: "which?", author, question });
+    expect(res.doc.comments[0]!.question).toEqual(question);
+  });
+});
+
+// --- the MEMO flag (agent:false) ----------------------------------------------
+
+describe("memo flag (agent:false)", () => {
+  it("span comment: agent:false is persisted as a memo", () => {
+    const res = addSpanComment({ body: "Pick the storage backend now.", comments: [] }, "storage backend", {
+      text: "note to self",
+      author,
+      agent: false,
+    })!;
+    expect(res.doc.comments[0]!.agent).toBe(false);
+  });
+
+  it("doc comment: agent:false is persisted as a memo", () => {
+    const res = addDocComment({ body: "x", comments: [] }, { text: "memo", author, agent: false });
+    expect(res.doc.comments[0]!.agent).toBe(false);
+  });
+
+  it("agent omitted (talk-to-agent default): the field is NOT written", () => {
+    const span = addSpanComment({ body: "Pick the storage backend now.", comments: [] }, "storage backend", { text: "ask", author })!;
+    expect("agent" in span.doc.comments[0]!).toBe(false);
+    const docc = addDocComment({ body: "x", comments: [] }, { text: "ask", author });
+    expect("agent" in docc.doc.comments[0]!).toBe(false);
+  });
+
+  it("agent:true (explicit) is also not written — only false is materialized", () => {
+    const docc = addDocComment({ body: "x", comments: [] }, { text: "ask", author, agent: true });
+    expect("agent" in docc.doc.comments[0]!).toBe(false);
+  });
+});
+
+// --- reply + answer -----------------------------------------------------------
+
+describe("addReply / addAnswer", () => {
+  it("addReply attaches a child reply (no anchor, no selected) to a thread", () => {
+    const root = addDocComment({ body: "x", comments: [] }, { text: "root", author });
+    const res = addReply(root.doc, root.id, "a reply", "Agent <a@inplan.ai>");
+    expect(res.doc.comments).toHaveLength(2);
+    const reply = res.doc.comments.find((c) => c.id === res.id)!;
+    expect(reply.parentId).toBe(root.id);
+    expect(reply.text).toBe("a reply");
+    expect(reply.author).toBe("Agent <a@inplan.ai>");
+    expect(reply.selected).toBeUndefined();
+    expect(isReply(reply)).toBe(true);
+  });
+
+  it("addAnswer attaches a reply carrying the selected labels", () => {
+    const question: Question = { multiSelect: true, choices: [{ label: "X" }, { label: "Y" }, { label: "Z" }] };
+    const root = addDocComment({ body: "x", comments: [] }, { text: "pick any", author, question });
+    const res = addAnswer(root.doc, root.id, ["X", "Z"], "and an other note", author);
+    const ans = res.doc.comments.find((c) => c.id === res.id)!;
+    expect(ans.parentId).toBe(root.id);
+    expect(ans.selected).toEqual(["X", "Z"]);
+    expect(ans.text).toBe("and an other note");
+    expect(isReply(ans)).toBe(true);
+  });
+
+  it("addAnswer with an empty selection (none chosen) keeps an empty array", () => {
+    const root = addDocComment({ body: "x", comments: [] }, { text: "pick", author });
+    const res = addAnswer(root.doc, root.id, [], "", author);
+    expect(res.doc.comments.find((c) => c.id === res.id)!.selected).toEqual([]);
+  });
+});
+
+// --- resolve / reopen toggling ------------------------------------------------
+
+describe("setResolved — toggling", () => {
+  it("resolves then reopens a comment, leaving others untouched", () => {
+    const a = addDocComment({ body: "x", comments: [] }, { text: "a", author });
+    const b = addDocComment(a.doc, { text: "b", author });
+    const resolved = setResolved(b.doc, a.id, true);
+    expect(resolved.comments.find((c) => c.id === a.id)!.resolved).toBe(true);
+    expect(resolved.comments.find((c) => c.id === b.id)!.resolved).toBe(false); // sibling unchanged
+    const reopened = setResolved(resolved, a.id, false);
+    expect(reopened.comments.find((c) => c.id === a.id)!.resolved).toBe(false);
+  });
+
+  it("toggling a non-existent id is a no-op", () => {
+    const a = addDocComment({ body: "x", comments: [] }, { text: "a", author });
+    const out = setResolved(a.doc, "cmt-zzzzzz", true);
+    expect(out.comments).toEqual(a.doc.comments);
+  });
+});
+
+// --- unique ids ---------------------------------------------------------------
+
+describe("generated ids", () => {
+  it("are well-formed and unique across many adds in one document", () => {
+    let doc: ParsedDocument = { body: "Pick the storage backend now and pick it again later.", comments: [] };
+    const ids = new Set<string>();
+    // doc comments avoid body-anchor collisions, so we can add many freely.
+    for (let i = 0; i < 50; i++) {
+      const res = addDocComment(doc, { text: `c${i}`, author });
+      doc = res.doc;
+      expect(res.id).toMatch(/^cmt-[0-9a-z]{6}$/);
+      expect(ids.has(res.id)).toBe(false); // never collides with an existing id
+      ids.add(res.id);
+    }
+    expect(ids.size).toBe(50);
+    expect(doc.comments.map((c) => c.id)).toEqual([...ids]);
+  });
+
+  it("a reply/answer id differs from its parent and siblings", () => {
+    const root = addDocComment({ body: "x", comments: [] }, { text: "root", author });
+    const r1 = addReply(root.doc, root.id, "r1", author);
+    const r2 = addReply(r1.doc, root.id, "r2", author);
+    expect(new Set([root.id, r1.id, r2.id]).size).toBe(3);
+  });
+});
+
+// --- full round-trip ----------------------------------------------------------
+
+describe("add → serialize → parse round-trip", () => {
+  it("preserves every field including agent, selected, question, and the body anchor", () => {
+    // Build a doc with: a span comment, a doc-level question, an answer, a reply,
+    // a resolved comment, and a memo (agent:false) — exercising the full schema.
+    let doc: ParsedDocument = { body: "Pick the storage backend now.", comments: [] };
+
+    const span = addSpanComment(doc, "storage backend", { text: "anchored?", author })!;
+    doc = span.doc;
+
+    const question: Question = { multiSelect: true, choices: [{ label: "Postgres" }, { label: "SQLite", description: "embedded" }] };
+    const q = addDocComment(doc, { text: "which backend?", author, question });
+    doc = q.doc;
+
+    const ans = addAnswer(doc, q.id, ["Postgres", "SQLite"], "either works", "Agent <a@inplan.ai>");
+    doc = ans.doc;
+
+    const reply = addReply(doc, span.id, "looks right", author);
+    doc = reply.doc;
+
+    const memo = addDocComment(doc, { text: "private note", author, agent: false });
+    doc = memo.doc;
+
+    // Resolve the span comment so the round-trip carries a resolved:true too.
+    doc = setResolved(doc, span.id, true);
+
+    const round = parse(serialize(doc));
+
+    // Body (with the anchor link) survives.
+    expect(round.body).toBe(doc.body);
+    expect(round.body).toContain("[storage backend](#" + span.id + ")");
+
+    // Comment count + ids preserved.
+    expect(round.comments).toHaveLength(5);
+    const byId = new Map(round.comments.map((c) => [c.id, c]));
+
+    const spanC = byId.get(span.id)!;
+    expect(spanC.text).toBe("anchored?");
+    expect(spanC.resolved).toBe(true); // toggled before serialization
+    expect(spanC.anchor).toBeUndefined();
+
+    const qC = byId.get(q.id)!;
+    expect(qC.anchor).toBe("doc");
+    expect(qC.question).toEqual(question); // nested choices + description survive
+
+    const ansC = byId.get(ans.id)!;
+    expect(ansC.parentId).toBe(q.id);
+    expect(ansC.selected).toEqual(["Postgres", "SQLite"]);
+    expect(ansC.text).toBe("either works");
+    expect(ansC.author).toBe("Agent <a@inplan.ai>");
+
+    const replyC = byId.get(reply.id)!;
+    expect(replyC.parentId).toBe(span.id);
+
+    const memoC = byId.get(memo.id)!;
+    expect(memoC.agent).toBe(false); // the memo flag survives the JSON round-trip
+
+    // Full structural equality of the comment set (order-independent).
+    expect([...byId.values()].sort((a, b) => a.id.localeCompare(b.id))).toEqual(
+      [...doc.comments].sort((a, b) => a.id.localeCompare(b.id)),
+    );
+  });
+
+  it("round-trips a unicode span selection and comment text", () => {
+    const doc: ParsedDocument = { body: "Adopt the café ☕ résumé policy.", comments: [] };
+    const res = addSpanComment(doc, "café ☕ résumé", { text: "naïve? 日本語 ok", author })!;
+    const round = parse(serialize(res.doc));
+    expect(round.body).toContain("[café ☕ résumé](#" + res.id + ")");
+    expect(round.comments[0]!.text).toBe("naïve? 日本語 ok");
+  });
+
+  it("stamps and preserves the data-block version on round-trip", () => {
+    const res = addDocComment({ body: "x", comments: [] }, { text: "c", author });
+    const round = parse(serialize(res.doc));
+    expect(round.version).toBe(1);
+  });
+});

--- a/packages/renderer/test/newDoc.matrix.test.ts
+++ b/packages/renderer/test/newDoc.matrix.test.ts
@@ -1,0 +1,283 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Matrix coverage for the Create Doc / Move Text to New Doc actions: title + filename derivation
+// (newDoc.ts), relative-link path resolution that seeds the move's link target (links.ts), and the
+// move/link splice itself (docOps.ts) — verbatim and block-span, comment-thread carry, edge cases,
+// and the new-doc-body seeding that the host appends (serialize/parse round-trip + genId collisions).
+
+import { describe, expect, it } from "vitest";
+import { genId, parse, serialize, type Comment, type ParsedDocument } from "@inplan/core";
+import { moveDocTitle, slugifyFilename } from "../src/newDoc";
+import { resolveDocPath } from "../src/links";
+import { linkSelectionToDoc, moveSelectionToDoc, spanSource } from "../src/docOps";
+
+const c = (over: Partial<Comment> & { id: string }): Comment => ({ author: "a", date: "2026-01-01T00:00:00Z", resolved: false, text: "t", ...over });
+const ids = (cs: Comment[]): string[] => cs.map((x) => x.id);
+
+// --- title derivation -----------------------------------------------------------------------
+
+describe("moveDocTitle (title derivation from the selected text)", () => {
+  it("picks the first sentence when it is shorter than the first five words", () => {
+    expect(moveDocTitle("Do it. Then more words follow here.")).toBe("Do it");
+    expect(moveDocTitle("Wow! more text here too")).toBe("Wow");
+    expect(moveDocTitle("Why not? extra words go here")).toBe("Why not");
+  });
+
+  it("falls back to the first five words when the sentence is longer (or absent)", () => {
+    expect(moveDocTitle("one two three four five six seven")).toBe("one two three four five");
+    expect(moveDocTitle("just four plain words")).toBe("just four plain words"); // < 5 words, no punctuation
+  });
+
+  it("ties to the sentence when sentence length <= five-word length", () => {
+    // sentence "alpha beta gamma delta." vs fiveWords "alpha beta gamma delta. epsilon" → sentence wins.
+    expect(moveDocTitle("alpha beta gamma delta. epsilon")).toBe("alpha beta gamma delta");
+  });
+
+  it("collapses internal/leading/trailing whitespace and trims trailing sentence punctuation", () => {
+    expect(moveDocTitle("  Hello   world  ")).toBe("Hello world");
+    expect(moveDocTitle("Hi.")).toBe("Hi");
+    expect(moveDocTitle("Done!!!")).toBe("Done");
+  });
+
+  it("returns Untitled for blank / punctuation-only input", () => {
+    expect(moveDocTitle("")).toBe("Untitled");
+    expect(moveDocTitle("   ")).toBe("Untitled");
+    expect(moveDocTitle("\t\n ")).toBe("Untitled");
+    expect(moveDocTitle("...")).toBe("Untitled"); // first sentence is "." → trimmed to empty
+  });
+
+  it("keeps unicode letters in the title (no ASCII restriction here)", () => {
+    expect(moveDocTitle("café señor mañana niño rocío más")).toBe("café señor mañana niño rocío");
+  });
+});
+
+// --- filename derivation --------------------------------------------------------------------
+
+describe("slugifyFilename (default Markdown filename)", () => {
+  it("lowercases, turns whitespace runs into a single underscore, and appends .md", () => {
+    expect(slugifyFilename("My Section")).toBe("my_section.md");
+    expect(slugifyFilename("  a   b  ")).toBe("a_b.md");
+    expect(slugifyFilename("Plan 2 v3")).toBe("plan_2_v3.md");
+  });
+
+  it("drops unsafe characters, collapses underscore runs, and trims leading/trailing _ or -", () => {
+    expect(slugifyFilename("Hello, World!!")).toBe("hello_world.md");
+    expect(slugifyFilename("--lead--")).toBe("lead.md");
+    expect(slugifyFilename("a-b-c")).toBe("a-b-c.md"); // hyphens are safe and preserved
+  });
+
+  it("falls back to untitled.md when nothing safe remains (empty / punctuation-only / unicode-only)", () => {
+    expect(slugifyFilename("")).toBe("untitled.md");
+    expect(slugifyFilename("   ")).toBe("untitled.md");
+    expect(slugifyFilename("***")).toBe("untitled.md");
+    expect(slugifyFilename("Café Señor")).toBe("caf_seor.md"); // non-ASCII letters are stripped
+  });
+});
+
+// --- link-target resolution (seeds the move's [title](target)) ------------------------------
+
+describe("resolveDocPath (relative/absolute/nested/'..' link targets)", () => {
+  it("joins a relative href against the base doc's directory", () => {
+    expect(resolveDocPath("docs/PLAN.md", "./design.md")).toBe("docs/design.md");
+    expect(resolveDocPath("a.md", "./b.md")).toBe("b.md"); // base has no directory
+    expect(resolveDocPath("docs/a.md", "././x.md")).toBe("docs/x.md"); // redundant ./ segments
+  });
+
+  it("normalizes '..' to climb directories, and stops at the root", () => {
+    expect(resolveDocPath("docs/PLAN.md", "../README.md")).toBe("README.md");
+    expect(resolveDocPath("docs/sub/deep/a.md", "../../b.md")).toBe("docs/b.md");
+    expect(resolveDocPath("a.md", "../../x.md")).toBe("x.md"); // popping past root is clamped, not negative
+  });
+
+  it("treats a leading '/' as repo-absolute (ignores the base directory)", () => {
+    expect(resolveDocPath("docs/sub/a.md", "/x.md")).toBe("x.md");
+    expect(resolveDocPath("docs/PLAN.md", "/root.md")).toBe("root.md");
+  });
+
+  it("drops the query/anchor, keeping only the target path", () => {
+    expect(resolveDocPath("docs/PLAN.md", "./x.md#sec")).toBe("docs/x.md");
+    expect(resolveDocPath("docs/PLAN.md", "/sub/x.md?q=1#f")).toBe("sub/x.md");
+  });
+});
+
+// --- spanSource (the new doc's body for a verbatim selection) -------------------------------
+
+describe("spanSource (selected Markdown that seeds the new-doc body)", () => {
+  const body = "# Plan\n\nUse Postgres for storage and scale.\n";
+
+  it("returns the exact source of a self-balanced selection", () => {
+    const sel = "Use Postgres for storage and scale.";
+    expect(spanSource(body, sel)).toBe(sel);
+    expect(spanSource("a **bold** b", "**bold**")).toBe("**bold**"); // emphasis fully inside
+  });
+
+  it("returns null for a not-found, empty, or whitespace-only selection", () => {
+    expect(spanSource(body, "nonexistent")).toBeNull();
+    expect(spanSource(body, "")).toBeNull();
+    expect(spanSource(body, "   ")).toBeNull();
+  });
+
+  it("returns null when the selection crosses an inline-emphasis boundary", () => {
+    expect(spanSource("a **bold and** plain", "and** plain")).toBeNull();
+  });
+});
+
+// --- linkSelectionToDoc (Create Doc: keep text, wrap as a link) -----------------------------
+
+describe("linkSelectionToDoc (Create Doc — keeps the text in place as a link)", () => {
+  const body = "# Plan\n\nUse Postgres for storage and scale.\n";
+
+  it("wraps the located selection as [text](target), leaving the rest untouched", () => {
+    expect(linkSelectionToDoc(body, "Postgres", undefined, "./postgres.md")).toBe(
+      "# Plan\n\nUse [Postgres](./postgres.md) for storage and scale.\n",
+    );
+  });
+
+  it("returns null when the selection can't be located or crosses formatting", () => {
+    expect(linkSelectionToDoc(body, "nonexistent", undefined, "./x.md")).toBeNull();
+    expect(linkSelectionToDoc("a **bold and** plain", "and** plain", undefined, "./x.md")).toBeNull();
+  });
+});
+
+// --- moveSelectionToDoc (Move Text to New Doc) ----------------------------------------------
+
+describe("moveSelectionToDoc (Move Text — carries text + threads, leaves a link)", () => {
+  it("verbatim (no span): replaces the inline selection with [title](target); no threads to carry", () => {
+    const body = "# Plan\n\nUse Postgres for storage and scale.\n";
+    const sel = "Use Postgres for storage and scale.";
+    const r = moveSelectionToDoc({ body, comments: [] }, sel, undefined, "Datastore", "./datastore.md")!;
+    expect(r.remaining.body).toBe("# Plan\n\n[Datastore](./datastore.md)\n");
+    expect(r.movedBody).toBe(sel);
+    expect(r.movedComments).toEqual([]);
+  });
+
+  it("block span with no comments inside: moves the block, leaves a link, comments untouched", () => {
+    const doc: ParsedDocument = { body: "# T\n\npara one\n\npara two\n", comments: [] };
+    const r = moveSelectionToDoc(doc, "para one", { startLine: 2, endLine: 3 }, "P1", "./p1.md")!;
+    expect(r.movedBody).toBe("para one");
+    expect(r.movedComments).toEqual([]);
+    expect(r.remaining.body).toBe("# T\n\n[P1](./p1.md)\n\npara two\n"); // link keeps its own block
+  });
+
+  it("carries a span-comment thread (root + reply) with the moved text; doc-level + outside stay", () => {
+    const doc: ParsedDocument = {
+      body: "# Plan\n\n## Section A\n\nUse [Postgres](#cmt-a1) here.\n\n## Section B\n\nKeep this.\n",
+      comments: [
+        c({ id: "cmt-a1", text: "datastore?" }),
+        c({ id: "cmt-r1", parentId: "cmt-a1", text: "Postgres." }),
+        c({ id: "cmt-doc", anchor: "doc", text: "overall" }),
+      ],
+    };
+    const r = moveSelectionToDoc(doc, "ignored-when-span", { startLine: 2, endLine: 4 }, "Section A", "./a.md")!;
+    expect(r.movedBody).toBe("## Section A\n\nUse [Postgres](#cmt-a1) here."); // anchor travels intact
+    expect(ids(r.movedComments)).toEqual(["cmt-a1", "cmt-r1"]);
+    expect(ids(r.remaining.comments)).toEqual(["cmt-doc"]); // doc-level stays
+    expect(r.remaining.body).toBe("# Plan\n\n## [Section A](./a.md)\n\n## Section B\n\nKeep this.\n");
+  });
+
+  it("carries MULTIPLE anchors in the moved span, plus replies of each moved root", () => {
+    const doc: ParsedDocument = {
+      body: "# Plan\n\n## Sec\n\nUse [PG](#cmt-a1) and [Redis](#cmt-b2) here.\n\n## Other\n\nkeep\n",
+      comments: [
+        c({ id: "cmt-a1", text: "pg?" }),
+        c({ id: "cmt-b2", text: "redis?" }),
+        c({ id: "cmt-r", parentId: "cmt-a1", text: "reply to pg" }),
+        c({ id: "cmt-doc", anchor: "doc", text: "overall" }),
+      ],
+    };
+    const r = moveSelectionToDoc(doc, "ignored", { startLine: 2, endLine: 4 }, "Sec", "./sec.md")!;
+    expect(r.movedBody).toBe("## Sec\n\nUse [PG](#cmt-a1) and [Redis](#cmt-b2) here.");
+    expect(ids(r.movedComments)).toEqual(["cmt-a1", "cmt-b2", "cmt-r"]); // both roots + the reply
+    expect(ids(r.remaining.comments)).toEqual(["cmt-doc"]);
+    expect(r.remaining.body).toBe("# Plan\n\n## [Sec](./sec.md)\n\n## Other\n\nkeep\n");
+  });
+
+  it("keeps the placeholder link its own block (span swallows the inter-block blank line)", () => {
+    const doc: ParsedDocument = { body: "# Plan\n\nfirst para\n\nsecond para\n", comments: [] };
+    const r = moveSelectionToDoc(doc, "first para", { startLine: 2, endLine: 3 }, "First", "./first.md")!;
+    expect(r.remaining.body).toBe("# Plan\n\n[First](./first.md)\n\nsecond para\n");
+    expect(r.movedBody).toBe("first para");
+  });
+
+  it("keeps a moved list item a list item (carries its marker onto the link)", () => {
+    const doc: ParsedDocument = { body: "# Plan\n\n- alpha\n- beta\n- gamma\n", comments: [] };
+    const r = moveSelectionToDoc(doc, "beta", { startLine: 3, endLine: 3 }, "Beta", "./beta.md")!;
+    expect(r.remaining.body).toBe("# Plan\n\n- alpha\n- [Beta](./beta.md)\n- gamma\n");
+    expect(r.movedBody).toBe("- beta");
+  });
+
+  it("returns null for an empty / whitespace-only verbatim selection (no usable span)", () => {
+    const doc: ParsedDocument = { body: "# T\n\nhi\n", comments: [] };
+    expect(moveSelectionToDoc(doc, "", undefined, "X", "./x.md")).toBeNull();
+    expect(moveSelectionToDoc(doc, "   ", undefined, "X", "./x.md")).toBeNull();
+  });
+
+  it("returns null when a comment anchor straddles the verbatim selection boundary", () => {
+    const doc: ParsedDocument = { body: "a [foo](#cmt-x) b", comments: [c({ id: "cmt-x" })] };
+    expect(moveSelectionToDoc(doc, "foo](#cmt-x) b", undefined, "T", "./t.md")).toBeNull();
+  });
+
+  it("returns null when the verbatim selection can't be located", () => {
+    expect(moveSelectionToDoc({ body: "# T\n\nhi\n", comments: [] }, "nope", undefined, "T", "./t.md")).toBeNull();
+  });
+});
+
+// --- new-doc body construction + id collisions ----------------------------------------------
+
+describe("new-doc seeding (movedBody + movedComments → serialize/parse round-trip)", () => {
+  it("the moved body and its carried threads serialize, then re-parse with anchors + ids intact", () => {
+    const doc: ParsedDocument = {
+      body: "# Plan\n\n## Sec\n\nUse [PG](#cmt-a1) here.\n",
+      comments: [c({ id: "cmt-a1", text: "pg?" }), c({ id: "cmt-r", parentId: "cmt-a1", text: "reply" })],
+    };
+    const r = moveSelectionToDoc(doc, "ignored", { startLine: 2, endLine: 4 }, "Sec", "./sec.md")!;
+    // The host seeds the new doc as `${movedBody}\n` + the moved comment block (see App.tsx).
+    const seeded = serialize({ body: `${r.movedBody}\n`, comments: r.movedComments });
+    const round = parse(seeded);
+    expect(round.body).toContain("[PG](#cmt-a1)"); // body anchor preserved
+    expect(ids(round.comments)).toEqual(["cmt-a1", "cmt-r"]); // ids carried verbatim (not regenerated)
+    expect(round.comments.find((x) => x.id === "cmt-r")?.parentId).toBe("cmt-a1"); // thread link intact
+  });
+
+  it("move preserves the moved comment ids (it does not regenerate them on extraction)", () => {
+    const doc: ParsedDocument = {
+      body: "# Plan\n\n## Sec\n\nUse [PG](#cmt-a1) here.\n",
+      comments: [c({ id: "cmt-a1" })],
+    };
+    const r = moveSelectionToDoc(doc, "ignored", { startLine: 2, endLine: 4 }, "Sec", "./sec.md")!;
+    expect(ids(r.movedComments)).toEqual(["cmt-a1"]);
+    expect(r.movedBody).toContain("(#cmt-a1)");
+  });
+});
+
+describe("genId (id collisions regenerate a fresh, well-formed comment id)", () => {
+  it("never returns an id already taken in the target doc, and stays cmt-base36 shaped", () => {
+    const taken = new Set(["cmt-a1", "cmt-b2", "cmt-r"]);
+    const id = genId(taken);
+    expect(taken.has(id)).toBe(false);
+    expect(id).toMatch(/^cmt-[0-9a-z]{6}$/);
+  });
+
+  it("regenerates a distinct id on each call so a batch stays collision-free", () => {
+    const taken = new Set<string>();
+    for (let i = 0; i < 50; i++) {
+      const id = genId(taken);
+      expect(taken.has(id)).toBe(false);
+      taken.add(id);
+    }
+    expect(taken.size).toBe(50);
+  });
+
+  it("skips a function-predicate's reserved ids", () => {
+    let firstTry: string | null = null;
+    const id = genId((candidate) => {
+      if (firstTry === null) {
+        firstTry = candidate; // pretend the first proposed id is taken
+        return true;
+      }
+      return false;
+    });
+    expect(id).not.toBe(firstTry);
+    expect(id).toMatch(/^cmt-[0-9a-z]{6}$/);
+  });
+});


### PR DESCRIPTION
Deepens open-core editor coverage with **142 new unit/component tests** across 6 focused files (authored + run-green by a multi-agent pass, each verified against actual source behavior — no src changed). Full suite **792 green**.

| file | tests | area |
|---|---|---|
| `newDoc.matrix` | 32 | move-to-new-doc, resolveDocPath, title/slug, genId |
| `docOps.comments.matrix` | 26 | span/doc/reply/answer, **memo (agent:false)**, anchoring edges, round-trip |
| `clipboard.matrix` | 18 | carry-comment copy/paste, fresh-id re-anchor, partial/multi spans |
| `App.findReplace.matrix` | 13 | match counts, case, scopes, literal regex |
| `App.review.matrix` | 9 | tri-switch cycle, per-hunk toggle, Apply/Reject, pencil edit |
| `grammar.matrix` (core) | 44 | parse/serialize round-trips, version, fenced-block, canonical, integrity, `docForAgent` |

Unit-heavy (the agreed tiering); these run fast + deterministic (no live agent, no DB).

**Follow-ups surfaced by the coverage critic (NOT in this PR):** 3 latent bugs (addSpanComment overlap-guard lives in App not the pure fn; applyProposal demotion only repairs root span comments, not replies; a possibly-dead straddle guard) + high-priority integration gaps (memo end-to-end App wiring, copy-paste cut/paste integration, review span-demotion). Tracked for fix/test PRs.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/13?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded grammar matrix coverage for document parsing/serialization, version stamping, code-block disambiguation, and byte-identical canonical serialization.
  * Added matrix tests for find/replace match count rendering, including scope and case/regex-like input behaviors.
  * Added integration tests for the review decision matrix, including hunk toggles and apply/reject flows.
  * Added clipboard round-trip tests validating anchored comment thread remapping and href rewriting, plus malformed/foreign payload fallbacks.
  * Added document/comment ops and new-doc creation/move-text matrix tests, covering anchoring, thread carry, and round-trip preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->