### PR TITLE
feat(cli): interactive `inplan login` via the browser handoff

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -28,6 +28,7 @@ import {
 import { agentAuthorFor } from "./agentAuthor";
 import { gitProvenance } from "./provenance";
 import { authedSession, clearAuth, currentUser, remoteBackend, saveAuth } from "./cliAuth";
+import { browserLogin } from "./cliLogin";
 import { resolveIdentity, setManualProfile, writeLocalProfile } from "./cliProfile";
 import { checkForUpdate, selfUpdate, UPDATE_PKG } from "./update";
 import { runningEditorPid } from "./editorProcess";
@@ -394,27 +395,43 @@ async function waitCycle(backend: WaitBackend, explicitCursor: number | null, co
 }
 
 /**
- * Store cloud credentials for `--remote` commands. Flags win over env so a shell
- * can pre-seed the deployment (`INPLAN_SUPABASE_URL` / `_ANON_KEY`) and only the
- * per-user `--refresh` token need be passed. (The browser handoff — `inplan login`
- * opens `/cli-auth` and receives the token — is a later slice; this is the seam.)
+ * Sign in to the cloud. Two paths:
+ *  - Interactive (default): `inplan login` opens the web app's /cli-auth page in the browser
+ *    and receives the project url/anon + refresh token back over a one-shot 127.0.0.1 listener
+ *    (see cliLogin.ts). This is what a human runs.
+ *  - Non-interactive: when `--url`/`--anon`/`--refresh` (or the matching env vars) are all
+ *    supplied, store them directly — for scripts and the desktop app, which already hold a
+ *    session. Flags win over env so a shell can pre-seed the deployment and pass only `--refresh`.
+ *    The refresh token can come via `INPLAN_REFRESH_TOKEN` to keep it out of argv (where `ps`
+ *    would expose it).
  */
 async function doLogin(args: string[]): Promise<void> {
   const url = getFlag(args, "url") ?? process.env.INPLAN_SUPABASE_URL;
   const anonKey = getFlag(args, "anon") ?? process.env.INPLAN_SUPABASE_ANON_KEY;
-  // The refresh token is sensitive, so callers (e.g. the desktop app) can pass it via the
-  // environment instead of argv (where `ps` would expose it). Flag still works for manual use.
   const refreshToken = getFlag(args, "refresh") ?? process.env.INPLAN_REFRESH_TOKEN;
-  if (!url || !anonKey || !refreshToken) {
-    process.stderr.write("usage: inplan login --url <url> --anon <anon-key> --refresh <refresh-token> [--email <e>]\n");
-    process.exit(64);
-  }
   const email = getFlag(args, "email");
-  saveAuth({ url, anonKey, refreshToken, ...(email ? { email } : {}) });
-  // Capture the cloud account's identity locally so comments are authored as the
-  // signed-in user (overrides any earlier git/manual profile on explicit login).
-  await persistCloudIdentity();
-  output({ status: "logged_in", url, ...(email ? { email } : {}) });
+
+  if (url && anonKey && refreshToken) {
+    // Non-interactive: all credentials supplied → store them as-is.
+    saveAuth({ url, anonKey, refreshToken, ...(email ? { email } : {}) });
+    // Capture the cloud account's identity locally so comments are authored as the
+    // signed-in user (overrides any earlier git/manual profile on explicit login).
+    await persistCloudIdentity();
+    output({ status: "logged_in", url, ...(email ? { email } : {}) });
+    return;
+  }
+
+  // Interactive browser handoff. No partial-credential mode: anything short of the full
+  // non-interactive set above falls through to the browser, which is the intended UX.
+  try {
+    const auth = await browserLogin({ onUrl: (u) => process.stderr.write(`Opening your browser to sign in:\n  ${u}\nIf it didn't open, paste that URL into your browser.\n`) });
+    saveAuth(auth);
+    await persistCloudIdentity();
+    output({ status: "logged_in", url: auth.url, ...(auth.email ? { email: auth.email } : {}) });
+  } catch (e) {
+    process.stderr.write(`inplan login: ${e instanceof Error ? e.message : String(e)}\n`);
+    process.exit(1);
+  }
 }
 
 /** Best-effort: write the signed-in cloud account's name/email to the local profile. */
@@ -1268,7 +1285,7 @@ async function main(): Promise<void> {
         "       inplan upload  <file> [--org <slug>] [--repo <name>] [--path <p>]   (Collaborate on Cloud)\n" +
         "       inplan promote <file> --cloud-doc <docId> [--locator org/repo/path]\n" +
         "       inplan demote  <file>\n" +
-        "       inplan login --url <url> --anon <anon-key> --refresh <refresh-token> [--email <e>]\n" +
+        "       inplan login   (opens the browser to sign in; or --url <url> --anon <key> --refresh <token> for scripts)\n" +
         "       inplan whoami | logout\n",
     );
     process.exit(64);

--- a/packages/cli/src/cliLogin.ts
+++ b/packages/cli/src/cliLogin.ts
@@ -45,7 +45,11 @@ function openInBrowser(url: string): void {
   const cmd = process.platform === "darwin" ? "open" : process.platform === "win32" ? "cmd" : "xdg-open";
   const args = process.platform === "win32" ? ["/c", "start", "", url] : [url];
   try {
-    spawn(cmd, args, { detached: true, stdio: "ignore" }).unref();
+    const child = spawn(cmd, args, { detached: true, stdio: "ignore" });
+    // A missing opener (headless/CI) surfaces as an async 'error' event, not a sync throw —
+    // swallow it so it can't become an unhandled error and crash before the printed-URL fallback.
+    child.on("error", () => {});
+    child.unref();
   } catch {
     /* opener missing (headless/CI) — the printed URL is the fallback */
   }
@@ -54,7 +58,13 @@ function openInBrowser(url: string): void {
 function isHandoff(v: unknown): v is Handoff {
   if (typeof v !== "object" || v === null) return false;
   const o = v as Record<string, unknown>;
-  return typeof o.state === "string" && typeof o.url === "string" && typeof o.anon === "string" && typeof o.refresh === "string";
+  return (
+    typeof o.state === "string" &&
+    typeof o.url === "string" &&
+    typeof o.anon === "string" &&
+    typeof o.refresh === "string" &&
+    (o.email === undefined || typeof o.email === "string")
+  );
 }
 
 /**

--- a/packages/cli/src/cliLogin.ts
+++ b/packages/cli/src/cliLogin.ts
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Interactive `inplan login`: the browser handoff. The CLI can't safely prompt for a
+// password (and OAuth providers reject headless flows), so login is delegated to the web
+// app's /cli-auth page, exactly as the desktop app does. We spin up a one-shot
+// 127.0.0.1 listener, open the browser at /cli-auth?port=<port>&state=<nonce>, and the page
+// POSTs the project url/anon + the freshly-minted refresh token back over the loopback once a
+// session exists. The token only ever crosses localhost; `state` is echoed back so a stray
+// local request can't inject a session.
+
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import { spawn } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import type { AuthFile } from "./cliAuth";
+
+/** The web app origin that hosts /cli-auth. Overridable for self-hosted / dev. */
+const DEFAULT_WEB_ORIGIN = process.env.INPLAN_WEB_URL || "https://inplan.ai";
+const DEFAULT_TIMEOUT_MS = 3 * 60_000;
+const MAX_BODY_BYTES = 64 * 1024; // a refresh token is small; cap to refuse junk.
+
+export interface BrowserLoginOptions {
+  /** Origin hosting /cli-auth (default https://inplan.ai or $INPLAN_WEB_URL). */
+  webOrigin?: string;
+  /** How long to wait for the browser handoff before giving up. */
+  timeoutMs?: number;
+  /** Launch the system browser at `url`. Overridable in tests. Default: OS opener. */
+  open?: (url: string) => void;
+  /** Notified with the handoff URL so the caller can print a manual fallback. */
+  onUrl?: (url: string) => void;
+}
+
+/** The JSON the /cli-auth page POSTs back over the loopback once signed in. */
+interface Handoff {
+  state: string;
+  url: string;
+  anon: string;
+  refresh: string;
+  email?: string;
+}
+
+/** Best-effort: open `url` in the OS browser. Errors are swallowed — the URL is also
+ *  printed so the user can open it by hand. */
+function openInBrowser(url: string): void {
+  const cmd = process.platform === "darwin" ? "open" : process.platform === "win32" ? "cmd" : "xdg-open";
+  const args = process.platform === "win32" ? ["/c", "start", "", url] : [url];
+  try {
+    spawn(cmd, args, { detached: true, stdio: "ignore" }).unref();
+  } catch {
+    /* opener missing (headless/CI) — the printed URL is the fallback */
+  }
+}
+
+function isHandoff(v: unknown): v is Handoff {
+  if (typeof v !== "object" || v === null) return false;
+  const o = v as Record<string, unknown>;
+  return typeof o.state === "string" && typeof o.url === "string" && typeof o.anon === "string" && typeof o.refresh === "string";
+}
+
+/**
+ * Run the browser login handoff and resolve with the credentials to persist. Rejects on
+ * timeout or if the listener fails. The caller is responsible for `saveAuth` + identity.
+ */
+export function browserLogin(opts: BrowserLoginOptions = {}): Promise<AuthFile> {
+  const webOrigin = (opts.webOrigin ?? DEFAULT_WEB_ORIGIN).replace(/\/$/, "");
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const open = opts.open ?? openInBrowser;
+  const state = randomBytes(16).toString("hex");
+
+  return new Promise<AuthFile>((resolve, reject) => {
+    let settled = false;
+    const finish = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      server.close();
+      fn();
+    };
+
+    // CORS: the page lives on an https origin and fetches this http://127.0.0.1 listener, so a
+    // JSON POST is preflighted. Echo the caller's Origin (the page) and allow the JSON content-type.
+    const cors = (req: IncomingMessage, res: ServerResponse) => {
+      res.setHeader("Access-Control-Allow-Origin", req.headers.origin || webOrigin);
+      res.setHeader("Vary", "Origin");
+      res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+      res.setHeader("Access-Control-Allow-Headers", "content-type");
+    };
+
+    const server = createServer((req, res) => {
+      const url = req.url ?? "";
+      if (req.method === "OPTIONS" && url.startsWith("/cb")) {
+        cors(req, res);
+        res.writeHead(204).end();
+        return;
+      }
+      if (req.method !== "POST" || !url.startsWith("/cb")) {
+        res.writeHead(404).end();
+        return;
+      }
+      cors(req, res);
+      let body = "";
+      let tooBig = false;
+      req.on("data", (chunk: Buffer) => {
+        body += chunk.toString("utf8");
+        if (body.length > MAX_BODY_BYTES) {
+          tooBig = true;
+          req.destroy();
+        }
+      });
+      req.on("end", () => {
+        if (tooBig) {
+          res.writeHead(413).end();
+          return;
+        }
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(body);
+        } catch {
+          res.writeHead(400).end();
+          return;
+        }
+        if (!isHandoff(parsed) || parsed.state !== state) {
+          // Not our handoff (mismatched/missing state) — reject but keep listening; a stray
+          // local request must not end the real flow.
+          res.writeHead(403).end();
+          return;
+        }
+        // Acknowledge so the page can show "you can close this tab", then finish.
+        res.writeHead(200, { "content-type": "text/plain" }).end("inplan: signed in — you can close this tab.");
+        const { url: projUrl, anon, refresh, email } = parsed;
+        finish(() => resolve({ url: projUrl, anonKey: anon, refreshToken: refresh, ...(email ? { email } : {}) }));
+      });
+    });
+
+    server.on("error", (err) => finish(() => reject(err)));
+
+    const timer = setTimeout(() => finish(() => reject(new Error("login timed out — no response from the browser"))), timeoutMs);
+    if (typeof timer.unref === "function") timer.unref();
+
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address() as AddressInfo;
+      const target = `${webOrigin}/cli-auth?port=${port}&state=${state}`;
+      opts.onUrl?.(target);
+      open(target);
+    });
+  });
+}

--- a/packages/cli/test/cliLogin.test.ts
+++ b/packages/cli/test/cliLogin.test.ts
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Covers the interactive browser login handoff: the one-shot loopback listener accepts the
+// /cli-auth page's POST (matching state), rejects a mismatched state, and times out cleanly.
+// The "browser" is simulated by a fetch from the injected `open` callback — no real browser.
+
+import { describe, expect, it } from "vitest";
+import { browserLogin } from "../src/cliLogin";
+
+/** Parse port + state out of the handoff URL the CLI would open. */
+function parse(url: string): { port: string; state: string } {
+  const u = new URL(url);
+  return { port: u.searchParams.get("port")!, state: u.searchParams.get("state")! };
+}
+
+/** POST a JSON body to the loopback /cb the way the web page does. */
+async function postCb(port: string, body: unknown): Promise<number> {
+  const r = await fetch(`http://127.0.0.1:${port}/cb`, {
+    method: "POST",
+    headers: { "content-type": "application/json", origin: "https://inplan.ai" },
+    body: JSON.stringify(body),
+  });
+  return r.status;
+}
+
+describe("browserLogin", () => {
+  it("resolves with the credentials the page hands back over the loopback", async () => {
+    const auth = await browserLogin({
+      timeoutMs: 5000,
+      open: (url) => {
+        const { port, state } = parse(url);
+        void postCb(port, { state, url: "https://proj.supabase.co", anon: "anon-key", refresh: "rt-123", email: "a@b.com" });
+      },
+    });
+    expect(auth).toEqual({ url: "https://proj.supabase.co", anonKey: "anon-key", refreshToken: "rt-123", email: "a@b.com" });
+  });
+
+  it("opens /cli-auth on the configured web origin with a port and a state nonce", async () => {
+    let seen = "";
+    const auth = await browserLogin({
+      timeoutMs: 5000,
+      webOrigin: "https://example.test/",
+      open: (url) => {
+        seen = url;
+        const { port, state } = parse(url);
+        void postCb(port, { state, url: "u", anon: "a", refresh: "r" });
+      },
+    });
+    expect(seen).toMatch(/^https:\/\/example\.test\/cli-auth\?port=\d+&state=[0-9a-f]{32}$/);
+    expect(auth.refreshToken).toBe("r"); // email is optional
+    expect(auth.email).toBeUndefined();
+  });
+
+  it("ignores a mismatched-state POST and keeps waiting for the real one", async () => {
+    const auth = await browserLogin({
+      timeoutMs: 5000,
+      open: (url) => {
+        const { port, state } = parse(url);
+        void (async () => {
+          const bad = await postCb(port, { state: "wrong", url: "u", anon: "a", refresh: "evil" });
+          expect(bad).toBe(403);
+          // The real handoff still completes.
+          await postCb(port, { state, url: "u", anon: "a", refresh: "good" });
+        })();
+      },
+    });
+    expect(auth.refreshToken).toBe("good");
+  });
+
+  it("rejects a malformed (non-JSON) body with 400 and keeps waiting", async () => {
+    const auth = await browserLogin({
+      timeoutMs: 5000,
+      open: (url) => {
+        const { port, state } = parse(url);
+        void (async () => {
+          const r = await fetch(`http://127.0.0.1:${port}/cb`, { method: "POST", headers: { "content-type": "application/json" }, body: "not json" });
+          expect(r.status).toBe(400);
+          await postCb(port, { state, url: "u", anon: "a", refresh: "ok" });
+        })();
+      },
+    });
+    expect(auth.refreshToken).toBe("ok");
+  });
+
+  it("times out when the browser never responds", async () => {
+    await expect(browserLogin({ timeoutMs: 150, open: () => {} })).rejects.toThrow(/timed out/);
+  });
+});

--- a/packages/cli/test/cliLogin.test.ts
+++ b/packages/cli/test/cliLogin.test.ts
@@ -82,6 +82,21 @@ describe("browserLogin", () => {
     expect(auth.refreshToken).toBe("ok");
   });
 
+  it("rejects a non-string email (bad type guard) with 403 and keeps waiting", async () => {
+    const auth = await browserLogin({
+      timeoutMs: 5000,
+      open: (url) => {
+        const { port, state } = parse(url);
+        void (async () => {
+          const bad = await postCb(port, { state, url: "u", anon: "a", refresh: "r", email: {} });
+          expect(bad).toBe(403);
+          await postCb(port, { state, url: "u", anon: "a", refresh: "ok" });
+        })();
+      },
+    });
+    expect(auth.refreshToken).toBe("ok");
+  });
+
   it("times out when the browser never responds", async () => {
     await expect(browserLogin({ timeoutMs: 150, open: () => {} })).rejects.toThrow(/timed out/);
   });


### PR DESCRIPTION
## What

Makes `inplan login` actually usable by a human. Today a bare `inplan login` only prints a usage error demanding raw `--url/--anon/--refresh` tokens that a user has no way to obtain — so the in-product **"Wait for my local agent"** instructions ("Check the CLI… sign in with `inplan login`… then `inplan wait --remote <id>`") dead-end at the sign-in step (found in manual prod QA, "M4-FAIL-1").

This adds the interactive browser handoff — the same flow the desktop app already uses, whose web `/cli-auth` page already exists in inplan-cloud:

1. `inplan login` (no args) spins up a one-shot `127.0.0.1` listener and opens `https://inplan.ai/cli-auth?port=<port>&state=<nonce>` in the browser.
2. The user signs in there (Google / GitHub / email).
3. The page POSTs the project url/anon + a fresh refresh token back over the loopback; the CLI validates `state`, persists via the existing `saveAuth`, and prints `{ "status": "logged_in" }`.

The token only ever crosses localhost; the random `state` nonce is echoed back so a stray local request can't inject a session.

## Backward compatible

The flag/env form is preserved for scripts and the desktop app: when **all** of `--url/--anon/--refresh` (or `INPLAN_SUPABASE_URL` / `INPLAN_SUPABASE_ANON_KEY` / `INPLAN_REFRESH_TOKEN`) are present, it stores them directly without opening a browser. `$INPLAN_WEB_URL` overrides the default `https://inplan.ai` (self-hosted / dev).

## Files

- `packages/cli/src/cliLogin.ts` (new): `browserLogin()` — loopback listener (CORS-preflight aware, 64 KB body cap, state-validated), OS browser opener, resolves with the credentials to persist. `open` is injectable for tests.
- `packages/cli/src/cli.ts`: `doLogin` is interactive by default, non-interactive when fully specified; usage text updated.

## Testing

- New `packages/cli/test/cliLogin.test.ts` (5 tests): handoff happy-path; the opened URL's origin/port/state shape; mismatched-state POST rejected with 403 while the real handoff still completes; malformed body → 400; timeout. **All green.**
- Full suite via the pre-commit gate: **655 passed / 2 skipped**, coverage **96.05% ≥ 95%**.

## Rollout note

Reaches users after the CLI is republished to npm (the normal release step). The web `/cli-auth` half is already live in inplan-cloud. Pairs with the inplan-cloud auth-UX PR.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/15?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive browser-based CLI login via system browser with local callback support
  * Login command now supports both interactive browser flow and non-interactive credential flags

* **Bug Fixes / Behavior**
  * Non-interactive credentials accepted only when all required flags/env are present; interactive flow used otherwise
  * Interactive login failures now report an error and exit with a non-zero status

* **Tests**
  * Added tests covering browser-based authentication and edge cases (timeouts, malformed handoffs)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->