### PR TITLE
release: 0.1.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6593,7 +6593,7 @@
     },
     "packages/cli": {
       "name": "@inplan/cli",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@inplan/backend-supabase": "0.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inplan/cli",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "private": true,
   "description": "inplan CLI: open / wait / signal orchestration over the document core.",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
Version bump for the npm `inplan` release. Cuts a GitHub Release `v0.1.15` once merged (release.yml OIDC-publishes to npm).

Since 0.1.14:
- **feat(cli)**: interactive `inplan login` via the browser handoff (#15)
- **fix(renderer/app)**: layout prefs persist across reload (StrictMode-safe); always auto-save on quit + remove the manual Save prompt; `highestPrecKeymap` so collab undo (Cmd+Z) works (#16)
- **test**: editor unit/component matrix + App-level integration gaps (#13, #14)

`npm version` updated `packages/cli/package.json` + the lockfile. After merge I'll `gh release create v0.1.15 --target main --latest`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/17?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * CLI package version updated to 0.1.15.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->