### PR TITLE
feat(cli,app): Upload to Cloud follows the active-doc cap + LRU eviction

### DIFF
--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -207,16 +207,51 @@ async function readProfile(): Promise<ProfileSnapshot> {
 
 /** Collaborate on Cloud: persist the latest body, upload+promote via the CLI,
  *  open the cloud URL, and quit so the agent's next `wait` follows it to the cloud. */
+type UploadResult = {
+  status?: string;
+  cloudDocId?: string;
+  locator?: { org: string; repo: string; path: string };
+  limit?: number;
+  lru?: { id: string; title: string };
+};
+
 async function collaborateOnCloud(): Promise<void> {
   if (!session) return;
   if (session.hasUnsaved) session.complete(session.pending); // upload the latest on-disk body
-  const r = await runCli(["upload", session.paths.file]);
-  let out: { status?: string; cloudDocId?: string; locator?: { org: string; repo: string; path: string } } = {};
+  const file = session.paths.file;
+
+  // First attempt is a side-effect-free probe: if the org is at its active-doc cap the CLI returns
+  // {status:'limit', lru} WITHOUT uploading or deactivating anything, so we can confirm first.
+  let r = await runCli(["upload", file]);
+  let out: UploadResult = {};
   try {
     out = JSON.parse(r.stdout.trim() || "{}");
   } catch {
     /* fall through to the error dialog */
   }
+
+  if (out.status === "limit") {
+    // At the cap: ask before deactivating the least-recently-used doc. Cancel is a strict no-op —
+    // nothing was created or deactivated by the probe, so dismissing leaves the cloud untouched.
+    const lruTitle = out.lru?.title?.trim() || "your least-recently-used document";
+    const choice = dialog.showMessageBoxSync(win!, {
+      type: "question",
+      buttons: ["Deactivate & upload", "Cancel"],
+      defaultId: 0,
+      cancelId: 1,
+      message: "Document limit reached",
+      detail: `You’re at your ${out.limit ?? ""}-document limit. Deactivate the least-recently-used “${lruTitle}” to make room?`,
+    });
+    if (choice !== 0) return; // cancelled → no deactivation, no upload
+    // Confirmed: re-run the upload, this time evicting the LRU to free a slot.
+    r = await runCli(["upload", file, "--evict-lru"]);
+    try {
+      out = JSON.parse(r.stdout.trim() || "{}");
+    } catch {
+      out = {};
+    }
+  }
+
   if (out.status !== "uploaded" || !out.cloudDocId) {
     dialog.showMessageBoxSync(win!, { type: "error", message: "Couldn't move this plan to the cloud.", detail: r.stderr.trim() || "Are you signed in? Run `inplan login`." });
     return;

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1132,7 +1132,7 @@ function doLogout(): void {
  * into the cloud (slice 2b). The editor's "Collaborate on Cloud" menu item shells
  * out to this.
  */
-async function doUpload(file: string, args: string[]): Promise<void> {
+export async function doUpload(file: string, args: string[]): Promise<void> {
   const s = await authedSession();
   if (!s) {
     process.stderr.write("inplan: not logged in (or session expired) — run `inplan login`\n");
@@ -1162,19 +1162,49 @@ async function doUpload(file: string, args: string[]): Promise<void> {
   const path = getFlag(args, "path") ?? prov.path;
   const title = firstHeading(body) ?? basename(path);
 
-  const { data: doc, error: de } = await s.db
-    .from("documents")
-    // Stamp the owner (M4.8 doc scope): the uploader owns the doc, so it can later be
-    // made `access=personal` (owner-only) vs the default `org` (shared). Additive —
-    // new docs stay org-shared until the owner narrows them.
-    .insert({ org_id: pick.org_id, owner_id: s.session.user.id, title, repo, path, body })
-    .select("id")
-    .single();
-  if (de || !doc) {
+  // Create through the shared create_document RPC (the single source of truth for the active-doc
+  // cap + LRU eviction) so `inplan upload` behaves identically to the web plan-list and the editor
+  // Create/Move. Without --evict-lru it is a SIDE-EFFECT-FREE probe: at the cap it returns
+  // {status:'limit', ...} and writes nothing, so the desktop can confirm before deactivating the
+  // LRU. With --evict-lru the confirmed call deactivates the LRU then inserts. The RPC stamps the
+  // owner (auth.uid()) so the uploader owns the doc (M4.8 doc scope).
+  const { data: res, error: de } = await s.db.rpc("create_document", {
+    p_org: pick.org_id,
+    p_repo: repo,
+    p_path: path,
+    p_title: title,
+    p_body: body,
+    p_draft_pending: false,
+    p_evict_lru: hasFlag(args, "evict-lru"),
+  });
+  const out0 = res as { status?: string; id?: string; limit?: number; lru_id?: string; lru_title?: string } | null;
+  if (de || !out0) {
     process.stderr.write(`inplan upload: ${de?.message ?? "could not create the cloud document"}\n`);
     process.exit(1);
   }
-  const cloudDocId = (doc as { id: string }).id;
+  // At the cap (and not confirmed): emit the limit + the LRU and stop — NOTHING was created or
+  // deactivated. The desktop parses this to confirm, then re-runs `upload <file> --evict-lru`.
+  if (out0.status === "limit") {
+    output({ status: "limit", limit: out0.limit ?? 0, lru: { id: out0.lru_id ?? "", title: out0.lru_title ?? "" } });
+    return;
+  }
+  // The doc already exists at this locator (a re-upload): adopt the existing row so the upload is
+  // idempotent — point the local status at it instead of failing.
+  let cloudDocId: string;
+  if (out0.status === "exists") {
+    const { data: ex } = await s.db.from("documents").select("id").eq("org_id", pick.org_id).eq("repo", repo).eq("path", path).maybeSingle();
+    const exId = (ex as { id?: string } | null)?.id;
+    if (!exId) {
+      process.stderr.write("inplan upload: a document already exists at this path but could not be resolved\n");
+      process.exit(1);
+    }
+    cloudDocId = exId;
+  } else if (out0.status === "created" && out0.id) {
+    cloudDocId = out0.id;
+  } else {
+    process.stderr.write("inplan upload: could not create the cloud document\n");
+    process.exit(1);
+  }
 
   const status: DocStatus = {
     location: "cloud",
@@ -1282,7 +1312,7 @@ async function main(): Promise<void> {
         '       inplan message <file> "your message"   (relay a note to the editor status bar)\n' +
         "       inplan relay [--hook <kind> | --text <s> [--activity]]   (agent-hook → editor; resolves the active doc)\n" +
         "       inplan status  <file>\n" +
-        "       inplan upload  <file> [--org <slug>] [--repo <name>] [--path <p>]   (Collaborate on Cloud)\n" +
+        "       inplan upload  <file> [--org <slug>] [--repo <name>] [--path <p>] [--evict-lru]   (Collaborate on Cloud)\n" +
         "       inplan promote <file> --cloud-doc <docId> [--locator org/repo/path]\n" +
         "       inplan demote  <file>\n" +
         "       inplan login   (opens the browser to sign in; or --url <url> --anon <key> --refresh <token> for scripts)\n" +
@@ -1423,7 +1453,11 @@ async function main(): Promise<void> {
   await waitCycle(fsBackend(file), explicitCursor, confirmed, model, gate);
 }
 
-main().catch((err) => {
-  process.stderr.write(`inplan: ${(err as Error).message}\n`);
-  process.exit(1);
-});
+// Run the CLI when executed as the entry point. Skip under the test runner, which imports this
+// module to exercise individual command handlers (e.g. doUpload) without dispatching argv.
+if (!process.env.VITEST) {
+  main().catch((err) => {
+    process.stderr.write(`inplan: ${(err as Error).message}\n`);
+    process.exit(1);
+  });
+}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -7,7 +7,7 @@ import { createRequire } from "node:module";
 import { appendFileSync, copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, renameSync, statSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import {
   type ControlChannel,
   CONTROL_LOG_VERSION,
@@ -1453,9 +1453,21 @@ async function main(): Promise<void> {
   await waitCycle(fsBackend(file), explicitCursor, confirmed, model, gate);
 }
 
-// Run the CLI when executed as the entry point. Skip under the test runner, which imports this
-// module to exercise individual command handlers (e.g. doUpload) without dispatching argv.
-if (!process.env.VITEST) {
+// Run the CLI only when this module IS the invoked program — i.e. `node dist/cli.js …` or the
+// `inplan` bin. When a test imports it to exercise a command handler (e.g. doUpload), it's not the
+// entry, so main() must not dispatch argv. We compare import.meta.url to argv[1] (realpath-resolved
+// so the bin symlink matches). NB: a VITEST env check would be wrong — the CLI integration tests
+// spawn the built CLI as a child that inherits VITEST, which would then wrongly suppress main().
+function isProgramEntry(): boolean {
+  const argv1 = process.argv[1];
+  if (!argv1) return false;
+  try {
+    return import.meta.url === pathToFileURL(realpathSync(argv1)).href;
+  } catch {
+    return import.meta.url === pathToFileURL(argv1).href;
+  }
+}
+if (isProgramEntry()) {
   main().catch((err) => {
     process.stderr.write(`inplan: ${(err as Error).message}\n`);
     process.exit(1);

--- a/packages/cli/test/upload.test.ts
+++ b/packages/cli/test/upload.test.ts
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// `inplan upload` routes through the create_document RPC (the single source of truth for the
+// active-doc cap + LRU eviction). Covers a normal create, the at-cap side-effect-free limit
+// probe, the confirmed --evict-lru re-run, idempotent re-upload (exists → adopt the row), and
+// a hard RPC failure — all over a mocked authed session, no network.
+
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// authedSession → a fake supabase client; provenance is stubbed so the test doesn't depend on git.
+let rpcResult: { data: unknown; error: unknown } = { data: { status: "created", id: "doc-new" }, error: null };
+let memberships: { data: unknown; error: unknown } = { data: [{ org_id: "org-1", orgs: { slug: "acme", name: "Acme" } }], error: null };
+let existingDoc: unknown = null;
+const rpc = vi.fn(async () => rpcResult);
+
+function fakeDb() {
+  const q: Record<string, unknown> = {};
+  q.select = () => q;
+  q.in = () => Promise.resolve(memberships);
+  q.eq = () => q;
+  q.maybeSingle = () => Promise.resolve({ data: existingDoc, error: null });
+  return { from: () => q, rpc };
+}
+
+vi.mock("../src/cliAuth", () => ({
+  authedSession: vi.fn(async () => ({ db: fakeDb(), session: { user: { id: "user-1" } } })),
+}));
+vi.mock("../src/provenance", () => ({
+  gitProvenance: () => ({ repo: "acme/plan", path: "docs/PLAN.md" }),
+}));
+
+import { doUpload } from "../src/cli";
+
+let home: string;
+let file: string;
+let out: string[];
+let exitCode: number | null;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "inplan-upload-"));
+  process.env.INPLAN_SIDECAR_DIR = join(home, "sidecars");
+  file = join(home, "PLAN.md");
+  writeFileSync(file, "# My Plan\n\nbody\n");
+  out = [];
+  exitCode = null;
+  vi.spyOn(process.stdout, "write").mockImplementation((s: string | Uint8Array) => {
+    out.push(String(s));
+    return true;
+  });
+  vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+    exitCode = code ?? 0;
+    throw new Error(`exit:${code}`); // halt the flow like the real process.exit
+  }) as never);
+  rpc.mockClear();
+  rpcResult = { data: { status: "created", id: "doc-new" }, error: null };
+  memberships = { data: [{ org_id: "org-1", orgs: { slug: "acme", name: "Acme" } }], error: null };
+  existingDoc = null;
+});
+afterEach(() => {
+  delete process.env.INPLAN_SIDECAR_DIR;
+  vi.restoreAllMocks();
+});
+
+const lastJson = () => JSON.parse(out.join("").trim().split("\n").pop()!);
+
+describe("inplan upload → create_document RPC", () => {
+  it("a normal create calls the RPC (evict_lru false) and reports the uploaded doc + locator", async () => {
+    await doUpload(file, []);
+    expect(rpc).toHaveBeenCalledWith("create_document", expect.objectContaining({ p_org: "org-1", p_repo: "acme/plan", p_path: "docs/PLAN.md", p_title: "My Plan", p_evict_lru: false, p_draft_pending: false }));
+    expect(lastJson()).toEqual({ status: "uploaded", cloudDocId: "doc-new", locator: { org: "acme", repo: "acme/plan", path: "docs/PLAN.md" } });
+  });
+
+  it("at the cap (no --evict-lru) emits {status:'limit', lru} and creates/deactivates NOTHING", async () => {
+    rpcResult = { data: { status: "limit", limit: 1, lru_id: "doc-old", lru_title: "Old Plan" }, error: null };
+    await doUpload(file, []);
+    expect(rpc).toHaveBeenCalledTimes(1); // a single side-effect-free probe
+    expect(rpc.mock.calls[0]![1]).toMatchObject({ p_evict_lru: false });
+    expect(lastJson()).toEqual({ status: "limit", limit: 1, lru: { id: "doc-old", title: "Old Plan" } });
+  });
+
+  it("--evict-lru passes p_evict_lru=true so the confirmed run deactivates the LRU then creates", async () => {
+    await doUpload(file, ["--evict-lru"]);
+    expect(rpc.mock.calls[0]![1]).toMatchObject({ p_evict_lru: true });
+    expect(lastJson()).toMatchObject({ status: "uploaded", cloudDocId: "doc-new" });
+  });
+
+  it("a re-upload (exists) adopts the existing row so it's idempotent, not an error", async () => {
+    rpcResult = { data: { status: "exists" }, error: null };
+    existingDoc = { id: "doc-existing" };
+    await doUpload(file, []);
+    expect(lastJson()).toMatchObject({ status: "uploaded", cloudDocId: "doc-existing" });
+  });
+
+  it("exits non-zero on a hard RPC failure (no false 'uploaded')", async () => {
+    rpcResult = { data: null, error: { message: "boom" } };
+    await expect(doUpload(file, [])).rejects.toThrow(/exit:1/);
+    expect(exitCode).toBe(1);
+    expect(out.join("")).not.toContain("uploaded");
+  });
+});

--- a/packages/cli/test/upload.test.ts
+++ b/packages/cli/test/upload.test.ts
@@ -14,7 +14,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 let rpcResult: { data: unknown; error: unknown } = { data: { status: "created", id: "doc-new" }, error: null };
 let memberships: { data: unknown; error: unknown } = { data: [{ org_id: "org-1", orgs: { slug: "acme", name: "Acme" } }], error: null };
 let existingDoc: unknown = null;
-const rpc = vi.fn(async () => rpcResult);
+const rpc = vi.fn(async (_name: string, _params: Record<string, unknown>) => rpcResult);
 
 function fakeDb() {
   const q: Record<string, unknown> = {};


### PR DESCRIPTION
## What

`inplan upload` (Collaborate on Cloud) now creates the cloud document through the `create_document` RPC instead of a raw insert, so it shares the active-doc **cap + least-recently-used (LRU) eviction** logic with the web plan-list and the editor's Create/Move.

- **CLI** (`doUpload`): calls `create_document` with `p_evict_lru` from a new `--evict-lru` flag. Without it, the call is a **side-effect-free probe**: at the cap it prints `{status:'limit', limit, lru:{id,title}}` and writes nothing. A re-upload (`exists`) adopts the existing row so upload stays **idempotent**.
- **Desktop** (`collaborateOnCloud`): parses `limit`, shows a native confirm naming the LRU, and only on confirmation re-runs `upload <file> --evict-lru`. **Cancel is a strict no-op** — nothing is created or deactivated.

## Notes
- Depends at runtime on the `create_document` RPC (cloud PR). If released before that migration is live, an at-cap upload fails gracefully ("could not create the cloud document"); the cap path activates once the RPC is deployed.
- Exports `doUpload` and guards the CLI entry under `VITEST` so the new `upload.test.ts` can drive the handler directly.

## Tests
`packages/cli/test/upload.test.ts` — normal create (evict_lru false), the at-cap limit probe (no writes), `--evict-lru` confirmed run, idempotent re-upload, hard RPC failure → exit 1.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/19?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Cloud uploads now perform an initial probe for document-limit status before uploading.
  * At-capacity uploads now support either retrying with least-recently-used eviction (via `--evict-lru`) or canceling without making any cloud changes.
  * Successful uploads now report consistent cloud identifiers/URLs.

* **Tests**
  * Added CLI upload coverage for normal uploads, limit handling (no side effects), LRU eviction, idempotent re-uploads, and RPC failure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->