### PR TITLE
release: 0.1.16 — Upload to Cloud honors the active-doc cap + LRU eviction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6593,7 +6593,7 @@
     },
     "packages/cli": {
       "name": "@inplan/cli",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@inplan/backend-supabase": "0.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inplan/cli",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": true,
   "description": "inplan CLI: open / wait / signal orchestration over the document core.",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
Version bump for the npm release. Bundles the at-cap deactivate-LRU flow shipped in #18 (editor confirm + read-only hardening) and #19 (`inplan upload --evict-lru` + desktop Collaborate-on-Cloud handshake).

Bumped via `npm version 0.1.16 --workspace @inplan/cli --no-git-tag-version` (updates both `packages/cli/package.json` and the root lockfile entry). The GitHub Release `v0.1.16` will create the tag and trigger `release.yml` (OIDC publish).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/20?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CLI package version updated to 0.1.16.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->