### PR TITLE
test(e2e): shared editor-control suite (desktop + web) — every button/menu

### DIFF
--- a/e2e/editorControls.electron.spec.ts
+++ b/e2e/editorControls.electron.spec.ts
@@ -1,48 +1,26 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //
 // Runs the SHARED editor-control suite (@inplan/renderer/e2e) against the ELECTRON desktop host, plus
-// the desktop-only controls below. One app instance is launched on a seeded plan file and reused; the
-// shared specs are non-destructive / self-cleaning so reuse is safe. The seeded doc embeds a doc-level
-// agent question so the shared QuestionChips spec needs no relaunch. Archived / parked-proposal /
-// active-doc-cap are cloud concepts the desktop doesn't have, so those hooks are omitted (the shared
-// specs skip them). Needs a real GUI — run locally: `npm run build && npm run test:e2e`.
+// the desktop-only controls below. Uses the repo's standard Electron harness (e2e/helpers.ts) to
+// launch the real app on a seeded plan and force-quit past the quit dialog — consistent with the
+// other Electron specs. DEFAULT_DOC already embeds a doc-level agent question, so the shared
+// QuestionChips spec needs no relaunch. Archived / parked-proposal / active-doc-cap are cloud
+// concepts the desktop doesn't have, so those hooks are omitted (the shared specs skip them). Needs a
+// real GUI — run locally: `npm run build && npm run test:e2e`.
 
-import { _electron as electron, expect, test, type ElectronApplication, type Page } from "@playwright/test";
-import { mkdtempSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { expect, test, type Page } from "@playwright/test";
+import { launch, quit, type Ctx } from "./helpers";
 import { registerEditorControlSpecs, type EditorHarness } from "@inplan/renderer/e2e";
 
-const REPO = process.cwd();
-let app: ElectronApplication;
+let ctx: Ctx;
 let win: Page;
 
-const QUESTION = JSON.stringify([
-  { id: "cmt-qst001", anchor: "doc", author: "Agent <agent@inplan>", date: "2026-06-01T00:00:00Z", resolved: false, text: "Pick a fruit?", question: { multiSelect: false, choices: [{ label: "Apple", description: "a" }, { label: "Banana", description: "b" }] } },
-]);
-const SEED_DOC = `# E2E Plan\n\nalpha beta gamma — a paragraph to select and comment on.\n\nSecond paragraph here.\n\n<!--inplan v1\n${QUESTION}\n-->\n`;
-
 test.beforeAll(async () => {
-  const dir = mkdtempSync(join(tmpdir(), "inplan-e2e-"));
-  const doc = join(dir, "design.plan.md");
-  writeFileSync(doc, SEED_DOC);
-  app = await electron.launch({
-    args: [`--user-data-dir=${join(dir, "userdata")}`, join(REPO, "packages/app"), doc],
-    executablePath: join(REPO, "node_modules/.bin/electron"),
-    env: { ...process.env, INPLAN_HOME: join(dir, "home"), INPLAN_SIDECAR_DIR: join(dir, "sidecars") },
-  });
-  win = await app.firstWindow();
-  // First launch shows the onboarding tour over a sample doc; skip it to reach the real document.
-  await expect(win.locator("body")).toContainText("Welcome to inplan", { timeout: 15_000 });
-  const skip = win.getByRole("button", { name: /skip tutorial/i });
-  if (await skip.isVisible().catch(() => false)) await skip.click();
-  await expect(win.locator("body")).toContainText("a paragraph to select", { timeout: 15_000 });
+  ctx = await launch(); // DEFAULT_DOC: heading + paragraphs + list + an anchored question thread
+  win = ctx.win;
 });
-
 test.afterAll(async () => {
-  // The window-close is intercepted by the quit-confirmation flow, so app.close() would hang; force-exit.
-  await app?.evaluate(({ app: a }) => a.exit(0)).catch(() => {});
-  await app?.close().catch(() => {});
+  await quit(ctx?.app);
 });
 
 const harness: EditorHarness = {
@@ -54,10 +32,10 @@ const harness: EditorHarness = {
     telemetry: true,
     agentMode: true,
     replayTutorial: true,
-    agentConnected: false, // no agent attached in the smoke harness → finish-turn disabled
+    agentConnected: false, // no agent attached in the harness → finish-turn disabled
   },
   openEditor: async () => win,
-  openWithQuestion: async () => win, // the seeded doc already carries a doc-level question
+  openWithQuestion: async () => win, // DEFAULT_DOC already carries a doc-level question
   // openArchived / openWithProposal / atActiveDocCap omitted — not desktop concepts.
 };
 

--- a/e2e/editorControls.electron.spec.ts
+++ b/e2e/editorControls.electron.spec.ts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Runs the SHARED editor-control suite (@inplan/renderer/e2e) against the ELECTRON desktop host, plus
+// the desktop-only controls below. One app instance is launched on a seeded plan file and reused; the
+// shared specs are non-destructive / self-cleaning so reuse is safe. The seeded doc embeds a doc-level
+// agent question so the shared QuestionChips spec needs no relaunch. Archived / parked-proposal /
+// active-doc-cap are cloud concepts the desktop doesn't have, so those hooks are omitted (the shared
+// specs skip them). Needs a real GUI — run locally: `npm run build && npm run test:e2e`.
+
+import { _electron as electron, expect, test, type ElectronApplication, type Page } from "@playwright/test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { registerEditorControlSpecs, type EditorHarness } from "@inplan/renderer/e2e";
+
+const REPO = process.cwd();
+let app: ElectronApplication;
+let win: Page;
+
+const QUESTION = JSON.stringify([
+  { id: "cmt-qst001", anchor: "doc", author: "Agent <agent@inplan>", date: "2026-06-01T00:00:00Z", resolved: false, text: "Pick a fruit?", question: { multiSelect: false, choices: [{ label: "Apple", description: "a" }, { label: "Banana", description: "b" }] } },
+]);
+const SEED_DOC = `# E2E Plan\n\nalpha beta gamma — a paragraph to select and comment on.\n\nSecond paragraph here.\n\n<!--inplan v1\n${QUESTION}\n-->\n`;
+
+test.beforeAll(async () => {
+  const dir = mkdtempSync(join(tmpdir(), "inplan-e2e-"));
+  const doc = join(dir, "design.plan.md");
+  writeFileSync(doc, SEED_DOC);
+  app = await electron.launch({
+    args: [`--user-data-dir=${join(dir, "userdata")}`, join(REPO, "packages/app"), doc],
+    executablePath: join(REPO, "node_modules/.bin/electron"),
+    env: { ...process.env, INPLAN_HOME: join(dir, "home"), INPLAN_SIDECAR_DIR: join(dir, "sidecars") },
+  });
+  win = await app.firstWindow();
+  // First launch shows the onboarding tour over a sample doc; skip it to reach the real document.
+  await expect(win.locator("body")).toContainText("Welcome to inplan", { timeout: 15_000 });
+  const skip = win.getByRole("button", { name: /skip tutorial/i });
+  if (await skip.isVisible().catch(() => false)) await skip.click();
+  await expect(win.locator("body")).toContainText("a paragraph to select", { timeout: 15_000 });
+});
+
+test.afterAll(async () => {
+  // The window-close is intercepted by the quit-confirmation flow, so app.close() would hang; force-exit.
+  await app?.evaluate(({ app: a }) => a.exit(0)).catch(() => {});
+  await app?.close().catch(() => {});
+});
+
+const harness: EditorHarness = {
+  host: "electron",
+  caps: {
+    backButton: "none", // desktop leaves via the OS window control (→ quit dialog), not a toolbar Back
+    agentIndicator: false, // local-first desktop has no presence-aware cloud indicator by default
+    draftPrompt: false,
+    telemetry: true,
+    agentMode: true,
+    replayTutorial: true,
+    agentConnected: false, // no agent attached in the smoke harness → finish-turn disabled
+  },
+  openEditor: async () => win,
+  openWithQuestion: async () => win, // the seeded doc already carries a doc-level question
+  // openArchived / openWithProposal / atActiveDocCap omitted — not desktop concepts.
+};
+
+registerEditorControlSpecs(harness, { test, expect });
+
+// ---- Desktop-only controls (not in the shared module) ----------------------------------------
+test.describe("desktop-only controls", () => {
+  test("ProfileMenu exposes the telemetry, keep-planning, and replay-tutorial controls", async () => {
+    await win.locator(".ap-avatar").click();
+    await expect(win.getByText("Share anonymous data")).toBeVisible();
+    await expect(win.getByText("Keep agent in planning")).toBeVisible();
+    await expect(win.getByText("Replay tutorial")).toBeVisible();
+    await win.keyboard.press("Escape");
+  });
+
+  test("telemetry + keep-planning toggles flip and revert (self-clean)", async () => {
+    await win.locator(".ap-avatar").click();
+    const tel = win.getByText("Share anonymous data");
+    await tel.click();
+    await tel.click();
+    const keep = win.getByText("Keep agent in planning");
+    await keep.click();
+    await keep.click();
+    await win.keyboard.press("Escape");
+  });
+  // The window-close → quit-confirmation flow (incl. the build-mode toggle) is covered by quit.spec.ts.
+});

--- a/packages/renderer/e2e/editorControls.shared.ts
+++ b/packages/renderer/e2e/editorControls.shared.ts
@@ -1,0 +1,287 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// The SHARED editor-control e2e suite. Driven through an injected {@link EditorHarness} so the exact
+// same specs run against BOTH hosts that render @inplan/renderer — the Electron desktop app and the
+// inplan.ai web app. Host differences are absorbed by `harness.caps` flags and the optional seeded-
+// state hooks; this file knows nothing about Electron or the cloud. Specs are non-destructive or
+// self-cleaning so a host may reuse a single Page across tests.
+//
+// IMPORTANT: this module is consumed cross-package (the cloud imports it from the symlinked open-core
+// renderer). It must NOT `import { test }` at runtime — that would load a SECOND @playwright/test
+// instance (the open-core copy) and clash with the host runner's copy. So the host passes its own
+// `test`/`expect` in via `pw`, and we import only TYPES here.
+
+import type { Page, test as TestApi, expect as ExpectApi } from "@playwright/test";
+import type { EditorHarness } from "./harness";
+
+/** The host's Playwright runtime, injected so the shared specs register on the host's own instance. */
+export interface PlaywrightApi {
+  test: typeof TestApi;
+  expect: typeof ExpectApi;
+}
+
+const MOD = "ControlOrMeta"; // Playwright maps this to ⌘ on macOS, Ctrl elsewhere — the app accepts either.
+
+export function registerEditorControlSpecs(h: EditorHarness, pw: PlaywrightApi): void {
+  const { test, expect } = pw;
+
+  /** Return the editor to a known baseline between tests: dismiss find/menus/composer/popovers and
+   *  show all three panes (so the comments rail — where thread cards render — is visible). */
+  async function resetUi(page: Page): Promise<void> {
+    await page.keyboard.press("Escape").catch(() => {});
+    await page.keyboard.press("Escape").catch(() => {});
+    const find = page.locator("#ap-find-input");
+    if (await find.isVisible().catch(() => false)) await page.getByRole("button", { name: "close" }).click().catch(() => {});
+    const threePanes = page.getByTitle("3 panes", { exact: true });
+    if (await threePanes.count()) await threePanes.click().catch(() => {});
+  }
+
+  /** Double-click the first word of the first preview PARAGRAPH (not a heading — comments can't anchor
+   *  to a heading) → a content-agnostic, anchorable span selection. */
+  async function selectFirstWord(page: Page): Promise<void> {
+    const para = page.locator(".ap-preview p, .ap-preview li").first();
+    await expect(para).toBeVisible();
+    // Click near the top-left where the first word sits — the element's center can be empty space
+    // past short text, and double-clicking whitespace yields an un-anchorable (disabled) selection.
+    await para.dblclick({ position: { x: 6, y: 8 } });
+  }
+
+  /** Clear any selection so the toolbar reads "Comment on Doc" (doc-level). */
+  async function clearSelection(page: Page): Promise<void> {
+    await page.locator(".ap-preview").click({ position: { x: 2, y: 2 } });
+    await page.evaluate(() => window.getSelection()?.removeAllRanges());
+  }
+
+  test.describe(`editor controls [${h.host}]`, () => {
+    let page: Page;
+    test.beforeEach(async () => {
+      page = await h.openEditor();
+      await resetUi(page);
+    });
+
+    // ---- TopBar: panes -------------------------------------------------------------------------
+    test.describe("TopBar · panes", () => {
+      for (const n of [1, 2, 3] as const) {
+        const label = n === 1 ? "1 pane" : `${n} panes`;
+        test(`switches to ${label} and marks it active`, async () => {
+          const btn = page.getByTitle(label, { exact: true });
+          await btn.click();
+          await expect(btn).toHaveClass(/active/);
+          if (n === 3) await expect(page.locator(".cm-editor")).toBeVisible(); // 3-pane includes the CodeMirror source
+        });
+      }
+    });
+
+    // ---- TopBar: zoom --------------------------------------------------------------------------
+    test("TopBar · zoom in / out / reset adjusts the percentage and reset returns to 100%", async () => {
+      const reset = page.getByRole("button", { name: "Reset zoom" });
+      await page.getByRole("button", { name: "Zoom in" }).click();
+      await expect(reset).not.toHaveText("100%");
+      await page.getByRole("button", { name: "Zoom out" }).click();
+      await reset.click();
+      await expect(reset).toHaveText("100%");
+    });
+
+    // ---- TopBar: find / replace ----------------------------------------------------------------
+    test.describe("Find & replace bar", () => {
+      test("opens from the toolbar button and the keyboard shortcut, and closes", async () => {
+        await page.getByRole("button", { name: "Find & replace" }).click();
+        await expect(page.locator("#ap-find-input")).toBeVisible();
+        await page.getByRole("button", { name: "Close" }).click();
+        await expect(page.locator("#ap-find-input")).toBeHidden();
+        await page.locator("body").press(`${MOD}+f`);
+        await expect(page.locator("#ap-find-input")).toBeVisible();
+      });
+
+      test("finds matches and steps next/prev", async () => {
+        await page.locator("body").press(`${MOD}+f`);
+        const input = page.locator("#ap-find-input");
+        await input.fill("e"); // a vowel present in any English seed body
+        await page.getByRole("button", { name: "Find Next" }).click();
+        await page.getByRole("button", { name: "Find Prev" }).click();
+      });
+
+      test("toggles replace mode (reveals the replace input)", async () => {
+        await page.locator("body").press(`${MOD}+f`);
+        await page.getByRole("checkbox", { name: "Replace" }).check();
+        await expect(page.getByPlaceholder(/replace/i)).toBeVisible();
+      });
+    });
+
+    // ---- TopBar: add comment (doc-level + selection) -------------------------------------------
+    test.describe("Add comment", () => {
+      test("with no selection the toolbar offers 'Comment on Doc' and opens the composer", async () => {
+        await clearSelection(page);
+        const btn = page.getByRole("button", { name: "Comment on Doc" });
+        await expect(btn).toBeEnabled();
+        await btn.click();
+        await expect(page.getByPlaceholder(/Add a comment/i)).toBeVisible();
+        await resetUi(page);
+      });
+
+      test("with a selection the toolbar offers 'Comment on Text' and opens the composer", async () => {
+        await selectFirstWord(page);
+        const btn = page.getByRole("button", { name: "Comment on Text" });
+        await expect(btn).toBeVisible(); // the toolbar relabels once the selection registers
+        await expect(btn).toBeEnabled();
+        await btn.click();
+        await expect(page.getByPlaceholder(/Add a comment/i)).toBeVisible();
+        await resetUi(page);
+      });
+    });
+
+    // ---- Composer + ThreadCard (create → reply → resolve → modify → delete) --------------------
+    test("Comment composer + thread card: create, reply, resolve/reopen, delete (self-clean)", async () => {
+      const probe = `e2e probe ${Date.now()}`;
+      await clearSelection(page);
+      await page.getByRole("button", { name: "Comment on Doc" }).click();
+      await page.getByPlaceholder(/Add a comment/i).fill(probe);
+      await page.getByRole("button", { name: "Comment", exact: true }).click();
+      const card = page.locator("article", { hasText: probe }).first();
+      await expect(card).toBeVisible();
+
+      await card.getByRole("button", { name: "Reply" }).click();
+      await card.getByPlaceholder(/Reply…/).fill("a reply");
+      await card.getByRole("button", { name: "Comment", exact: true }).click();
+      await expect(card.getByText("a reply")).toBeVisible();
+
+      // Resolving moves the thread out of the default rail (resolved threads are hidden) …
+      await card.getByRole("button", { name: "Resolve thread" }).click();
+      await expect(page.locator("article", { hasText: probe })).toBeHidden();
+      // … reveal resolved/orphaned to bring it back; the resolved card exposes Reopen + More.
+      await page.locator(".ap-reveal").click();
+      const revealed = page.locator("article", { hasText: probe }).first();
+      await expect(revealed.getByRole("button", { name: "Reopen thread" })).toBeVisible();
+      // Delete it directly from the revealed view (self-clean). The per-comment menu button renders
+      // as a "⋯" glyph (its accessible name is the glyph, not the title) — match it by title.
+      await revealed.getByTitle("More").first().click();
+      await page.getByRole("button", { name: "Delete" }).click();
+      await expect(page.locator("article", { hasText: probe })).toHaveCount(0);
+      await page.locator(".ap-reveal").click().catch(() => {}); // un-reveal the (now-empty) resolved view
+    });
+
+    test("the composer audience switch offers talk-to-agent vs leave-a-memo", async () => {
+      await clearSelection(page);
+      await page.getByRole("button", { name: "Comment on Doc" }).click();
+      await expect(page.getByRole("radiogroup", { name: "Comment audience" })).toBeVisible();
+      await resetUi(page);
+    });
+
+    // ---- Right-click context menu --------------------------------------------------------------
+    test("Context menu offers the contextual actions", async () => {
+      await selectFirstWord(page);
+      await page.locator(".ap-preview").click({ button: "right" });
+      await expect(page.getByText("Find text").first()).toBeVisible();
+      await expect(page.getByText("Select all").first()).toBeVisible();
+      await resetUi(page);
+    });
+
+    // ---- New-doc modal -------------------------------------------------------------------------
+    test("New-doc modal opens via 'Create Doc', shows Title + File location, and cancels", async () => {
+      await clearSelection(page);
+      await page.locator(".ap-preview").click({ button: "right" });
+      const create = page.getByText("Create Doc", { exact: true });
+      if (!(await create.count())) {
+        test.skip(true, "host does not expose newDoc");
+        return;
+      }
+      await create.click();
+      await expect(page.getByText("Create new document")).toBeVisible();
+      await expect(page.getByLabel("File location")).toBeVisible();
+      if (h.caps.draftPrompt) await expect(page.locator(".ap-newdoc-prompt")).toBeVisible();
+      await page.getByRole("button", { name: "Cancel" }).click();
+      await expect(page.getByText("Create new document")).toBeHidden();
+    });
+
+    // ---- Settings / ProfileMenu (shared toggles) ----------------------------------------------
+    test.describe("ProfileMenu / settings", () => {
+      test("opens the account menu and toggles auto-accept; auto-resolve + language present", async () => {
+        await page.locator(".ap-avatar").click();
+        const autoAccept = page.getByText("Auto-accept agent's changes");
+        await expect(autoAccept).toBeVisible();
+        await autoAccept.click();
+        await autoAccept.click(); // flip back (self-clean)
+        await expect(page.getByText("Auto-resolve comments")).toBeVisible();
+        await expect(page.getByRole("combobox", { name: "Language" })).toBeVisible();
+        await resetUi(page);
+      });
+
+      test("desktop-only toggles appear when the host supports them", async () => {
+        test.skip(!h.caps.telemetry && !h.caps.agentMode && !h.caps.replayTutorial, "no desktop-only toggles on this host");
+        await page.locator(".ap-avatar").click();
+        if (h.caps.telemetry) await expect(page.getByText("Share anonymous data")).toBeVisible();
+        if (h.caps.agentMode) await expect(page.getByText("Keep agent in planning")).toBeVisible();
+        if (h.caps.replayTutorial) await expect(page.getByText("Replay tutorial")).toBeVisible();
+        await resetUi(page);
+      });
+    });
+
+    // ---- Save / finish-turn / back (presence/enabled-state; non-destructive) -------------------
+    test("Save is enabled on an editable doc", async () => {
+      await expect(page.getByRole("button", { name: "Save", exact: true })).toBeEnabled();
+    });
+    test("finish-turn enabled-state follows whether an agent is connected", async () => {
+      const ft = page.getByRole("button", { name: "Finish turn" });
+      if (!(await ft.count())) {
+        test.skip(true, "this mode has no finish-turn control");
+        return;
+      }
+      await (h.caps.agentConnected ? expect(ft).toBeEnabled() : expect(ft).toBeDisabled());
+    });
+    test("the back affordance matches the host", async () => {
+      const back = page.getByRole("button", { name: "Back", exact: true });
+      await (h.caps.backButton === "none" ? expect(back).toHaveCount(0) : expect(back).toBeVisible()); // don't click — it leaves the editor
+    });
+
+    test("StatusBar shows the mode label", async () => {
+      await expect(page.locator(".ap-status-mode")).toBeVisible();
+    });
+
+    // ====== Seeded-state controls (optional hooks; skip when a host can't seed) =================
+    test.describe("Review bar (parked proposal)", () => {
+      test.skip(!h.openWithProposal, "host can't seed a proposal");
+      test("shows the review controls + the accept/reject tri-switch + Apply", async () => {
+        const p = await h.openWithProposal!();
+        // A parked proposal surfaces either the pending banner (click Review) or the open review bar.
+        const reviewBtn = p.getByRole("button", { name: "Review", exact: true });
+        if (await reviewBtn.count()) await reviewBtn.click();
+        // Review-next + Apply are unique to the open review bar ("Agent proposed changes" also appears
+        // in the status bar, so it's ambiguous).
+        await expect(p.getByRole("button", { name: /^Review next/ })).toBeVisible();
+        await expect(p.getByRole("button", { name: "Apply" })).toBeVisible();
+      });
+    });
+
+    test.describe("Read-only (archived doc)", () => {
+      test.skip(!h.openArchived, "host can't seed an archived doc");
+      test("shows the archived banner and disables mutating controls", async () => {
+        const p = await h.openArchived!();
+        await expect(p.getByText(/archived — view and download only/)).toBeVisible();
+        await expect(p.getByRole("button", { name: "Save", exact: true })).toBeDisabled();
+        await expect(p.getByRole("button", { name: /Comment on (Doc|Text)/ })).toBeDisabled();
+      });
+    });
+
+    test.describe("QuestionChips (agent question)", () => {
+      test.skip(!h.openWithQuestion, "host can't seed a question");
+      test("renders the picker and the Answer button", async () => {
+        const p = await h.openWithQuestion!();
+        await expect(p.getByRole("button", { name: "Answer", exact: true })).toBeVisible();
+      });
+    });
+
+    test.describe("CapLimitDialog (at the active-doc cap)", () => {
+      test.skip(!h.atActiveDocCap, "host can't seed the active-doc cap");
+      test("creating a doc at the cap raises the deactivate-LRU prompt; Cancel is a no-op", async () => {
+        const p = await h.atActiveDocCap!();
+        await p.locator(".ap-preview").click({ button: "right" });
+        await p.getByText("Create Doc", { exact: true }).click();
+        await p.getByLabel("File location").fill(`cap-${Date.now()}.md`);
+        await p.getByRole("button", { name: "Create", exact: true }).click();
+        await expect(p.getByText("Document limit reached")).toBeVisible();
+        await p.getByRole("button", { name: "Cancel" }).click();
+        await expect(p.getByText("Document limit reached")).toBeHidden();
+      });
+    });
+  });
+}

--- a/packages/renderer/e2e/harness.ts
+++ b/packages/renderer/e2e/harness.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// The host-agnostic seam for the SHARED editor-control e2e suite. Both hosts that render
+// @inplan/renderer — the Electron desktop app (open-core) and the inplan.ai web app (cloud) —
+// implement this interface, and `registerEditorControlSpecs(harness)` (editorControls.shared.ts)
+// drives the identical editor UI through it. This file MUST stay free of any host specifics
+// (no Electron, no Supabase/web) — every host difference is expressed via `caps` flags or the
+// OPTIONAL seeded-state hooks (a host that can't seed a given state simply omits the hook and the
+// matching specs `test.skip()`).
+
+import type { Page } from "@playwright/test";
+
+/** Host-specific capabilities so the shared specs guard a control instead of branching on host. */
+export interface EditorCaps {
+  /** The TopBar Back/leave affordance: desktop quits the window; web returns to the plan list. */
+  backButton: "quit" | "plans" | "none";
+  /** The presence-aware agent indicator + policy controls (cloud only). */
+  agentIndicator: boolean;
+  /** The NewDocModal "draft from a prompt" field (cloud paid orgs only). */
+  draftPrompt: boolean;
+  /** ProfileMenu desktop-only toggles. */
+  telemetry: boolean;
+  agentMode: boolean;
+  replayTutorial: boolean;
+  /** A connected agent is present, so finish-turn / cadence controls are enabled (vs the no-agent
+   *  desktop default where they're disabled). */
+  agentConnected: boolean;
+}
+
+/**
+ * A host adapter the shared suite drives. `openEditor` returns a Page already on an editable
+ * document with the onboarding tour dismissed; the host owns the Page's lifecycle (the web host
+ * typically keeps one signed-in page and reuses it, the Electron host reuses its single window).
+ * The shared specs are written to be non-destructive or self-cleaning, so a reused Page is safe.
+ */
+export interface EditorHarness {
+  host: "web" | "electron";
+  caps: EditorCaps;
+  /** Open the editor on an editable doc and return its Page (onboarding already skipped). */
+  openEditor(seed?: { body?: string }): Promise<Page>;
+
+  // --- OPTIONAL seeded-state hooks (specs skip when a host omits one) -------------------------
+  /** A doc with a parked agent proposal → the review bar (next/tri-switch/apply) + pending banner. */
+  openWithProposal?(): Promise<Page>;
+  /** An archived (active=false) doc → the read-only banner + disabled mutating controls. */
+  openArchived?(): Promise<Page>;
+  /** A doc carrying an unanswered agent question → the QuestionChips picker. */
+  openWithQuestion?(): Promise<Page>;
+  /** The org at its active-doc cap → creating a doc raises the CapLimitDialog. */
+  atActiveDocCap?(): Promise<Page>;
+}

--- a/packages/renderer/e2e/index.ts
+++ b/packages/renderer/e2e/index.ts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Public entry for the shared editor-control e2e suite. A host (the Electron desktop spec, or the
+// cloud web spec) imports `registerEditorControlSpecs` + the `EditorHarness` type and wires its own
+// adapter. Exposed via the package's "./e2e" subpath; raw .ts (Playwright transpiles on import).
+
+export { type EditorHarness, type EditorCaps } from "./harness";
+export { registerEditorControlSpecs, type PlaywrightApi } from "./editorControls.shared";

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -12,7 +12,8 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
-    "./styles.css": "./src/styles.css"
+    "./styles.css": "./src/styles.css",
+    "./e2e": "./e2e/index.ts"
   },
   "files": [
     "dist",


### PR DESCRIPTION
## What
A host-agnostic Playwright suite covering **every editor button/menu**, authored once in `@inplan/renderer/e2e` and driven through an injected `EditorHarness` so the **same specs run on both hosts** — the Electron desktop app and the inplan.ai web app (both render `@inplan/renderer`, so selectors are identical; web `page` and Electron `win` are both `Page`).

- `packages/renderer/e2e/{harness.ts, editorControls.shared.ts, index.ts}` + a `./e2e` subpath export (raw .ts; Playwright transpiles; not published — `files` stays dist-only). The host passes its own `test`/`expect` so a cross-package consumer (the cloud) doesn't load a second `@playwright/test`.
- `e2e/editorControls.electron.spec.ts`: the Electron harness (reuses the smoke-spec launch; seeds a doc-level question) + desktop-only ProfileMenu toggles.

## Coverage
panes · zoom · find/replace · add-comment (doc + span) · composer + thread (reply/resolve/reveal/reopen/delete) + audience switch · context menu · new-doc modal · profile/settings toggles · save/finish-turn/back · statusbar; seeded-state: review bar, read-only archived, question chips, cap dialog (each skipped where a host can't seed it via the optional hooks).

## Notes
- e2e stays **out of CI** (matches today; the renderer tsconfig only includes `src`, so this doesn't touch the CI typecheck/unit gate). Run locally: `npm run build && npm run test:e2e` (needs a GUI for Electron).
- The cloud half is in inplan-cloud (consumes `@inplan/renderer/e2e`); merge this first so the symlinked renderer carries the module.
- Web half verified locally vs TEST Supabase: shared suite **20 passed / 3 skipped**.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/21?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Introduced a shared Playwright “editor controls” E2E suite with a host capability harness, covering pane switching, zoom, find/replace, comments, composer/thread flows, context menus, and editor affordances.
  * Added a desktop Electron end-to-end spec that runs the shared suite against the desktop app and verifies desktop-only profile/telemetry and keep-planning/replay-tutorial controls.
* **Chores**
  * Exposed the shared E2E harness/suite via new renderer package subpath exports for reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->