### PR TITLE
ci: nightly Electron e2e (Xvfb, change-gated, issue-on-failure)

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -16,7 +16,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
 
 jobs:
   changed:
@@ -43,6 +42,9 @@ jobs:
     needs: changed
     if: needs.changed.outputs.run == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write # only this job opens the failure issue (least privilege)
     # NOTE: no ELECTRON_SKIP_BINARY_DOWNLOAD — unlike `ci`, this job DOES launch Electron, so it
     # needs the real binary downloaded during `npm ci`.
     steps:
@@ -67,7 +69,7 @@ jobs:
 
       - name: Upload Playwright artifacts on failure
         if: failure()
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: playwright-results
           path: test-results

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Nightly Electron end-to-end (Playwright) run. e2e is kept OUT of the per-PR `ci` gate (it
+# launches the real Electron app, which needs a display + the ~100MB Electron binary), so this
+# scheduled job is where it runs: once a day, but ONLY when main changed in the last 24h, plus a
+# manual `workflow_dispatch`. The app runs headless under Xvfb (a virtual framebuffer). On failure
+# it opens (or refreshes) a tracking issue; GitHub also emails watchers by default. No secrets
+# needed — the desktop suite is fully local (seeded plan files, no cloud/Supabase).
+
+name: e2e-nightly
+
+on:
+  schedule:
+    - cron: "30 7 * * *" # 07:30 UTC daily (offset from the cloud nightly)
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  changed:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.gate.outputs.run }}
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - id: gate
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "manual dispatch → run"; echo "run=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          if [ -n "$(git log --since='24 hours ago' --oneline)" ]; then
+            echo "commits in the last 24h → run"; echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "no commits in the last 24h → skip"; echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  e2e:
+    needs: changed
+    if: needs.changed.outputs.run == 'true'
+    runs-on: ubuntu-latest
+    # NOTE: no ELECTRON_SKIP_BINARY_DOWNLOAD — unlike `ci`, this job DOES launch Electron, so it
+    # needs the real binary downloaded during `npm ci`.
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version: "22"
+          cache: npm
+      - run: npm ci
+      - run: npm run build # builds the renderer dist + the CLI (INPLAN_CLI target) + the app
+      # System libraries Electron/Chromium need on a headless runner, plus Xvfb for the display.
+      - name: Install Electron/Chromium system deps + Xvfb
+        run: |
+          npx playwright install-deps chromium
+          sudo apt-get update && sudo apt-get install -y xvfb
+      - name: Run the Electron e2e suite under Xvfb
+        env:
+          INPLAN_CLI: ${{ github.workspace }}/packages/cli/dist/cli.js
+        run: xvfb-run -a npm run test:e2e
+
+      - name: Upload Playwright artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
+        with:
+          name: playwright-results
+          path: test-results
+          retention-days: 7
+
+      - name: Open / refresh the failure issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          existing=$(gh issue list --repo "${{ github.repository }}" --state open --label e2e-nightly --json number --jq '.[0].number' 2>/dev/null || true)
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "${{ github.repository }}" --body "Nightly Electron e2e failed again — $URL ($(date -u +%F))"
+          else
+            gh label create e2e-nightly --repo "${{ github.repository }}" --color B60205 --description "Nightly e2e failures" 2>/dev/null || true
+            gh issue create --repo "${{ github.repository }}" --title "Nightly e2e (Electron) failed" --label e2e-nightly --body "The scheduled Electron e2e run failed: $URL"$'\n\n'"See the uploaded \`playwright-results\` artifact (test-results/) for the failing specs."
+          fi


### PR DESCRIPTION
Adds a scheduled Electron e2e run (`.github/workflows/e2e-nightly.yml`):
- **Daily at 07:30 UTC**, but the heavy job runs **only if main changed in the last 24h** (a gate job checks `git log --since`); `workflow_dispatch` always runs.
- Launches the real Electron app **headless under Xvfb** with the real binary (no `ELECTRON_SKIP_BINARY_DOWNLOAD`), after `npm run build` + `playwright install-deps`.
- On failure: uploads `test-results/` and **opens/refreshes an `e2e-nightly` issue** (GitHub emails watchers too).
- **No secrets** needed — the desktop suite is fully local.
- e2e stays out of the per-PR `ci` gate; this is the scheduled home for it.

Validate after merge with **Actions → e2e-nightly → Run workflow** (or `gh workflow run e2e-nightly.yml`). NOTE: scheduled workflows only fire from `main`, so the cron starts once this lands.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/22?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Implemented an automated nightly Electron end-to-end testing pipeline to improve quality assurance and catch regressions early.
  * Added Playwright-based execution with scheduled runs, and automatic publishing of test results when failures occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->