### PR TITLE
fix(renderer): agent quota pie — 1px core gap + usage-threshold ring colours

### DIFF
--- a/packages/renderer/src/AgentIndicator.tsx
+++ b/packages/renderer/src/AgentIndicator.tsx
@@ -6,8 +6,8 @@ import { useT } from "./i18n";
 
 /** Quota gauge: a solid green core (the "connected" indicator) with only the outer ring
  *  pie-charted for usage — `color` fills `pct` of the ring, the rest is `var(--line)`.
- *  `pct` ∈ [0..1]. The green centre stays green regardless of usage; the ring tints
- *  orange on overage / dark blue for a BYO key (via `color`). */
+ *  `pct` ∈ [0..1]. The green centre stays green regardless of usage; the ring tint comes
+ *  from `color` (light green → amber → red as usage climbs; dark blue for a BYO key). */
 function QuotaPie({ pct, color }: { pct: number; color: string }): JSX.Element {
   const deg = Math.round(Math.max(0, Math.min(1, pct)) * 360);
   return (
@@ -22,7 +22,7 @@ function QuotaPie({ pct, color }: { pct: number; color: string }): JSX.Element {
 /**
  * Menu-bar agent connection indicator (the cloud/quota indicator, moved out of the
  * profile menu). Shows where the agent runs + its model, a quota pie when a managed
- * agent is metered (blue, orange on overage; dark blue for BYO key), a green dot for
+ * agent is metered (light green → amber → red by usage; dark blue for BYO key), a green dot for
  * a local agent and a red dot when none is connected. Clicking opens the connection
  * preference picker. Purely presentational — the host supplies the state.
  */
@@ -88,7 +88,17 @@ export function AgentIndicator({
 
   let icon: JSX.Element;
   if (location === "cloud") {
-    const color = byoKey ? "var(--agent-byo, #1e3a8a)" : quota?.overage ? "#e67e22" : "var(--accent)";
+    // Usage-ring tint: light green < 75%, amber 75–95%, red at/over 95% (or overage). BYO keys are
+    // unmetered → dark blue; no quota (uncapped plan) → the plain green accent.
+    const color = byoKey
+      ? "var(--agent-byo, #1e3a8a)"
+      : quota
+        ? quota.overage || quota.usedPct >= 0.95
+          ? "#c0392b" // red (matches .ap-agent-quota-at)
+          : quota.usedPct >= 0.75
+            ? "#e0a23b" // amber/yellow
+            : "#3fa46a" // light green
+        : "var(--accent)";
     icon = quota ? <QuotaPie pct={quota.usedPct} color={color} /> : <span className="ap-agent-dot" style={{ background: color }} aria-hidden="true" />;
   } else if (location === "local") {
     icon = <span className="ap-agent-dot ap-agent-local" aria-hidden="true" />;

--- a/packages/renderer/src/styles.css
+++ b/packages/renderer/src/styles.css
@@ -136,8 +136,10 @@ body {
 .ap-agent-off { background: var(--danger); } /* no agent connected */
 .ap-agent-pie { position: relative; width: 14px; height: 14px; border-radius: 50%; flex: 0 0 auto; }
 /* Green "connected" core; only the thin outer band of .ap-agent-pie shows the usage conic. The
-   1px box-shadow ring (in the button background) leaves a 1px gap between the core and the usage band. */
+   1px box-shadow ring is the button's background colour, leaving a 1px gap between the core and the
+   usage band — so it must track the button's hover bg (below) to stay invisible in every state. */
 .ap-agent-pie-core { position: absolute; inset: 16%; border-radius: 50%; background: var(--accent); box-shadow: 0 0 0 1px var(--bg); }
+.ap-agent-btn:hover .ap-agent-pie-core { box-shadow: 0 0 0 1px var(--accent-soft); }
 /* Anchor to the trigger's RIGHT edge (it sits on the right of the topbar) so the 220px menu opens
    leftward and stays on-screen — left:0 made it overflow off the right of the viewport, clipping the
    item labels. Mirrors .ap-profile-menu. */

--- a/packages/renderer/src/styles.css
+++ b/packages/renderer/src/styles.css
@@ -135,8 +135,9 @@ body {
 .ap-agent-local { background: #2bb673; }   /* agent on your machine */
 .ap-agent-off { background: var(--danger); } /* no agent connected */
 .ap-agent-pie { position: relative; width: 14px; height: 14px; border-radius: 50%; flex: 0 0 auto; }
-/* Green "connected" core; only the thin outer band of .ap-agent-pie shows the usage conic. */
-.ap-agent-pie-core { position: absolute; inset: 16%; border-radius: 50%; background: var(--accent); }
+/* Green "connected" core; only the thin outer band of .ap-agent-pie shows the usage conic. The
+   1px box-shadow ring (in the button background) leaves a 1px gap between the core and the usage band. */
+.ap-agent-pie-core { position: absolute; inset: 16%; border-radius: 50%; background: var(--accent); box-shadow: 0 0 0 1px var(--bg); }
 /* Anchor to the trigger's RIGHT edge (it sits on the right of the topbar) so the 220px menu opens
    leftward and stays on-screen — left:0 made it overflow off the right of the viewport, clipping the
    item labels. Mirrors .ap-profile-menu. */

--- a/packages/renderer/test/AgentIndicator.test.tsx
+++ b/packages/renderer/test/AgentIndicator.test.tsx
@@ -46,14 +46,26 @@ describe("AgentIndicator", () => {
     expect(screen.queryByRole("radiogroup")).toBeNull();
   });
 
-  it("tints the pie for overage and shows the over-included note", () => {
+  it("tints the pie red for overage and shows the over-included note", () => {
     render(<AgentIndicator location="cloud" model="Opus" quota={{ usedPct: 1.1, overage: true }} />);
     const btn = screen.getByRole("button");
     expect(btn.getAttribute("title")).toContain("(over)");
     const pie = btn.querySelector(".ap-agent-pie") as HTMLElement;
-    expect(pie.style.background).toContain("#e67e22"); // orange on overage
+    expect(pie.style.background).toContain("#c0392b"); // red on overage
     fireEvent.click(btn);
     expect(document.body.textContent).toContain("over included");
+  });
+
+  it("tints the usage ring by threshold: light green <75%, amber 75–95%, red ≥95%", () => {
+    const ring = (usedPct: number): string => {
+      const { unmount } = render(<AgentIndicator location="cloud" model="Opus" quota={{ usedPct, overage: false }} />);
+      const bg = (screen.getByRole("button").querySelector(".ap-agent-pie") as HTMLElement).style.background;
+      unmount();
+      return bg;
+    };
+    expect(ring(0.5)).toContain("#3fa46a"); // light green
+    expect(ring(0.8)).toContain("#e0a23b"); // amber
+    expect(ring(0.97)).toContain("#c0392b"); // red
   });
 
   it("warns when a capped plan approaches the limit (≥80%, under cap)", () => {


### PR DESCRIPTION
Two small tweaks to the managed-agent **quota pie** (`AgentIndicator` / `.ap-agent-pie`), shared by desktop + web:

1. **1px gap** between the green "connected" core and the usage ring — a 1px `box-shadow` ring on `.ap-agent-pie-core` in the button background (`--bg`).
2. **Usage-threshold ring colours** — instead of a flat accent, the ring is now **light green `#3fa46a` (<75%)**, **amber `#e0a23b` (75–95%)**, **red `#c0392b` (≥95% or overage)**. (`#c0392b` matches the existing at-limit warning text.) BYO key (dark blue) and the uncapped-plan green dot are unchanged.

Tests: updated the overage assertion (now red) + added an explicit green/amber/red threshold test. Renderer typecheck + the full suite/coverage gate pass locally.

Ships to inplan.ai on the next renderer rebuild + cloud redeploy.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/24?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Agent quota indicator now uses color-coded usage status based on thresholds: green (low), amber (75–95%), and red (95%+).
  * Clarified quota visualization to explicitly distinguish overage and high-usage states.
* **Style**
  * Improved quota pie core ring separation with a subtle 1px gap and updated hover behavior for clearer emphasis.
* **Documentation**
  * Refreshed `QuotaPie` and quota indicator documentation to match the updated color behavior.
* **Tests**
  * Expanded coverage for the new color/tint thresholds and overage interaction flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->