### PR TITLE
docs(skill): drop dead @cis/inplan install fallback

### DIFF
--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -26,8 +26,6 @@ Check for the CLI and install it if missing:
 
     inplan --version || npm install -g inplan
 
-(If the unscoped name is unavailable, install `@cis/inplan`.)
-
 **If `open` runs headless** (it prints "the bundled editor's Electron runtime is
 unavailable"): the npm package installed but Electron's **binary** didn't download — a
 proxy/firewall/AV blocked it, or `ignore-scripts` is set. Do **not** `npm install -g


### PR DESCRIPTION
## Summary
`SKILL.md` told agents to fall back to `@cis/inplan` if the unscoped name was unavailable — but `inplan` is published on npm (https://www.npmjs.com/package/inplan) and is the canonical install name, while `@cis/inplan` 404s. The fallback pointed at a nonexistent package.

This removes the dead fallback line, leaving a single correct install command:

    inplan --version || npm install -g inplan

Docs-only change; no code paths affected.

Found during a skill-reliability audit ahead of listing inplan in awesome-* directories.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/25?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions by removing redundant fallback guidance, streamlining the setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->