### PR TITLE
release: inplan 0.1.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6593,7 +6593,7 @@
     },
     "packages/cli": {
       "name": "@inplan/cli",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@inplan/backend-supabase": "0.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inplan/cli",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": true,
   "description": "inplan CLI: open / wait / signal orchestration over the document core.",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
Patch release bumping `@inplan/cli` 0.1.16 → 0.1.17 (the only version source; the published `inplan` package and CLI `--version` both read it).

Includes the merged agent quota pie fix (#24): the 1px gap ring now tracks the agent button's hover background instead of showing an off-colour seam, plus the usage-threshold ring colours.

Once merged, I'll publish a `v0.1.17` GitHub Release, which triggers the OIDC trusted-publish workflow.

Diff is version-only (package.json + package-lock.json).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/26?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CLI package version updated to 0.1.17

<!-- end of auto-generated comment: release notes by coderabbit.ai -->