### PR TITLE
fix(cli): auto-recover a blocked Electron binary download via a mirror

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { spawn } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import { createRequire } from "node:module";
 import { appendFileSync, copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, renameSync, statSync, writeFileSync } from "node:fs";
@@ -105,6 +105,36 @@ function electronBinaryFromDisk(reqUrl: string): string | null {
   }
 }
 
+/** The Electron download mirror to retry with when the binary is missing: an explicit
+ *  ELECTRON_MIRROR wins; otherwise default to npmmirror, which serves the binaries when the
+ *  default GitHub host is blocked by a proxy/firewall/AV (the common corp-network case). */
+export function electronMirror(env: Record<string, string | undefined>): string {
+  return env.ELECTRON_MIRROR?.trim() || "https://npmmirror.com/mirrors/electron/";
+}
+
+/** When electron's binary is missing — its postinstall download from GitHub was blocked, so
+ *  `dist/electron(.exe)` + path.txt never got written — re-run electron's OWN installer
+ *  (`install.js`) with ELECTRON_MIRROR set, so it downloads + extracts + writes path.txt exactly
+ *  as a normal install would, just from a reachable host. This automates the manual "set a mirror
+ *  + rebuild" fix. Best-effort: returns true only if the binary is present afterward; any failure
+ *  (mirror also blocked, install error) returns false so the caller falls back to headless.
+ *  Skipped when INPLAN_NO_ELECTRON_DOWNLOAD=1 (air-gapped/CI — the attempt would just be slow). */
+function autoInstallElectron(reqUrl: string): boolean {
+  if (process.env.INPLAN_NO_ELECTRON_DOWNLOAD === "1") return false;
+  try {
+    const pkgDir = dirname(createRequire(reqUrl).resolve("electron/package.json"));
+    const installJs = join(pkgDir, "install.js");
+    if (!existsSync(installJs)) return false;
+    const mirror = electronMirror(process.env);
+    process.stderr.write(`[inplan] editor runtime missing — downloading Electron via ${mirror} …\n`);
+    // The original GitHub download already failed, so go straight to the mirror (don't retry it).
+    execFileSync(process.execPath, [installJs], { cwd: pkgDir, stdio: "inherit", env: { ...process.env, ELECTRON_MIRROR: mirror } });
+    return electronBinaryFromDisk(reqUrl) !== null;
+  } catch {
+    return false;
+  }
+}
+
 function resolveBundledApp(): BundledApp {
   const here = dirname(fileURLToPath(import.meta.url));
   const appMain = join(here, "..", "app", "main", "index.js");
@@ -140,6 +170,17 @@ function spawnApp(file: string): number | null {
     const child = spawn(bundled.electron, [bundled.appMain, file], { detached: true, stdio: "ignore", env });
     child.unref();
     return child.pid ?? null;
+  }
+  // App present but its Electron runtime is missing (the download was blocked). Try electron's own
+  // installer once via a mirror, then re-resolve — turning the manual "set ELECTRON_MIRROR + rebuild"
+  // fix into an automatic one. Any failure falls through to the headless guidance below.
+  if (bundled.appMain !== null && "error" in bundled && autoInstallElectron(import.meta.url)) {
+    const retry = resolveBundledApp();
+    if ("electron" in retry) {
+      const child = spawn(retry.electron, [retry.appMain, file], { detached: true, stdio: "ignore", env });
+      child.unref();
+      return child.pid ?? null;
+    }
   }
   // No editor — surface WHY (not just "no editor"), so the failure is actionable. Also report it
   // (opt-in, anonymous): the app never starts here, so this is the only place the launch failure

--- a/packages/cli/test/electronMirror.test.ts
+++ b/packages/cli/test/electronMirror.test.ts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// The mirror used to auto-recover a missing Electron binary (its GitHub postinstall download was
+// blocked by a proxy/firewall/AV). An explicit ELECTRON_MIRROR wins; otherwise we default to
+// npmmirror so `inplan open` can self-heal instead of falling back to headless.
+
+import { describe, it, expect } from "vitest";
+import { electronMirror } from "../src/cli";
+
+const NPMMIRROR = "https://npmmirror.com/mirrors/electron/";
+
+describe("electronMirror", () => {
+  it("prefers an explicit ELECTRON_MIRROR", () => {
+    expect(electronMirror({ ELECTRON_MIRROR: "https://my.mirror/electron/" })).toBe("https://my.mirror/electron/");
+  });
+  it("trims surrounding whitespace on the env value", () => {
+    expect(electronMirror({ ELECTRON_MIRROR: "  https://m/e/  " })).toBe("https://m/e/");
+  });
+  it("defaults to npmmirror when unset", () => {
+    expect(electronMirror({})).toBe(NPMMIRROR);
+  });
+  it("defaults to npmmirror when blank/whitespace-only", () => {
+    expect(electronMirror({ ELECTRON_MIRROR: "   " })).toBe(NPMMIRROR);
+    expect(electronMirror({ ELECTRON_MIRROR: "" })).toBe(NPMMIRROR);
+  });
+});

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -28,16 +28,22 @@ Check for the CLI and install it if missing:
 
 **If `open` runs headless** (it prints "the bundled editor's Electron runtime is
 unavailable"): the npm package installed but Electron's **binary** didn't download — a
-proxy/firewall/AV blocked it, or `ignore-scripts` is set. Do **not** `npm install -g
-electron` separately (inplan won't use it). Re-download inplan's own copy, using the path
-the message prints:
+proxy/firewall/AV blocked it, or `ignore-scripts` is set. `open` now **auto-recovers** first:
+when the binary is missing it re-runs Electron's own installer via a mirror
+(`ELECTRON_MIRROR`, default `https://npmmirror.com/mirrors/electron/`) and launches the GUI if
+that succeeds. You only see the headless message when the mirror is **also** unreachable. Then:
 
-    npm rebuild electron --prefix "$(npm root -g)/inplan"               # macOS/Linux
-    npm rebuild electron --prefix "%APPDATA%\npm\node_modules\inplan"   # Windows (cmd)
+- Point it at a reachable mirror and retry: `ELECTRON_MIRROR=<url> inplan open …`
+  (`set ELECTRON_MIRROR=<url>` on Windows cmd).
+- Or re-download inplan's own copy (do **not** `npm install -g electron` separately — inplan
+  won't use it), using the path the message prints:
 
-If the download itself is blocked, set a mirror first (`ELECTRON_MIRROR=https://npmmirror.com/mirrors/electron/`,
-`set ELECTRON_MIRROR=…` on Windows), then rebuild. The loop still works headless until then,
-but the human can't review in the GUI — surface the fix to them and proceed.
+      npm rebuild electron --prefix "$(npm root -g)/inplan"               # macOS/Linux
+      npm rebuild electron --prefix "%APPDATA%\npm\node_modules\inplan"   # Windows (cmd)
+
+Set `INPLAN_NO_ELECTRON_DOWNLOAD=1` to skip the auto-download (air-gapped/CI). The loop still
+works headless until a binary is present, but the human can't review in the GUI — surface the
+fix to them and proceed.
 
 ## File convention
 


### PR DESCRIPTION
## Problem
On Windows (and behind corporate proxies/AV), `npm install -g inplan` frequently can't fetch Electron's prebuilt binary from GitHub during electron's postinstall, so `dist/electron(.exe)` + `path.txt` never get written. `inplan open` then silently falls back to **headless** and the GUI never appears — the install looks "done" but the editor can't launch. The documented fix was manual (`set ELECTRON_MIRROR=… && npm rebuild electron`).

## Fix — automate the manual mirror recovery
When the bundled app is present but its Electron runtime is missing, `inplan open` now re-runs **electron's own installer** (`install.js`) once with `ELECTRON_MIRROR` set (explicit value, else the npmmirror default), which downloads + extracts + writes `path.txt` from a reachable host — then re-resolves and launches the GUI. It's the documented manual fix, made automatic.

- **Fail-safe:** any failure (mirror also blocked, install error) falls through to the **existing** headless guidance — behaviour is unchanged when recovery genuinely isn't possible (e.g. fully air-gapped). The original GitHub download already failed, so we go straight to the mirror.
- **Opt-out:** `INPLAN_NO_ELECTRON_DOWNLOAD=1` skips the attempt (air-gapped/CI).
- New `electronMirror(env)` helper (`ELECTRON_MIRROR` → npmmirror default) with unit tests.
- `skill/SKILL.md` updated: `open` now auto-recovers first; the manual steps are the fallback.

## Why this, not Tauri / code-signing
Per our discussion: this specific symptom is a **blocked download** (firewall/AV/proxy), not signature/SmartScreen deletion — so it's fully fixable inside the CLI. Tauri wouldn't address it (an unsigned Tauri exe faces the same trust issues), and signing is a separate track. This is the cheapest fix that directly resolves the reported install failure.

## Validation
- `electronMirror` unit tests (4) green; full open-core suite **829 passing**, coverage ≥95% (pre-commit gate).
- Typecheck clean; cli builds.
- The actual download path (electron's `install.js` + a real blocked network) can't be exercised in CI/here — it's verified by inspection: it reuses electron's own installer with a mirror, and is strictly additive/fail-safe over today's headless fallback. Best validated by a Windows tester reproducing the original blocked-install.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/27?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI now automatically downloads and installs the Electron runtime when missing, with optional mirror configuration via environment variables.
  * Added ability to disable automatic Electron downloads if needed.

* **Documentation**
  * Updated installation guidance with auto-recovery workflow for missing Electron binaries.

* **Tests**
  * Added unit tests for Electron mirror selection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->