### PR TITLE
ci(cla): store CLA signatures on a dedicated branch, not protected main

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -40,7 +40,12 @@ jobs:
         with:
           path-to-signatures: 'signatures/cla.json'
           path-to-document: 'https://github.com/melly-lgtm/inplan/blob/main/CLA.md'
-          branch: 'main'
+          # Store signatures on a DEDICATED, unprotected branch — NOT main. The action commits the
+          # signature file directly (it has no PR flow), but main now has a ruleset requiring PRs, so
+          # writing to main was rejected ("Changes must be made through a pull request") and external
+          # contributors' signatures never recorded → the CLA check stayed red. cla-signatures is
+          # outside that ruleset, so the bot can persist signatures again.
+          branch: 'cla-signatures'
           # The company's own maintainer account is the licensor, not a third-party
           # contributor — it doesn't sign its own CLA. External contributors still must.
           allowlist: 'melly-lgtm,dependabot[bot]'


### PR DESCRIPTION
## Problem (blocks every external contributor — e.g. PR #28)
`main` now has a ruleset requiring all changes via PR. The CLA Assistant action records a signature by **committing `signatures/cla.json` directly** (it has no PR flow), with `branch: 'main'`. That push is rejected:

```
Could not update the JSON file: Repository rule violations found
Changes must be made through a pull request.
```

So an external contributor's signature never persists (`signatures/cla.json` stays `{"signedContributors": []}`) and the `cla` check stays red **even after they comment the sign phrase**. It worked for internal PRs only because `melly-lgtm` is allowlisted/admin.

## Fix
Point the action at a **dedicated, unprotected** `cla-signatures` branch (already created, with an empty `signedContributors` list) instead of `main`. The bot can persist signatures there without hitting the `main` ruleset. The `CLA.md` document still lives on `main`; the internal-maintainer allowlist is unchanged.

## After merge — to unblock PR #28
The contributor already signed correctly; once this is on `main`, commenting **`recheck`** on #28 records the signature on `cla-signatures` and the check goes green. Future external contributors then work normally.

## Notes
- Verified the `main` ruleset is scoped to `~DEFAULT_BRANCH` only, so `cla-signatures` is genuinely unprotected.
- Config-only change to `.github/workflows/cla.yml`; pre-commit suite (825 tests) + coverage gate green.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/29?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CLA signature handling to ensure contributor license agreements are properly recorded and reflected in contributor verification status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->