### PR TITLE
ci(cla): friendly CLA — pending status (not red), flips green on the sign comment

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -26,6 +26,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: CLA Assistant
+        id: cla
+        # continue-on-error: the action calls setFailed when unsigned, which would turn this job's
+        # check RED — looking like a broken build on a brand-new PR. We don't gate on the job; the
+        # next step reports a friendly `CLA` commit status instead (pending, not failure). The job
+        # itself stays green. outcome (success/failure) is still readable below to drive that status.
+        continue-on-error: true
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
         # SHA-pinned (not a mutable tag): this action has contents/PR write + a PAT,
         # and the upstream repo is archived, so a force-pushed tag must not be able
@@ -50,4 +56,36 @@ jobs:
           # contributor — it doesn't sign its own CLA. External contributors still must.
           allowlist: 'melly-lgtm,dependabot[bot]'
           custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
-          custom-notsigned-prcomment: 'Thanks for your PR! Before we can merge it, please sign our [Contributor License Agreement](https://github.com/melly-lgtm/inplan/blob/main/CLA.md) by commenting below:'
+          custom-notsigned-prcomment: |
+            👋 Thanks for the contribution! This isn't a build failure — before we can merge, we just need a **one-time** sign-off on our [Contributor License Agreement](https://github.com/melly-lgtm/inplan/blob/main/CLA.md).
+
+            To sign, reply to this PR with a new comment containing exactly:
+
+            ```
+            I have read the CLA Document and I hereby sign the CLA
+            ```
+
+            The **CLA** check turns green automatically right after you comment — no need to re-push or reopen.
+
+      # Report the result as a friendly `CLA` commit status on the PR's head commit — `pending`
+      # (yellow "action needed", NOT a red failure) when unsigned, `success` (green) when signed.
+      # Set on BOTH pull_request_target AND the sign/recheck comment, always targeting the PR head
+      # SHA, so signing flips it green WITHOUT a reopen (an issue_comment run can't refresh the
+      # job's own check, but it can set a commit status). Uses gh + GITHUB_TOKEN (statuses: write) —
+      # no third-party action to pin. Skipped when the CLA step didn't run (e.g. an unrelated comment).
+      - name: Report CLA status on the PR head
+        if: steps.cla.conclusion != 'skipped'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SIGNED: ${{ steps.cla.outcome }}
+          REPO: ${{ github.repository }}
+          EVENT: ${{ github.event_name }}
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
+          ISSUE_NUM: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" = "pull_request_target" ]; then SHA="$PR_SHA"; else SHA="$(gh api "repos/$REPO/pulls/$ISSUE_NUM" --jq .head.sha)"; fi
+          if [ "$SIGNED" = "success" ]; then STATE=success; DESC="CLA signed — thank you!"; else STATE=pending; DESC="Please sign the CLA — comment to sign (see the bot comment above)."; fi
+          gh api -X POST "repos/$REPO/statuses/$SHA" \
+            -f state="$STATE" -f context="CLA" -f description="$DESC" \
+            -f target_url="https://github.com/melly-lgtm/inplan/blob/main/CLA.md"


### PR DESCRIPTION
Improves the external-contributor CLA UX (the red check + reopen friction seen on #28).

## Problem
The `cla` gate **is the GitHub Actions job** — the action calls `setFailed` when unsigned, so a brand-new PR shows a **red CI failure**, and the `issue_comment` run that records a signature can't refresh that commit-scoped check (a reopen/push was needed to clear it).

## Change
- Run the CLA action with **`continue-on-error`** so the job never goes red.
- Add a step (plain `gh`, no new pinned action; `statuses: write` already granted) that sets a **`CLA` commit status on the PR head**: **`pending`** ("please sign", yellow — *not* a failure) when unsigned, **`success`** (green) when signed. Runs on **both** `pull_request_target` *and* the sign/recheck comment, always targeting the PR head SHA → signing flips it green **with no reopen**.
- Rewrite the not-signed comment: says it's a **one-time sign-off, not a build failure**, and shows the exact phrase to comment in a copy-paste block.

## Hard-blocking (per decision)
After this is merged and verified, I'll add **`CLA`** to the `main` branch ruleset's **required status checks** so a `pending`/missing CLA blocks merge until signed. (Done after, so the status exists before it's required.)

## Verification plan (post-merge — a workflow only runs from `main`)
I'll open a throwaway PR from a non-allowlisted identity and confirm: (a) unsigned → yellow `CLA` + the clear comment, **no red**; (b) the sign comment → `CLA` flips **green with no reopen**. I'll report the observed result before calling it done.

Note: melly-lgtm stays allowlisted; signatures still live on `cla-signatures` (#29).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/30?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CLA workflow to provide clearer, multi-line notification messages instructing contributors on completing agreement signing
  * Improved workflow resilience to gracefully handle pending CLA verification, ensuring status updates continue automatically once agreements are signed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->