### PR TITLE
release: inplan 0.1.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6593,7 +6593,7 @@
     },
     "packages/cli": {
       "name": "@inplan/cli",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@inplan/backend-supabase": "0.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inplan/cli",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "private": true,
   "description": "inplan CLI: open / wait / signal orchestration over the document core.",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
Patch release.

**Ships the Windows install fix (#28):** auto-recover a blocked Electron binary download via a mirror, and fix the ESM main-process crash so the bundled editor launches on Windows. This is the headline reason to cut the release — `npm i -g inplan@0.1.17` still installs without it.

Also includes CI-only CLA workflow changes (#29, #30); no other runtime changes since 0.1.17.

Version bump only: `packages/cli/package.json` + `package-lock.json`.

After merge: `gh release create v0.1.18` → `release.yml` publishes `inplan` to npm via OIDC.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/31?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bump to 0.1.18

<!-- end of auto-generated comment: release notes by coderabbit.ai -->