### PR TITLE
docs(readme): add demo (GIF + narrated video)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ process that remains adaptable without sacrificing correctness.
 > edition lives at **[inplan.ai](https://inplan.ai)**; this repository is the open
 > core you can run yourself.
 
+## Demo
+
+[![inplan — plan with your coding agent](https://github.com/melly-lgtm/inplan/releases/download/v0.1.18/inplan-demo.gif)](https://github.com/melly-lgtm/inplan/releases/download/v0.1.18/inplan-demo.mp4)
+
+Comment on a specific sentence and discuss it with the agent in a thread; when it
+revises the plan, review the diff and apply it like a PR.
+▶ **[Watch with narration](https://github.com/melly-lgtm/inplan/releases/download/v0.1.18/inplan-demo.mp4)**
+
 ## How it works
 
 You and the agent edit one Markdown plan, like two people in a shared document:


### PR DESCRIPTION
Adds a Demo section to the README: the animated GIF (inline) linking to the narrated HD MP4. Both are hosted as v0.1.18 release assets (no repo bloat).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/32?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new **Demo** section to the README with a visual demo link and brief usage steps.
  * Included guidance for commenting on a sentence, discussing it with the agent, reviewing changes, and applying them like a pull request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->