### PR TITLE
ci: enforce the authorship gate locally via a commit-msg hook

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Local mirror of the CI authorship gate (.github/workflows/authorship.yml). Rejects a commit
+# whose author/committer is a known AI/bot identity, or whose message carries an AI-authorship
+# marker (a "Generated with …" line, the 🤖 trailer, or `Co-authored-by: <bot>`) — catching at
+# commit time what the PR check would otherwise only catch later. Runs as `commit-msg` (not
+# `pre-commit`) because the commit MESSAGE — where the markers live — only exists at this stage.
+# Shares the rule set with CI via authorship_lib.sh, so the two can never drift.
+#
+# Enabled via core.hooksPath (set by the root `prepare` script on `npm install`).
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+# shellcheck source=.github/scripts/authorship_lib.sh
+. "$root/.github/scripts/authorship_lib.sh"
+
+# The pending commit's identities (strip the trailing "<unix-ts> <tz>" git appends to the ident).
+author=$(git var GIT_AUTHOR_IDENT | sed -E 's/ [0-9]+ [-+][0-9]+$//')
+committer=$(git var GIT_COMMITTER_IDENT | sed -E 's/ [0-9]+ [-+][0-9]+$//')
+body=$(cat "$1")
+
+fail=0
+if printf '%s\n%s\n' "$author" "$committer" | grep -qiE "$AUTHORSHIP_BOT_RE"; then
+  echo "[commit-msg] ✗ AI/bot author or committer — author: ${author}, committer: ${committer}"
+  fail=1
+fi
+if printf '%s\n' "$body" | grep -qiE "$AUTHORSHIP_MARK_RE"; then
+  echo "[commit-msg] ✗ AI-authorship marker in the message (Co-authored-by / 'Generated with' / 🤖)"
+  fail=1
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "[commit-msg] commits must be human-authored under your own identity, with no AI/bot author, committer, or co-author marker (see CONTRIBUTING.md)."
+  exit 1
+fi

--- a/.github/scripts/authorship_lib.sh
+++ b/.github/scripts/authorship_lib.sh
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Shared authorship-rule definitions, sourced by BOTH the CI range check
+# (.github/scripts/check_authorship.sh) and the local commit-msg hook
+# (.githooks/commit-msg) so the rule set is defined exactly once and can never drift
+# between "caught at commit time" and "caught at PR time". Adding a tool here covers both.
+#
+# AI/bot identity clues, matched case-insensitively against author/committer
+# "name <email>". `[bot]` catches GitHub App bot accounts (cursor[bot], etc.).
+AUTHORSHIP_BOT_RE='\[bot\]|cursoragent|bugbot|devin|copilot|claude|anthropic|chatgpt|openai|gpt-[0-9]|codeium|tabnine|amazon[- ]?q|gemini-'
+
+# Machine-authorship markers in the commit body. BOTH the "generated with …" and the
+# Co-authored-by branches reuse BOT_RE so they screen against the same identity set as the
+# author/committer (no drift). The Co-authored-by branch is anchored to line start (^) so it
+# matches a real git trailer, not prose mentioning "Co-authored-by:". `codex`/`gpt` are
+# marker-only extras: too generic to match a human's name/email, but unambiguous after the
+# literal "generated with ".
+AUTHORSHIP_MARK_RE="generated with .*(${AUTHORSHIP_BOT_RE}|codex|gpt)|🤖 generated|^ *co-authored-by:.*(${AUTHORSHIP_BOT_RE})"

--- a/.github/scripts/check_authorship.sh
+++ b/.github/scripts/check_authorship.sh
@@ -15,17 +15,13 @@ set -euo pipefail
 BASE="${1:?usage: check_authorship.sh <base-sha> <head-sha>}"
 HEAD="${2:?usage: check_authorship.sh <base-sha> <head-sha>}"
 
-# AI/bot identity clues, matched case-insensitively against author/committer
-# "name <email>". `[bot]` catches GitHub App bot accounts (cursor[bot], etc.).
-BOT_RE='\[bot\]|cursoragent|bugbot|devin|copilot|claude|anthropic|chatgpt|openai|gpt-[0-9]|codeium|tabnine|amazon[- ]?q|gemini-'
-# Machine-authorship markers in the commit body. BOTH the "generated with …" and
-# the Co-authored-by branches reuse BOT_RE so they screen against the same identity
-# set as the author/committer (no drift — adding a tool to BOT_RE covers all three).
-# The Co-authored-by branch is anchored to line start (^) so it matches a real git
-# trailer, not prose that merely mentions "Co-authored-by:" (e.g. this script's own
-# commit messages). `codex`/`gpt` are marker-only extras: too generic to match a
-# human's name/email, but unambiguous after the literal "generated with ".
-MARK_RE="generated with .*(${BOT_RE}|codex|gpt)|🤖 generated|^ *co-authored-by:.*(${BOT_RE})"
+# Identity clues (BOT_RE) + body markers (MARK_RE) are defined in a shared lib so the local
+# commit-msg hook (.githooks/commit-msg) enforces the EXACT same rule set as this PR check —
+# adding a tool in one place covers both.
+# shellcheck source=.github/scripts/authorship_lib.sh
+. "$(dirname "$0")/authorship_lib.sh"
+BOT_RE="$AUTHORSHIP_BOT_RE"
+MARK_RE="$AUTHORSHIP_MARK_RE"
 
 fail=0
 # Fail closed: if rev-list errors (bad/missing refs, shallow clone), don't let the


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/35?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added commit-time checks that block commits with AI/bot authorship indicators in the author, committer, or commit message.
  * Standardized authorship detection rules so the same checks are used consistently across validation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->