### PR TITLE
fix(app): unblock the nightly Electron e2e (main → out/main/index.cjs) + fix e2e drift

### DIFF
--- a/e2e/editorControls.electron.spec.ts
+++ b/e2e/editorControls.electron.spec.ts
@@ -44,7 +44,7 @@ registerEditorControlSpecs(harness, { test, expect });
 // ---- Desktop-only controls (not in the shared module) ----------------------------------------
 test.describe("desktop-only controls", () => {
   test("ProfileMenu exposes the telemetry, keep-planning, and replay-tutorial controls", async () => {
-    await win.locator(".ap-avatar").click();
+    await win.locator("button.ap-avatar").click();
     await expect(win.getByText("Share anonymous data")).toBeVisible();
     await expect(win.getByText("Keep agent in planning")).toBeVisible();
     await expect(win.getByText("Replay tutorial")).toBeVisible();
@@ -52,7 +52,7 @@ test.describe("desktop-only controls", () => {
   });
 
   test("telemetry + keep-planning toggles flip and revert (self-clean)", async () => {
-    await win.locator(".ap-avatar").click();
+    await win.locator("button.ap-avatar").click();
     const tel = win.getByText("Share anonymous data");
     await tel.click();
     await tel.click();

--- a/e2e/quit.spec.ts
+++ b/e2e/quit.spec.ts
@@ -39,19 +39,19 @@ test("closing with no unsaved changes raises the dialog WITHOUT a Save box; plai
   await requestClose();
   await expect(win.locator(".ap-quit")).toBeVisible({ timeout: 5_000 });
   // No edits → no Save checkbox; only the build-mode toggle is offered.
-  await expect(win.getByText(/^Save /)).toHaveCount(0);
+  await expect(win.locator(".ap-quit").getByText(/^Save /)).toHaveCount(0);
   await win.getByRole("button", { name: /^quit$/i }).click();
   const ev = await waitForEvent(ctx, "session_closed");
   expect((ev.payload as { reason?: string }).reason).toBe("window_closed");
 });
 
-test("closing with unsaved changes offers a Save box; 'build mode' closes as completed", async () => {
+test("closing with unsaved changes still shows no Save box (auto-save); 'build mode' closes as completed", async () => {
   await makeDirty();
   await requestClose();
   await expect(win.locator(".ap-quit")).toBeVisible({ timeout: 5_000 });
-  // The Save box appears (dirty) and is checked by default.
-  const saveBox = win.locator(".ap-quit-opt", { hasText: /^Save / }).locator("input[type=checkbox]");
-  await expect(saveBox).toBeChecked();
+  // Quit always auto-saves the latest content now (the manual Save checkbox was removed), so even a
+  // dirty doc offers no Save box — only the build-mode toggle.
+  await expect(win.locator(".ap-quit").getByText(/^Save /)).toHaveCount(0);
   // Tick "Switch agent to build mode" → the session closes as the completed hand-off.
   await win.getByText(/switch agent to build mode/i).click();
   await win.getByRole("button", { name: /^quit$/i }).click();

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -5,7 +5,7 @@
   "description": "inplan Electron editor for human/agent collaboration on planning documents.",
   "license": "AGPL-3.0-or-later",
   "type": "module",
-  "main": "./out/main/index.js",
+  "main": "./out/main/index.cjs",
   "scripts": {
     "dev": "electron-vite dev",
     "build": "electron-vite build",

--- a/packages/renderer/e2e/editorControls.shared.ts
+++ b/packages/renderer/e2e/editorControls.shared.ts
@@ -196,19 +196,23 @@ export function registerEditorControlSpecs(h: EditorHarness, pw: PlaywrightApi):
     // ---- Settings / ProfileMenu (shared toggles) ----------------------------------------------
     test.describe("ProfileMenu / settings", () => {
       test("opens the account menu and toggles auto-accept; auto-resolve + language present", async () => {
-        await page.locator(".ap-avatar").click();
+        await page.locator("button.ap-avatar").click();
         const autoAccept = page.getByText("Auto-accept agent's changes");
         await expect(autoAccept).toBeVisible();
         await autoAccept.click();
         await autoAccept.click(); // flip back (self-clean)
         await expect(page.getByText("Auto-resolve comments")).toBeVisible();
-        await expect(page.getByRole("combobox", { name: "Language" })).toBeVisible();
+        // The language picker only renders when more than one locale is bundled
+        // (ProfileMenu gates it on i18n.available.length > 1). Single-locale builds
+        // (e.g. en-only) legitimately omit it, so assert presence only when it shows.
+        const lang = page.getByRole("combobox", { name: "Language" });
+        if (await lang.count()) await expect(lang).toBeVisible();
         await resetUi(page);
       });
 
       test("desktop-only toggles appear when the host supports them", async () => {
         test.skip(!h.caps.telemetry && !h.caps.agentMode && !h.caps.replayTutorial, "no desktop-only toggles on this host");
-        await page.locator(".ap-avatar").click();
+        await page.locator("button.ap-avatar").click();
         if (h.caps.telemetry) await expect(page.getByText("Share anonymous data")).toBeVisible();
         if (h.caps.agentMode) await expect(page.getByText("Keep agent in planning")).toBeVisible();
         if (h.caps.replayTutorial) await expect(page.getByText("Replay tutorial")).toBeVisible();
@@ -226,7 +230,10 @@ export function registerEditorControlSpecs(h: EditorHarness, pw: PlaywrightApi):
         test.skip(true, "this mode has no finish-turn control");
         return;
       }
-      await (h.caps.agentConnected ? expect(ft).toBeEnabled() : expect(ft).toBeDisabled());
+      // Only presence-aware hosts (web/cloud) gate finish-turn on a connected agent. The desktop's
+      // local agent is implicit (not presence-aware), so finish-turn stays enabled there regardless.
+      const expectEnabled = h.caps.agentIndicator ? h.caps.agentConnected : true;
+      await (expectEnabled ? expect(ft).toBeEnabled() : expect(ft).toBeDisabled());
     });
     test("the back affordance matches the host", async () => {
       const back = page.getByRole("button", { name: "Back", exact: true });

--- a/packages/renderer/e2e/harness.ts
+++ b/packages/renderer/e2e/harness.ts
@@ -22,8 +22,9 @@ export interface EditorCaps {
   telemetry: boolean;
   agentMode: boolean;
   replayTutorial: boolean;
-  /** A connected agent is present, so finish-turn / cadence controls are enabled (vs the no-agent
-   *  desktop default where they're disabled). */
+  /** A connected agent is present. On presence-aware hosts (web/cloud, `agentIndicator: true`) this
+   *  gates whether finish-turn / cadence controls are enabled; the desktop's local agent is implicit
+   *  (not presence-aware), so those controls stay enabled there regardless of this flag. */
   agentConnected: boolean;
 }
 


### PR DESCRIPTION
Re-lands the net changes from #33 as two clean commits.

**1. Launch fix** — the Force-CJS main-process build emits `out/main/index.cjs`, but `packages/app/package.json` still pointed `main` at `index.js`, so Electron aborted every spec with "Cannot find module .../out/main/index.js". Points `main` at `out/main/index.cjs`.

**2. e2e drift** — with the launch fixed, the full desktop nightly runs again and surfaces stale tests:
- scope the ProfileMenu trigger to `button.ap-avatar` (`.ap-avatar` is now shared with the comment-author Avatar);
- assert the Language picker only when a locale `<select>` is present (en-only builds omit it);
- finish-turn is always enabled for the desktop's implicit local agent — gate it only for presence-aware hosts;
- the manual Save checkbox was removed (auto-save on quit), so the dirty-close test expects no Save box, scoped to `.ap-quit`.

Fixes the nightly Electron e2e launch failure (#23).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/36?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

