### PR TITLE
release: inplan v0.1.19

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,10 @@ permissions:
 
 jobs:
   publish:
+    # Only publish for version tags (vX.Y.Z). Other releases (e.g. the pinned
+    # `demo-assets` release that hosts the README demo media) must NOT trigger a
+    # publish. workflow_dispatch carries no release tag, so allow it explicitly.
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'v')
     runs-on: ubuntu-latest
     # Must match the "Environment name" set on npm's Trusted Publisher config (`release`),
     # or the OIDC token's environment claim won't match and npm rejects it (→ ENEEDAUTH).

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ process that remains adaptable without sacrificing correctness.
 
 ## Demo
 
-[![inplan — plan with your coding agent](https://github.com/melly-lgtm/inplan/releases/download/v0.1.19/inplan-demo.gif)](https://github.com/melly-lgtm/inplan/releases/download/v0.1.19/inplan-demo.mp4)
+[![inplan — plan with your coding agent](https://github.com/melly-lgtm/inplan/releases/latest/download/inplan-demo.gif)](https://github.com/melly-lgtm/inplan/releases/latest/download/inplan-demo.mp4)
 
 Comment on a specific sentence and discuss it with the agent in a thread; when it
 revises the plan, review the diff and apply it like a PR.
-▶ **[Watch with narration](https://github.com/melly-lgtm/inplan/releases/download/v0.1.19/inplan-demo.mp4)**
+▶ **[Watch with narration](https://github.com/melly-lgtm/inplan/releases/latest/download/inplan-demo.mp4)**
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ process that remains adaptable without sacrificing correctness.
 
 ## Demo
 
-[![inplan — plan with your coding agent](https://github.com/melly-lgtm/inplan/releases/latest/download/inplan-demo.gif)](https://github.com/melly-lgtm/inplan/releases/latest/download/inplan-demo.mp4)
+[![inplan — plan with your coding agent](https://github.com/melly-lgtm/inplan/releases/download/demo-assets/inplan-demo.gif)](https://github.com/melly-lgtm/inplan/releases/download/demo-assets/inplan-demo.mp4)
 
 Comment on a specific sentence and discuss it with the agent in a thread; when it
 revises the plan, review the diff and apply it like a PR.
-▶ **[Watch with narration](https://github.com/melly-lgtm/inplan/releases/latest/download/inplan-demo.mp4)**
+▶ **[Watch with narration](https://github.com/melly-lgtm/inplan/releases/download/demo-assets/inplan-demo.mp4)**
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ process that remains adaptable without sacrificing correctness.
 
 ## Demo
 
-[![inplan — plan with your coding agent](https://github.com/melly-lgtm/inplan/releases/download/v0.1.18/inplan-demo.gif)](https://github.com/melly-lgtm/inplan/releases/download/v0.1.18/inplan-demo.mp4)
+[![inplan — plan with your coding agent](https://github.com/melly-lgtm/inplan/releases/download/v0.1.19/inplan-demo.gif)](https://github.com/melly-lgtm/inplan/releases/download/v0.1.19/inplan-demo.mp4)
 
 Comment on a specific sentence and discuss it with the agent in a thread; when it
 revises the plan, review the diff and apply it like a PR.
-▶ **[Watch with narration](https://github.com/melly-lgtm/inplan/releases/download/v0.1.18/inplan-demo.mp4)**
+▶ **[Watch with narration](https://github.com/melly-lgtm/inplan/releases/download/v0.1.19/inplan-demo.mp4)**
 
 ## How it works
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6593,7 +6593,7 @@
     },
     "packages/cli": {
       "name": "@inplan/cli",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@inplan/backend-supabase": "0.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inplan/cli",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "private": true,
   "description": "inplan CLI: open / wait / signal orchestration over the document core.",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
Patch release bundling the unreleased commits on main since v0.1.18:
- fix(app): unblock the nightly Electron e2e (main → out/main/index.cjs) + e2e drift (#36)
- ci: enforce the authorship gate locally via a commit-msg hook (#35)
- docs(readme): add demo (GIF + narrated video) (#32)

Bumps packages/cli/package.json (single source for the published version) + lockfile entry. Publishing GitHub Release v0.1.19 after merge triggers release.yml (OIDC trusted publish to npm).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/37?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the `@inplan/cli` package version to `0.1.19`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->