### PR TITLE
docs: README polish (badges + further reading) + fix: git-identity GIT_DIR leak

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,3 +55,11 @@ The codebase is a TypeScript monorepo:
 - `packages/cli` — the `inplan` CLI (`open` / `wait` / `signal`)
 - `packages/app` — the Electron editor
 - `skill/` — the agent skill
+
+## Good first issues
+
+New here? Start with an issue labelled
+[**good first issue**](https://github.com/melly-lgtm/inplan/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) —
+these are small, self-contained, and a friendly way in. Comment on one to claim it, then
+open a PR (sign off with `git commit -s`, and sign the CLA on your first PR). Broadening
+OS / cadence / agent support (see the README's Project status) is especially welcome.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 # inplan
 
+**Plan with your coding agent — before it writes the code.**
+
+[![npm version](https://img.shields.io/npm/v/inplan?label=inplan&color=1f5c4d)](https://www.npmjs.com/package/inplan)
+[![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-1f5c4d)](./LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/melly-lgtm/inplan?color=e0a23b)](https://github.com/melly-lgtm/inplan/stargazers)
+[![inplan.ai](https://img.shields.io/badge/site-inplan.ai-1f5c4d)](https://inplan.ai)
+
+A Markdown workspace where you and your AI coding agent turn a vague ask into a real
+spec: the agent drafts, raises the open questions inline, you answer them in place, it
+revises, and you apply the diff like a PR. Think of it as **vibe coding with a plan** —
+the agent builds against a versioned spec instead of guessing from a fading chat. The
+hosted edition lives at **[inplan.ai](https://inplan.ai)**; this repo is the open core
+you can run yourself.
+
 **InPlan (Interactive Planning Editor)** brings structure and accountability to
 AI-assisted software development. While AI coding agents are excellent at generating
 code quickly, they struggle when requirements evolve, context grows, and decisions
@@ -15,10 +29,6 @@ from bug fixes, and maintain a reliable source of truth that neither humans nor 
 agents can consistently hold in memory. The result is less implementation drift,
 safer refactoring, better alignment between intent and code, and a development
 process that remains adaptable without sacrificing correctness.
-
-> A Markdown workspace where you and your coding agent plan together. The hosted
-> edition lives at **[inplan.ai](https://inplan.ai)**; this repository is the open
-> core you can run yourself.
 
 ## Demo
 
@@ -166,6 +176,15 @@ rough edges there.
 
 **Contributions are very welcome** — especially anything that broadens and hardens support for
 the OSes, modes, and agents above. See [`CONTRIBUTING.md`](./CONTRIBUTING.md).
+
+## Further reading
+
+Notes from building inplan, on the [blog](https://inplan.ai/blog.html):
+
+- [**A one-liner builds the minimum. A plan builds the app**](https://inplan.ai/blog/build-off-with-a-plan.html) — we re-ran a 12-model coding build-off and measured how much of the app you actually *get*: 11–67% from a one-liner vs. 63–91% from a plan, graded with executable tests.
+- [**Your coding agent doesn't need a better model. It needs a better plan**](https://inplan.ai/blog/planning-in-agentic-coding.html) — why shared understanding, not the model, is the bottleneck.
+- [**All you need is more thorough planning**](https://inplan.ai/blog/does-planning-make-your-agent-faster.html) — a checkout pricing engine, first-pass correctness 4/8 → 8/8.
+- [**One document, three jobs**](https://inplan.ai/blog/how-teams-use-inplan.html) — how a developer, a PM, and an architect work the same plan.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Plan with your coding agent — before it writes the code.**
 
 [![npm version](https://img.shields.io/npm/v/inplan?label=inplan&color=1f5c4d)](https://www.npmjs.com/package/inplan)
-[![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-1f5c4d)](./LICENSE)
+[![License: AGPL-3.0-or-later](https://img.shields.io/badge/license-AGPL--3.0--or--later-1f5c4d)](./LICENSE)
 [![GitHub stars](https://img.shields.io/github/stars/melly-lgtm/inplan?color=e0a23b)](https://github.com/melly-lgtm/inplan/stargazers)
 [![inplan.ai](https://img.shields.io/badge/site-inplan.ai-1f5c4d)](https://inplan.ai)
 

--- a/packages/cli/src/provenance.ts
+++ b/packages/cli/src/provenance.ts
@@ -13,7 +13,12 @@ export type GitRunner = (args: string[], cwd: string) => string | null;
 
 const defaultRun: GitRunner = (args, cwd) => {
   try {
-    return execFileSync("git", args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+    // Discovery must be based purely on `cwd`. Strip any inherited git environment —
+    // notably GIT_DIR, which git hooks export — otherwise `rev-parse` would treat an
+    // unrelated directory as "inside a work tree" and leak the ambient repo's identity.
+    const env = { ...process.env };
+    for (const k of ["GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_COMMON_DIR", "GIT_OBJECT_DIRECTORY", "GIT_CONFIG_PARAMETERS"]) delete env[k];
+    return execFileSync("git", args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], env }).trim();
   } catch {
     return null;
   }


### PR DESCRIPTION
Two commits:

**1. `fix(cli)`: resolve git identity from the doc dir, not an inherited `GIT_DIR`.** gitIdentity ran git without sanitizing the env, so an inherited GIT_DIR (which every git hook exports) made `rev-parse --is-inside-work-tree` return true for *any* directory — leaking the ambient repo's identity as a doc's author, and failing the 'non-git dir → null' test whenever the suite runs inside a commit hook (the pre-commit gate itself). Now strips GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE/etc. so discovery is cwd-based. Found while committing #2 through the gate.

**2. `docs(readme)`:** one-line value prop + badges (npm/license/stars/site), a 'vibe coding with a plan' summary before the PDD intro, and a Further reading section linking the blog. Adds a Good first issues pointer to CONTRIBUTING.

Gate green (825 tests, coverage ≥95%); both commits signed off (DCO).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/38?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git command reliability by clearing inherited Git-related environment settings before running Git, reducing incorrect repository/work-tree discovery.

* **Documentation**
  * Added a “good first issues” section with guidance on how to find, claim, and complete a first PR, including CLA/sign-off reminders.
  * Updated README with a new top tagline, refreshed badge links, and added a “Further reading” section with blog links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->