### PR TITLE
docs: document inplan's environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ Packages: `@inplan/core` (pure, embeddable editor + plan-format logic),
 `@inplan/cli` (the `inplan` command — the agent's side of the loop), and
 `@inplan/app` (the Electron editor — the human's side).
 
+Most users never need to configure anything, but for restricted networks,
+air-gapped/CI, or source checkouts see the
+[environment variables reference](./docs/environment.md).
+
 ## Quick start
 
 You don't run `inplan` yourself — your **coding agent** does. There are two steps:

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -1,0 +1,41 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+
+# Environment variables
+
+inplan reads a handful of environment variables. Most users never need to set
+any of them — the defaults are chosen so the CLI and editor "just work". They're
+listed here for restricted networks, air-gapped/CI setups, and development from a
+source checkout.
+
+## Paths & storage
+
+| Variable | What it does | Default |
+| --- | --- | --- |
+| `INPLAN_HOME` | Root directory for inplan's own state — sidecars, settings, auth, and the plugin cache. | `~/.inplan` |
+| `INPLAN_SIDECAR_DIR` | Overrides just the sidecar location (control log, canonical base, backups). Takes precedence over `INPLAN_HOME` for sidecars. | `<INPLAN_HOME>/sidecars` |
+
+## Editor launch (development / source checkouts)
+
+| Variable | What it does | Default |
+| --- | --- | --- |
+| `INPLAN_APP_CMD` | Command the CLI runs for `inplan open` instead of the bundled desktop editor. Needed when running from a source checkout, where no editor is bundled — otherwise the CLI falls back to headless. | *(unset — use bundled editor)* |
+
+## Electron download (restricted networks)
+
+| Variable | What it does | Default |
+| --- | --- | --- |
+| `ELECTRON_MIRROR` | Electron's standard mirror URL, honored when the bundled editor's Electron binary must be (re-)downloaded behind a proxy/firewall — e.g. `https://npmmirror.com/mirrors/electron/`. inplan never falls back to a third-party mirror on its own; only a mirror you set here is used. | *(unset — official host)* |
+| `INPLAN_NO_ELECTRON_DOWNLOAD` | Set to `1` to skip the Electron auto-download entirely (air-gapped / CI). The loop still runs headless, but the human can't review in the GUI. | *(unset)* |
+
+## Skill installation
+
+| Variable | What it does | Default |
+| --- | --- | --- |
+| `INPLAN_NO_SKILL_INSTALL` | Set to skip auto-installing the agent skill into detected coding agents on install. Run `inplan install-skill` later to install it manually. | *(unset — skill is installed)* |
+
+## Timing (advanced)
+
+| Variable | What it does | Default |
+| --- | --- | --- |
+| `INPLAN_DEBOUNCE_MS` | Debounce, in milliseconds, before the CLI reacts to file changes. | `3000` |
+| `INPLAN_POLL_MS` | Poll interval, in milliseconds, while the CLI waits for the next human action. | `200` |

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -18,7 +18,7 @@ source checkout.
 
 | Variable | What it does | Default |
 | --- | --- | --- |
-| `INPLAN_APP_CMD` | Command the CLI runs for `inplan open` instead of the bundled desktop editor. Needed when running from a source checkout, where no editor is bundled — otherwise the CLI falls back to headless. | *(unset — use bundled editor)* |
+| `INPLAN_APP_CMD` | Command the CLI runs for `inplan open` instead of the bundled desktop editor. | *(unset — bundled editor when installed; headless from source checkouts)* |
 
 ## Electron download (restricted networks)
 


### PR DESCRIPTION
## What

Adds `docs/environment.md` — a single reference for every environment variable inplan reads — and links it from the README's install section.

The variables are grouped by purpose, each with what it does and its default:

- **Paths & storage** — `INPLAN_HOME`, `INPLAN_SIDECAR_DIR`
- **Editor launch** (source checkouts) — `INPLAN_APP_CMD`
- **Electron download** (restricted networks) — `ELECTRON_MIRROR`, `INPLAN_NO_ELECTRON_DOWNLOAD`
- **Skill installation** — `INPLAN_NO_SKILL_INSTALL`
- **Timing** (advanced) — `INPLAN_DEBOUNCE_MS` (3000), `INPLAN_POLL_MS` (200)

All entries were verified against the source (`process.env.*` reads in `packages/core`, `packages/cli`, `packages/app`); internal-only vars (PostHog/Supabase/plugin keys) are intentionally left out since they aren't part of the user-facing surface.

Docs-only, no code changes.

Closes #40

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/42?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an environment variables reference covering storage paths, editor settings, restricted-network configuration, optional skill installation, and timing controls.
  * Updated installation guidance to direct source-checkout, CI, restricted-network, and air-gapped users to the new reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->