### PR TITLE
docs: add a keyboard shortcuts reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,9 @@ The plan should [use Postgres](#cmt-abfdb1) for storage.
 Because the format is plain Markdown plus one HTML comment, a plan renders fine in any
 Markdown viewer and diffs cleanly in code review.
 
+The editor has a handful of keyboard shortcuts (find, undo/redo, save, add comment) —
+see the [keyboard shortcuts reference](./docs/shortcuts.md).
+
 ## Project status
 
 inplan **aims** to support every combination of:

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -1,0 +1,27 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+
+# Keyboard shortcuts
+
+Shortcuts for the inplan editor. The primary modifier is **⌘ on macOS** and
+**Ctrl on Windows/Linux** — shown below as `Mod`.
+
+## Global
+
+| Shortcut | Action |
+| --- | --- |
+| `Mod` + `F` | Open the find bar and focus it (also works while the source editor is focused; re-press to select the query and type over it). |
+| `Mod` + `Z` | Undo. While a proposed change is open for review, this steps back through the review's own accept/reject timeline instead of the document history. |
+| `Mod` + `Shift` + `Z` | Redo (mirrors undo, including within an open review). |
+| `Mod` + `S` | Save — writes canonically in **Instant** mode, or takes a checkpoint backup in **Turn** mode. |
+| `Mod` + `/` | Add a comment on the current selection. |
+| `Esc` | Dismiss, in order: the open composer → the find bar → the review panel. |
+
+## Comment composer & replies
+
+| Shortcut | Action |
+| --- | --- |
+| `Mod` + `Enter` | Submit the comment or reply you're typing. |
+
+> On a deactivated (read-only) document the mutating shortcuts — undo/redo, save,
+> and add-comment — are disabled, but **find** (`Mod`+`F`) and **Esc** still work
+> so the document stays searchable and viewable.


### PR DESCRIPTION
## What

Adds `docs/shortcuts.md` documenting the inplan editor's keyboard shortcuts, and links it from the README. Documents existing behavior only — no code changes.

Shortcuts are verified against the global key handler in `packages/renderer/src/App.tsx` and the platform modifier in `platform.ts` (⌘ on macOS, Ctrl on Windows/Linux):

| Shortcut | Action |
| --- | --- |
| `Mod`+`F` | Open/focus find |
| `Mod`+`Z` / `Mod`+`Shift`+`Z` | Undo / redo (review-aware) |
| `Mod`+`S` | Save (canonical in Instant, checkpoint in Turn) |
| `Mod`+`/` | Add comment on selection |
| `Esc` | Dismiss composer → find → review |
| `Mod`+`Enter` | Submit comment/reply |

Also notes which shortcuts stay active on a read-only document (find and Esc).

Closes #39

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/43?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a keyboard shortcuts reference for the inplan editor.
  * Documented shortcuts for search, undo/redo, saving, comments, replies, and dismissing dialogs.
  * Clarified modifier keys across macOS, Windows, and Linux.
  * Noted which shortcuts remain available in read-only documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->