### PR TITLE
docs: add a 'Works with' agents/editors compatibility section

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,23 @@ The plan should [use Postgres](#cmt-abfdb1) for storage.
 Because the format is plain Markdown plus one HTML comment, a plan renders fine in any
 Markdown viewer and diffs cleanly in code review.
 
+## Works with
+
+inplan plugs into your coding agent through a bundled **skill** plus relay hooks: on
+install it detects the agents present on your machine and drops the skill in for each
+(`inplan install-skill` does this manually). The agent then drives the loop through the
+CLI — `inplan open` / `wait` / `signal` — while you review in the editor.
+
+| Agent | Detected at | Support |
+| --- | --- | --- |
+| **Claude Code** | `~/.claude` | Primary — actively developed and tested. |
+| **Codex** | `~/.codex` | Wired (skill + hooks installed); lightly exercised. |
+| **Pi** | `~/.pi/agent` | Wired (skill + hooks installed); lightly exercised. |
+
+If your agent isn't detected automatically, point it at the bundled skill
+(`skill/SKILL.md`) and ask it to plan. Any agent that can read a skill and run the
+`inplan` CLI can participate.
+
 ## Project status
 
 inplan **aims** to support every combination of:


### PR DESCRIPTION
## What

Adds a **Works with** section to the README so people evaluating inplan can see at a glance which agents it integrates with and how.

It explains the integration surface (bundled skill + relay hooks, driven through the `inplan open`/`wait`/`signal` CLI) and lists the three agents inplan's `install-skill` detects, with a support note for each:

| Agent | Support |
| --- | --- |
| Claude Code | Primary — actively developed and tested |
| Codex | Wired; lightly exercised |
| Pi | Wired; lightly exercised |

Kept factual: agents/paths match the detection targets in `packages/cli/src/cli.ts`, and the well-tested-vs-experimental split mirrors the existing **Project status** note. Docs-only.

Closes #41

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/44?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

