### PR TITLE
ci(cla): exempt CrazyIdeaStudio staff account jaden-cis from the CLA

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -52,9 +52,10 @@ jobs:
           # contributors' signatures never recorded → the CLA check stayed red. cla-signatures is
           # outside that ruleset, so the bot can persist signatures again.
           branch: 'cla-signatures'
-          # The company's own maintainer account is the licensor, not a third-party
-          # contributor — it doesn't sign its own CLA. External contributors still must.
-          allowlist: 'melly-lgtm,dependabot[bot]'
+          # The company's own accounts are the licensor, not third-party contributors — their work is
+          # already owned via employment IP assignment, so they don't sign their own CLA. External
+          # contributors still must. (melly-lgtm = maintainer; jaden-cis = staff.)
+          allowlist: 'melly-lgtm,jaden-cis,dependabot[bot]'
           custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
           custom-notsigned-prcomment: |
             👋 Thanks for the contribution! This isn't a build failure — before we can merge, we just need a **one-time** sign-off on our [Contributor License Agreement](https://github.com/melly-lgtm/inplan/blob/main/CLA.md).


### PR DESCRIPTION
## What

Adds `jaden-cis` to the CLA `allowlist` in `.github/workflows/cla.yml`, alongside the existing `melly-lgtm` maintainer account.

## Why

The CLA bot (`contributor-assistant/github-action`) exempts by **GitHub username**, and company-owned accounts are the licensor rather than third-party contributors — their work is already owned via employment IP assignment, so they don't sign the project's own CLA. External contributors still must.

## Note

The action's `allowlist` matches usernames only (not commit email), so staff exemptions are tracked by adding the GitHub username here. Both listed accounts (`melly-lgtm`, `jaden-cis`) are verified to exist on GitHub.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/46?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated contributor agreement validation to recognize an additional approved contributor.
  * Clarified the workflow guidance for determining when external agreement approval is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->