### PR TITLE
fix(renderer): hide HTML comments from the rendered preview

### DIFF
--- a/packages/renderer/src/markdown.ts
+++ b/packages/renderer/src/markdown.ts
@@ -64,6 +64,45 @@ for (const name of ["fence", "code_block"]) {
   };
 }
 
+// Byte ranges of the input covered by a fenced code block (``` or ~~~), so a `<!-- -->` shown
+// as a syntax EXAMPLE inside a fence isn't mistaken for a real author note. Mirrors the
+// fence-tracking in core's findBlockOpen (the inplan comment-data-block scanner).
+function fencedRanges(text: string): Array<[number, number]> {
+  const ranges: Array<[number, number]> = [];
+  let inFence = false;
+  let fenceStart = 0;
+  let offset = 0;
+  for (const line of text.split("\n")) {
+    if (/^\s*(```|~~~)/.test(line)) {
+      if (!inFence) {
+        inFence = true;
+        fenceStart = offset;
+      } else {
+        inFence = false;
+        ranges.push([fenceStart, offset + line.length]);
+      }
+    }
+    offset += line.length + 1; // account for the split-out "\n"
+  }
+  return ranges;
+}
+
+// `html: false` (below) makes markdown-it escape raw HTML as visible literal text rather than
+// passing it through — a deliberate XSS guard (a collaborative doc's body isn't trusted input,
+// and this HTML is fed straight into dangerouslySetInnerHTML). That guard also makes a
+// `<!-- author note -->` render as visible text instead of vanishing like a real HTML comment
+// would. Strip comments before the guard sees them — narrowly, so nothing else about `html:
+// false` changes — but preserve their internal newlines (not the surrounding text) so `data-line`
+// stays aligned with the *source* editor for cross-pane sync. Never touch the raw source itself
+// (doc.body / SourceEditor) — only this rendered preview.
+function stripHtmlComments(body: string): string {
+  const fences = fencedRanges(body);
+  return body.replace(/<!--[\s\S]*?-->/g, (m, offset: number) => {
+    if (fences.some(([s, e]) => offset >= s && offset < e)) return m; // syntax example inside a fence — leave it
+    return "\n".repeat((m.match(/\n/g) ?? []).length);
+  });
+}
+
 /**
  * Render Markdown body to HTML, with comment anchors tagged for the UI and
  * block elements tagged with their source line (`data-line`).
@@ -72,5 +111,5 @@ for (const name of ["fence", "code_block"]) {
  * off). When omitted, all anchors render as links.
  */
 export function renderMarkdown(body: string, showAnchor?: (id: string) => boolean): string {
-  return md.render(body, { showAnchor });
+  return md.render(stripHtmlComments(body), { showAnchor });
 }

--- a/packages/renderer/src/markdown.ts
+++ b/packages/renderer/src/markdown.ts
@@ -15,7 +15,10 @@ import MarkdownIt from "markdown-it";
 // genuine comments are now hidden instead of shown as escaped text.
 const md = new MarkdownIt({ html: true, linkify: true });
 
-const isHtmlComment = (html: string): boolean => /^<!--[\s\S]*-->\s*$/.test(html);
+// CommonMark allows an HTML block (a comment included) to be indented up to 3 spaces —
+// markdown-it keeps that leading whitespace in the token's content, so the match must allow it
+// too, or an indented `<!-- note -->` falls through to the escaped-text branch below.
+const isHtmlComment = (html: string): boolean => /^\s*<!--[\s\S]*-->\s*$/.test(html);
 const renderHtmlToken = (tokens: Parameters<MarkdownIt["renderer"]["renderToken"]>[0], idx: number): string => {
   const html = tokens[idx]!.content;
   return isHtmlComment(html) ? "" : md.utils.escapeHtml(html);

--- a/packages/renderer/src/markdown.ts
+++ b/packages/renderer/src/markdown.ts
@@ -2,7 +2,26 @@
 
 import MarkdownIt from "markdown-it";
 
-const md = new MarkdownIt({ html: false, linkify: true });
+// `html: true` lets markdown-it's OWN parser recognize raw HTML (as `html_block` /
+// `html_inline` tokens) with full awareness of code spans and fences — a backtick span or
+// fenced block is consumed by markdown-it's own higher-priority rules before html_inline/
+// html_block ever sees those characters, so `<!--`/`-->` shown as a syntax example inside
+// code is untouched, with no hand-rolled fence/code-span tracker to keep in sync with
+// CommonMark's actual rules (unclosed fences, backtick-vs-tilde + length matching, etc.).
+// The renderer overrides below make an `html_block`/`html_inline` token that IS a comment
+// render as nothing (hidden from the preview), and anything else render HTML-escaped —
+// i.e. exactly the visible-literal-text behavior `html: false` used to give for ALL raw
+// HTML — so a stray `<script>`/`<div>` typed into a collaborative doc is still inert; only
+// genuine comments are now hidden instead of shown as escaped text.
+const md = new MarkdownIt({ html: true, linkify: true });
+
+const isHtmlComment = (html: string): boolean => /^<!--[\s\S]*-->\s*$/.test(html);
+const renderHtmlToken = (tokens: Parameters<MarkdownIt["renderer"]["renderToken"]>[0], idx: number): string => {
+  const html = tokens[idx]!.content;
+  return isHtmlComment(html) ? "" : md.utils.escapeHtml(html);
+};
+md.renderer.rules.html_block = (tokens, idx) => renderHtmlToken(tokens, idx);
+md.renderer.rules.html_inline = (tokens, idx) => renderHtmlToken(tokens, idx);
 
 // Tag comment-anchor links (`#cmt-...`) so the preview can highlight them and
 // wire up click-to-focus behavior. When `showAnchor(id)` is false (e.g. a resolved
@@ -64,45 +83,6 @@ for (const name of ["fence", "code_block"]) {
   };
 }
 
-// Byte ranges of the input covered by a fenced code block (``` or ~~~), so a `<!-- -->` shown
-// as a syntax EXAMPLE inside a fence isn't mistaken for a real author note. Mirrors the
-// fence-tracking in core's findBlockOpen (the inplan comment-data-block scanner).
-function fencedRanges(text: string): Array<[number, number]> {
-  const ranges: Array<[number, number]> = [];
-  let inFence = false;
-  let fenceStart = 0;
-  let offset = 0;
-  for (const line of text.split("\n")) {
-    if (/^\s*(```|~~~)/.test(line)) {
-      if (!inFence) {
-        inFence = true;
-        fenceStart = offset;
-      } else {
-        inFence = false;
-        ranges.push([fenceStart, offset + line.length]);
-      }
-    }
-    offset += line.length + 1; // account for the split-out "\n"
-  }
-  return ranges;
-}
-
-// `html: false` (below) makes markdown-it escape raw HTML as visible literal text rather than
-// passing it through — a deliberate XSS guard (a collaborative doc's body isn't trusted input,
-// and this HTML is fed straight into dangerouslySetInnerHTML). That guard also makes a
-// `<!-- author note -->` render as visible text instead of vanishing like a real HTML comment
-// would. Strip comments before the guard sees them — narrowly, so nothing else about `html:
-// false` changes — but preserve their internal newlines (not the surrounding text) so `data-line`
-// stays aligned with the *source* editor for cross-pane sync. Never touch the raw source itself
-// (doc.body / SourceEditor) — only this rendered preview.
-function stripHtmlComments(body: string): string {
-  const fences = fencedRanges(body);
-  return body.replace(/<!--[\s\S]*?-->/g, (m, offset: number) => {
-    if (fences.some(([s, e]) => offset >= s && offset < e)) return m; // syntax example inside a fence — leave it
-    return "\n".repeat((m.match(/\n/g) ?? []).length);
-  });
-}
-
 /**
  * Render Markdown body to HTML, with comment anchors tagged for the UI and
  * block elements tagged with their source line (`data-line`).
@@ -111,5 +91,5 @@ function stripHtmlComments(body: string): string {
  * off). When omitted, all anchors render as links.
  */
 export function renderMarkdown(body: string, showAnchor?: (id: string) => boolean): string {
-  return md.render(stripHtmlComments(body), { showAnchor });
+  return md.render(body, { showAnchor });
 }

--- a/packages/renderer/test/markdown.test.ts
+++ b/packages/renderer/test/markdown.test.ts
@@ -128,4 +128,27 @@ describe("renderMarkdown HTML comments", () => {
       expect(html).not.toContain("&lt;!--");
     }
   });
+
+  it("escapes block-level raw HTML, not just inline — the XSS guard covers html_block too", () => {
+    // The inline `<script>` case above exercises the html_inline path; a `<script>` on its own
+    // line parses as an html_block. Both must escape (never emit raw HTML into the preview, which
+    // is fed to dangerouslySetInnerHTML). This locks the more dangerous, block-level path.
+    const html = renderMarkdown("<script>alert(1)</script>\n");
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+
+    const div = renderMarkdown('<div onclick="alert(1)">x</div>\n');
+    expect(div).not.toContain("<div");
+    expect(div).toContain("&lt;div");
+  });
+
+  it("hides the trailing <!--inplan …--> comment block (the app's own comment store)", () => {
+    // doc.body carries the plan's trailing inplan comment block; under `html: false` it used to
+    // render as visible escaped JSON at the bottom of every preview. It must now be hidden.
+    const body = '# Title\n\nSome text.\n\n<!--inplan\n[ { "id": "cmt-abc123", "text": "note" } ]\n-->\n';
+    const html = renderMarkdown(body);
+    expect(html).toContain("Some text.");
+    expect(html).not.toContain("cmt-abc123");
+    expect(html).not.toContain("&lt;!--inplan");
+  });
 });

--- a/packages/renderer/test/markdown.test.ts
+++ b/packages/renderer/test/markdown.test.ts
@@ -120,4 +120,12 @@ describe("renderMarkdown HTML comments", () => {
     expect(html).not.toContain("<script>");
     expect(html).toContain("&lt;script&gt;");
   });
+
+  it("hides a block HTML comment indented up to 3 spaces (CommonMark still treats it as an HTML block)", () => {
+    for (const indent of ["", " ", "  ", "   "]) {
+      const html = renderMarkdown(`# Title\n\n${indent}<!-- indented note -->\n\nAfter.\n`);
+      expect(html).not.toContain("indented note");
+      expect(html).not.toContain("&lt;!--");
+    }
+  });
 });

--- a/packages/renderer/test/markdown.test.ts
+++ b/packages/renderer/test/markdown.test.ts
@@ -58,3 +58,35 @@ describe("renderMarkdown comment anchors", () => {
     expect(html).toContain("https://x.test");
   });
 });
+
+describe("renderMarkdown HTML comments", () => {
+  it("hides an inline HTML comment from the rendered preview", () => {
+    const html = renderMarkdown("before <!-- private note --> after");
+    expect(html).toContain("before");
+    expect(html).toContain("after");
+    expect(html).not.toContain("private note");
+    expect(html).not.toContain("&lt;!--"); // not even as escaped literal text
+  });
+
+  it("hides a multi-line HTML comment while keeping later line numbers aligned with the source", () => {
+    const body = "# Title\n\n<!--\nhidden note\nspanning lines\n-->\n\nAfter.\n";
+    const html = renderMarkdown(body);
+    expect(html).not.toContain("hidden note");
+    // "After." is on source line 7 (0-based) — must still be, since only the comment's
+    // own newlines were preserved, not deleted along with its content.
+    expect(html).toMatch(/data-line="7"[^>]*>\s*After\./);
+  });
+
+  it("does NOT strip a `<!-- -->` shown as a syntax example inside a fenced code block", () => {
+    const html = renderMarkdown("```html\n<!-- example comment -->\n```\n");
+    expect(html).toContain("example comment");
+  });
+
+  it("leaves the raw source (SourceEditor's doc.body) untouched — only the rendered preview hides comments", () => {
+    // renderMarkdown never mutates its input; the caller's doc.body (fed to SourceEditor) is
+    // whatever was passed in, unaffected by what the preview renders.
+    const body = "before <!-- note --> after";
+    renderMarkdown(body);
+    expect(body).toBe("before <!-- note --> after");
+  });
+});

--- a/packages/renderer/test/markdown.test.ts
+++ b/packages/renderer/test/markdown.test.ts
@@ -89,4 +89,35 @@ describe("renderMarkdown HTML comments", () => {
     renderMarkdown(body);
     expect(body).toBe("before <!-- note --> after");
   });
+
+  it("does not eat a paragraph sitting between two inline code spans that each contain comment delimiters", () => {
+    // A naive `<!--[\s\S]*?-->` regex over raw text would span from the `<!--` inside the first
+    // code span to the `-->` inside the second, deleting everything between — including this
+    // paragraph. markdown-it's own backtick rule consumes each code span before html_inline ever
+    // sees the characters inside it, so this can't happen here.
+    const body = "Use `<!--` to start.\n\nThis paragraph must survive.\n\nUse `-->` to end.\n";
+    const html = renderMarkdown(body);
+    expect(html).toContain("This paragraph must survive.");
+    expect(html).toContain("<code>&lt;!--</code>");
+    expect(html).toContain("<code>--&gt;</code>");
+  });
+
+  it("does not strip a `<!-- -->` example inside an UNCLOSED fenced code block", () => {
+    const html = renderMarkdown("```html\n<!-- unclosed fence, no closing marker -->\n");
+    expect(html).toContain("unclosed fence, no closing marker");
+  });
+
+  it("requires the closing fence to match the opening fence's character and length (~~~ isn't closed by ```)", () => {
+    // A stray ``` inside a ~~~ block must not be treated as closing it — the `<!-- -->` inside
+    // stays a syntax example either way, but for the RIGHT reason (still inside the fence).
+    const body = "~~~html\n<!-- inside a tilde fence -->\n```\nstill inside\n~~~\n";
+    const html = renderMarkdown(body);
+    expect(html).toContain("inside a tilde fence");
+  });
+
+  it("still escapes non-comment raw HTML as visible literal text (XSS guard unchanged)", () => {
+    const html = renderMarkdown('before <script>alert(1)</script> after');
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
 });


### PR DESCRIPTION
The rendered preview feeds straight into `dangerouslySetInnerHTML` over untrusted collaborative doc content, so raw HTML must never render. `markdown-it` was configured with `html: false`, which enforced that by escaping ALL raw HTML to visible literal text — but that also made a `<!-- author note -->` show up as visible text in `.ap-preview` instead of vanishing like a real HTML comment would.

This switches to `html: true` and overrides the `html_block` / `html_inline` renderers instead: a token that **is** an HTML comment renders as nothing (hidden from the preview), and any other raw HTML renders **HTML-escaped** — i.e. exactly the visible-literal-text behavior `html: false` gave for all raw HTML, so a stray `<script>` / `<div>` typed into a doc stays inert. Only genuine comments are now hidden instead of shown as escaped text.

Letting markdown-it's own parser emit those tokens means code spans and fenced blocks are handled by CommonMark's real rules (backtick vs tilde, fence length matching, unclosed fences), so a `<!-- -->` shown as a syntax example inside code is never swallowed — no hand-rolled fence/code-span tracker to keep in sync. The raw source (`doc.body` / SourceEditor) is untouched — only the rendered preview hides comments — and `data-line` alignment for cross-pane sync now comes for free from the parser's source maps rather than manual newline preservation.

Tests cover: comment hiding (inline / multi-line block / indented up to 3 spaces), `<!-- -->` examples preserved inside backtick fences, tilde fences, unclosed fences, and inline code spans, **block- and inline-level** non-comment HTML still escaped (XSS guard), the plan's trailing `<!--inplan …-->` comment block hidden, and that the input markdown is not mutated.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/48?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Markdown previews now suppress HTML comments (`<!-- ... -->`) so they don’t appear in rendered output.
  * Multi-line comment removal preserves alignment for subsequent rendered content.
  * Comment-like delimiters inside inline code and fenced code blocks are preserved as literal text (including tricky fence-closure cases).
  * Other raw HTML is still displayed as escaped, literal text.
* **Tests**
  * Added a dedicated suite covering HTML comment stripping, alignment behavior, fenced/code edge cases, and that the input markdown is not mutated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
