### PR TITLE
ci(cla): tolerate trailing newlines in the sign comment (contains, not ==)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -32,7 +32,11 @@ jobs:
         # next step reports a friendly `CLA` commit status instead (pending, not failure). The job
         # itself stays green. outcome (success/failure) is still readable below to drive that status.
         continue-on-error: true
-        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        # Match with contains(), NOT ==: GitHub's comment box appends a trailing CRLF ("\r\n") to the
+        # body, so an exact `== 'the phrase'` skips a correctly-worded sign comment and the CLA status
+        # never flips green (hit on #43/#44 — the contributor signed, but the run skipped on the stray
+        # newline). contains() tolerates that trailing whitespace.
+        if: (contains(github.event.comment.body, 'recheck') || contains(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA')) || github.event_name == 'pull_request_target'
         # SHA-pinned (not a mutable tag): this action has contents/PR write + a PAT,
         # and the upstream repo is archived, so a force-pushed tag must not be able
         # to swap in malicious code. ca4a40a = v2.6.1 — the LAST release (the repo is


### PR DESCRIPTION
## Problem
On #43 and #44 the **CLA** check stayed **pending** even though the contributor posted the exact sign phrase — and was already recorded in `signatures/cla.json`.

Cause: GitHub's comment box appends a trailing **CRLF** (`\r\n`) to the comment body, so the workflow's exact-match guard

```yaml
if: github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA' || ...
```

evaluated **false** (`'…the CLA\r\n' != '…the CLA'`). Both the CLA action step and the status-reporting step were **skipped**, so the `CLA` commit status never flipped. A `recheck` comment wouldn't help either — same `==`, same trailing newline.

## Fix
Match the sign / `recheck` comment with `contains(...)` instead of `==`, which tolerates the trailing whitespace. The `pull_request_target` path is unchanged.

## Note
#43 and #44 have already been unblocked (re-ran their `pull_request_target` check → re-evaluated as already-signed → green). This PR stops the next contributor from hitting the same wall.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/49?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLA workflow recognition for comments containing the required recheck or sign-off phrases, including comments with trailing line breaks.
  * Preserved the existing behavior that bypasses CLA checks for designated pull request events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->