### PR TITLE
test(e2e): capture Electron traces + retry in CI so nightly failures are diagnosable

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -75,12 +75,25 @@ export async function launch(opts: LaunchOpts = {}): Promise<Ctx> {
     env: { ...process.env, INPLAN_HOME: home, INPLAN_SIDECAR_DIR: sidecarDir, ...opts.env },
   });
   const win = await app.firstWindow();
+  // Trace the whole app context so a headless-CI failure is diagnosable (config `use.trace` can't
+  // reach a hand-launched Electron app). Opt-in via CI or PWTRACE=1 locally; the trace is saved in
+  // quit(). Best-effort — tracing must never break the run.
+  if (tracingOn) await app.context().tracing.start({ screenshots: true, snapshots: true, sources: true }).catch(() => {});
   if (!opts.showOnboarding) await expect(win.locator("body")).toContainText(opts.expectText ?? "alpha", { timeout: 15_000 });
   return { app, win, dir, home, docPath, sidecarDir };
 }
 
+/** Whether to record a Playwright trace (on in CI; opt in locally with PWTRACE=1). */
+const tracingOn = Boolean(process.env.CI || process.env.PWTRACE);
+
 /** Force-exit past the quit-confirmation dialog (a graceful close() would hang on the dialog). */
 export async function quit(app?: ElectronApplication): Promise<void> {
+  // Save the trace before exiting (one zip per spec file, under test-results/ which CI uploads).
+  // If the app already crashed/closed, stopping the trace will reject — swallow it.
+  if (app && tracingOn) {
+    mkdirSync("test-results", { recursive: true });
+    await app.context().tracing.stop({ path: join("test-results", `electron-trace-${Date.now()}.zip`) }).catch(() => {});
+  }
   await app?.evaluate(({ app: a }) => a.exit(0)).catch(() => {});
   await app?.close().catch(() => {});
 }

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -90,10 +90,17 @@ const tracingOn = Boolean(process.env.CI) || process.env.PWTRACE === "1" || proc
 /** Force-exit past the quit-confirmation dialog (a graceful close() would hang on the dialog). */
 export async function quit(app?: ElectronApplication): Promise<void> {
   // Save the trace before exiting (one zip per spec file, under test-results/ which CI uploads).
-  // If the app already crashed/closed, stopping the trace will reject — swallow it.
+  // Whole block is try/catch'd so it's strictly best-effort: a synchronous mkdirSync throw (bad
+  // perms, or a file named test-results) OR an async tracing.stop reject (app already crashed/closed)
+  // must never fail the run. A random suffix avoids any same-millisecond filename collision.
   if (app && tracingOn) {
-    mkdirSync("test-results", { recursive: true });
-    await app.context().tracing.stop({ path: join("test-results", `electron-trace-${Date.now()}.zip`) }).catch(() => {});
+    try {
+      mkdirSync("test-results", { recursive: true });
+      const uniq = Math.random().toString(36).slice(2, 8);
+      await app.context().tracing.stop({ path: join("test-results", `electron-trace-${Date.now()}-${uniq}.zip`) });
+    } catch {
+      /* best-effort — tracing never breaks the run */
+    }
   }
   await app?.evaluate(({ app: a }) => a.exit(0)).catch(() => {});
   await app?.close().catch(() => {});

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -83,8 +83,9 @@ export async function launch(opts: LaunchOpts = {}): Promise<Ctx> {
   return { app, win, dir, home, docPath, sidecarDir };
 }
 
-/** Whether to record a Playwright trace (on in CI; opt in locally with PWTRACE=1). */
-const tracingOn = Boolean(process.env.CI || process.env.PWTRACE);
+/** Whether to record a Playwright trace (on in CI; opt in locally with PWTRACE=1). env values are
+ *  strings, so match PWTRACE explicitly — otherwise PWTRACE=0/false would still be truthy. */
+const tracingOn = Boolean(process.env.CI) || process.env.PWTRACE === "1" || process.env.PWTRACE === "true";
 
 /** Force-exit past the quit-confirmation dialog (a graceful close() would hang on the dialog). */
 export async function quit(app?: ElectronApplication): Promise<void> {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,5 +9,17 @@ export default defineConfig({
   timeout: 30_000,
   fullyParallel: false,
   workers: 1,
+  // In CI, retry twice: a pass-on-retry marks the spec flaky (vs a genuine, repeatable failure that
+  // still reds the run), so the nightly stops crying wolf over transient headless-xvfb hiccups while
+  // real regressions stay visible. Local runs don't retry (fail fast while iterating).
+  retries: process.env.CI ? 2 : 0,
   reporter: [["list"]],
+  // Capture artifacts on failure. NB: these `use` options only auto-apply to Playwright's own
+  // page/context fixtures; the Electron specs launch the app manually, so their trace is started
+  // explicitly in e2e/helpers.ts (config `use.trace` can't reach a hand-launched Electron app).
+  use: {
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
 });


### PR DESCRIPTION
## Toward #45

The Electron nightly (#45) has failed the same **2 specs** for 3 runs — the comment-composer lifecycle (`editorControls.shared.ts:134`) and the desktop telemetry toggle (`editorControls.electron.spec.ts:54`), both 30s timeouts — but the run captures **no trace/screenshot** and uses **0 retries**, so we can't see *where* they hang (the specs' selectors are all valid) or tell flake from a real regression.

This doesn't fix the tests — it makes the next failure **diagnosable**:

- **`playwright.config.ts`** — `retries: 2` in CI (a pass-on-retry marks the spec flaky rather than reding the whole nightly; a repeatable failure still fails, confirming it's real), plus `trace`/`screenshot`/`video` `retain-on-failure`.
- **`e2e/helpers.ts`** — start a Playwright trace on the launched Electron app's **context** and save it to `test-results/electron-trace-*.zip` in `quit()` (on in CI, or `PWTRACE=1` locally). Config `use.trace` can't reach a hand-launched Electron app, so it's wired explicitly. Best-effort (try/catch) — tracing can never break a run. The nightly already uploads `test-results/`, so the next failure ships an openable trace (`npx playwright show-trace`).

After this merges, the next nightly (or a manual dispatch) will either pass-on-retry (flaky) or attach a trace pinpointing the exact hanging step — then the real fix is a follow-up. Unit gate green; no behaviour change to the app.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/50?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability in CI by retrying flaky tests up to two times.
  * Added automatic capture of traces, screenshots, and videos when tests fail.
  * Added optional detailed tracing for Electron test runs, with trace files saved for troubleshooting.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->