### PR TITLE
release: inplan 0.1.20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6593,7 +6593,7 @@
     },
     "packages/cli": {
       "name": "@inplan/cli",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@hocuspocus/provider": "^2.15.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inplan/cli",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "private": true,
   "description": "inplan CLI: open / wait / signal orchestration over the document core.",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
Bumps `@inplan/cli` (the published `inplan` package) 0.1.19 → 0.1.20.

### User-facing fixes since 0.1.19
- **#47** — restore the local-agent presence announce for `wait --remote`
- **#48** — hide HTML comments from the rendered preview (they were showing as escaped text)
- **#38** — fix a git-identity `GIT_DIR` leak so `inplan` commits/provenance run against the invoking repo

### Also merged (docs / infra, no runtime change)
- docs: environment variables (#42), keyboard shortcuts (#43), "Works with" agents (#44)
- CI/CLA: staff CLA exemption (#46), newline-tolerant sign-comment match (#49), Electron-nightly trace/retry diagnostics (#50)

After merge: `gh release create v0.1.20` publishes to npm via `release.yml` (OIDC).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/51?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CLI package to version 0.1.20.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->