### PR TITLE
fix(e2e): de-flake the composer spec (trailing un-reveal hung to timeout) — #45

### DIFF
--- a/packages/renderer/e2e/editorControls.shared.ts
+++ b/packages/renderer/e2e/editorControls.shared.ts
@@ -157,7 +157,14 @@ export function registerEditorControlSpecs(h: EditorHarness, pw: PlaywrightApi):
       await revealed.getByTitle("More").first().click();
       await page.getByRole("button", { name: "Delete" }).click();
       await expect(page.locator("article", { hasText: probe })).toHaveCount(0);
-      await page.locator(".ap-reveal").click().catch(() => {}); // un-reveal the (now-empty) resolved view
+      // Un-reveal only if the toggle is still there. Deleting the last resolved/orphaned thread
+      // unmounts `.ap-reveal` (it renders only while resolvedCount || orphanedCount > 0), so a bare
+      // `.click()` would auto-wait the FULL test timeout for a gone element — the `.catch` can't
+      // save it because the test-level timeout fires first. This was the composer spec's flaky 30s
+      // hang on the Electron nightly (#45). Guard on visibility instead.
+      if (await page.locator(".ap-reveal").isVisible().catch(() => false)) {
+        await page.locator(".ap-reveal").click().catch(() => {});
+      }
     });
 
     test("the composer audience switch offers talk-to-agent vs leave-a-memo", async () => {


### PR DESCRIPTION
Fixes the deterministic culprit behind the flaky Electron nightly (#45).

**Diagnosis** (from the trace #50 captured on the 07-22 run): the composer spec runs fine through create → reply → resolve → reveal → reopen → **Delete**, then its final line
```ts
await page.locator(".ap-reveal").click().catch(() => {}); // un-reveal
```
hangs the **whole 30s test budget**. Deleting the last resolved thread unmounts `.ap-reveal` (App.tsx renders it only while `resolvedCount || orphanedCount > 0`), so the bare `.click()` auto-waits for a gone element — and the `.catch` never runs because the test-level timeout fires first. The "Target page/browser has been closed" in the log is just teardown after the timeout.

**Fix:** guard the un-reveal on visibility so it clicks only if the toggle still exists. Shared spec → protects the web run too.

The separate `telemetry` spec flake ("browser closed" opening the avatar menu) is intermittent and retry-covered by #50; not touched here.

After merge I'll dispatch the Electron nightly to confirm green, then close #45.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/52?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when deleting the final resolved or orphaned comment thread.
  - Prevented the comment interface from waiting on controls that are no longer available after deletion.
- **Tests**
  - Strengthened automated coverage for comment composer and thread cleanup flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->