### PR TITLE
release: 0.1.21 — fix broken global install (missing runtime deps)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6593,7 +6593,7 @@
     },
     "packages/cli": {
       "name": "@inplan/cli",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@hocuspocus/provider": "^2.15.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inplan/cli",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "private": true,
   "description": "inplan CLI: open / wait / signal orchestration over the document core.",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
Bumps `@inplan/cli` to **0.1.21** to republish a working `inplan` npm package.

`0.1.20` (current `latest`) crashes on first run for every fresh global install:

```
$ npm i -g inplan && inplan
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@hocuspocus/provider'
```

It shipped without `yjs` and `@hocuspocus/provider` in its published `dependencies`. #53 fixed the release script to derive runtime deps from the CLI bundle; this bump ships a correct manifest.

- Version bumped via `npm version` (package.json + package-lock in sync; `check-lockfile-sync` passes).
- After merge: publish GitHub Release `v0.1.21` (targeting `main`) → `release.yml` auto-publishes to npm via OIDC.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/54?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

