### PR TITLE
fix(backend-supabase): declare @inplan/core as a workspace dep, not a cross-repo file: path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6587,7 +6587,7 @@
       "version": "0.0.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
-        "@inplan/core": "file:../../../inplan/packages/core",
+        "@inplan/core": "0.0.0",
         "@supabase/supabase-js": "^2.45.0"
       }
     },

--- a/packages/backend-supabase/package.json
+++ b/packages/backend-supabase/package.json
@@ -21,7 +21,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@inplan/core": "file:../../../inplan/packages/core",
+    "@inplan/core": "0.0.0",
     "@supabase/supabase-js": "^2.45.0"
   }
 }


### PR DESCRIPTION
`packages/backend-supabase/package.json` declared its workspace dependency the wrong way:

```jsonc
"@inplan/core": "file:../../../inplan/packages/core"   // ← points OUTSIDE the repo
```

Every other workspace uses the convention `"@inplan/core": "0.0.0"` (e.g. `packages/cli`), resolved by the `packages/*` workspaces glob to the local `packages/core`. The `file:` form is inplan-cloud's cross-repo pattern, copy-pasted at this package's creation (`aba9f32`, May 31).

### Why it matters
It worked only because npm's workspace linking shadowed the bogus specifier. But:
- It **broke `npm ci` on newer npm** — reproduced locally: `npm error Missing: @inplan/core@0.0.0 from lock file`. (CI's bundled npm tolerated it, which is why this stayed green and hidden.)
- It would fail outright in any checkout **without a sibling `inplan/` directory** next to the repo.

### Fix
Align both `package.json` and the matching `package-lock.json` entry with the workspace convention (`"0.0.0"`).

### Verification
- `npm ci` now **succeeds** (was failing before this change); `node_modules/@inplan/core → ../../packages/core`.
- `npm run check:lockfile` passes; build + typecheck + test/coverage gate green.
- Diff is exactly two lines (manifest + lockfile).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/55?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

