### PR TITLE
release: 0.1.22 — Electron 43 (macOS launch fix)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5335,7 +5335,7 @@
     },
     "packages/cli": {
       "name": "@inplan/cli",
-      "version": "0.1.21",
+      "version": "0.1.22",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@hocuspocus/provider": "^2.15.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inplan/cli",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "private": true,
   "description": "inplan CLI: open / wait / signal orchestration over the document core.",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
Bumps `@inplan/cli` to **0.1.22** to publish the Electron 43 fix.

### What ships
- **Electron 31.4.0 → 43.2.0** (#56) — Electron 31.7.7's notarization was revoked by Apple, so the shipped macOS app stopped launching (Gatekeeper "malicious software" block). 43.2.0 clears it. jaden smoke-tested the E43 build launches (open → edit → save, no Gatekeeper prompt).
- **backend-supabase workspace-dep fix** (#55).

### Verified (end-to-end `build-release.mjs` on this branch)
```
version: 0.1.22
electron dep: ^43.2.0
engines:  {"node":">= 22.12.0"}   ← derived from Electron's own engines.node
deps: @hocuspocus/provider, @supabase/supabase-js, electron, ws, yjs
```
- Version bumped in `package.json` + `package-lock.json` (both), `check:lockfile` passes.
- Build/typecheck/test + coverage gate green.

### After merge
Publish GitHub Release `v0.1.22` (targeting `main`) → `release.yml` auto-publishes to npm via OIDC. Then verify `npm i -g inplan@0.1.22` launches on macOS (the whole point of the E43 bump).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/57?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the CLI package version to 0.1.22.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->