### PR TITLE
skill: don't fake-orphan comments to dodge the confirm gate

### DIFF
--- a/packages/cli/src/gate.ts
+++ b/packages/cli/src/gate.ts
@@ -61,8 +61,13 @@ export interface AgentEditEvaluation {
  * (not just leave it dangling) in the same breath as orphaning its parent. Scanning only `current`
  * would never see that reply at all — it's simply gone, so nothing flags its removal as needing
  * confirmation, and it's deleted with no acknowledgement. `deletionGraph` unions in `canonical` so
- * an outright-deleted descendant is still found (and still has to be named), current's copy taking
- * precedence for anything that still exists there.
+ * an outright-deleted descendant is still found (and still has to be named).
+ *
+ * For an id that exists in both, canonical — not current — is authoritative for that graph. An
+ * edit could otherwise reparent a descendant away from its removed parent (drop `parentId`, relabel
+ * it `anchor: "doc"`) to make it look independent and dodge confirmation entirely; trusting current's
+ * shape for ancestry would fall for exactly that. Current only fills in ids canonical never had —
+ * genuinely new comments added in this same edit.
  */
 export function evaluateAgentEdit(
   canonicalText: string,
@@ -73,7 +78,7 @@ export function evaluateAgentEdit(
   const canonical = parse(canonicalText);
 
   const lost = detectLostComments(canonical, current);
-  const deletionGraph = new Map([...canonical.comments, ...current.comments].map((c) => [c.id, c]));
+  const deletionGraph = new Map([...current.comments, ...canonical.comments].map((c) => [c.id, c]));
 
   const removedSet = new Set(lost.filter((c) => confirmed.has(c.id)).map((c) => c.id));
   for (let grew = true; grew; ) {

--- a/packages/cli/src/gate.ts
+++ b/packages/cli/src/gate.ts
@@ -56,6 +56,13 @@ export interface AgentEditEvaluation {
  * leaves the caller to reverse-engineer which reply id it's missing. Since the code already knows
  * exactly which comments dangle, they're reported through `unconfirmed` instead (alongside newly-
  * orphaned roots), so `wait`'s `confirm_required` response names the exact ids to add next time.
+ *
+ * That dangling scan has to look past `current` alone: an edit can delete a reply object outright
+ * (not just leave it dangling) in the same breath as orphaning its parent. Scanning only `current`
+ * would never see that reply at all — it's simply gone, so nothing flags its removal as needing
+ * confirmation, and it's deleted with no acknowledgement. `deletionGraph` unions in `canonical` so
+ * an outright-deleted descendant is still found (and still has to be named), current's copy taking
+ * precedence for anything that still exists there.
  */
 export function evaluateAgentEdit(
   canonicalText: string,
@@ -66,11 +73,12 @@ export function evaluateAgentEdit(
   const canonical = parse(canonicalText);
 
   const lost = detectLostComments(canonical, current);
+  const deletionGraph = new Map([...canonical.comments, ...current.comments].map((c) => [c.id, c]));
 
   const removedSet = new Set(lost.filter((c) => confirmed.has(c.id)).map((c) => c.id));
   for (let grew = true; grew; ) {
     grew = false;
-    for (const c of current.comments) {
+    for (const c of deletionGraph.values()) {
       if (c.parentId !== undefined && removedSet.has(c.parentId) && confirmed.has(c.id) && !removedSet.has(c.id)) {
         removedSet.add(c.id);
         grew = true;
@@ -84,9 +92,10 @@ export function evaluateAgentEdit(
     comments: current.comments.filter((c) => !removedSet.has(c.id)),
   };
 
-  // Still-standing replies whose parent is about to be removed but who weren't themselves
-  // confirmed — exactly what would fail as `missing_parent` below, named instead of inferred.
-  const dangling = current.comments.filter((c) => c.parentId !== undefined && removedSet.has(c.parentId) && !removedSet.has(c.id));
+  // A descendant of something being removed that wasn't itself confirmed — whether it's still
+  // standing in `current` (would fail as `missing_parent` below) or was deleted outright in this
+  // same edit (never reaches `accepted`/integrity at all, so nothing else would catch it).
+  const dangling = [...deletionGraph.values()].filter((c) => c.parentId !== undefined && removedSet.has(c.parentId) && !removedSet.has(c.id));
   const danglingIds = new Set(dangling.map((c) => c.id));
   const unconfirmed = [...lost.filter((c) => !confirmed.has(c.id)), ...dangling];
 

--- a/packages/cli/src/gate.ts
+++ b/packages/cli/src/gate.ts
@@ -17,7 +17,9 @@ export interface AgentEditEvaluation {
   integrityErrors: IntegrityError[];
   /** Span comments newly orphaned by this edit (link removed vs canonical). */
   lost: Comment[];
-  /** Lost comments not yet acknowledged via --confirmed-comment-deletion. */
+  /** Comments the caller still needs to acknowledge via --confirmed-comment-deletion before this
+   *  edit can be accepted: newly-orphaned roots, plus any reply left dangling because a confirmed
+   *  parent was removed out from under it without its own id being confirmed too. */
   unconfirmed: Comment[];
   /** Confirmed-lost comment ids removed from the accepted document. */
   removedIds: string[];
@@ -48,6 +50,12 @@ export interface AgentEditEvaluation {
  * when that descendant's own id is *also* in `confirmed` — an unconfirmed
  * reply is left in place (and surfaces as `missing_parent`) rather than
  * silently deleted, so every removed comment is still one the caller named.
+ *
+ * A parent that IS confirmed but leaves an unconfirmed reply behind (the reply's own id was never
+ * named) would otherwise surface only as a bare `missing_parent` integrity error — correct, but it
+ * leaves the caller to reverse-engineer which reply id it's missing. Since the code already knows
+ * exactly which comments dangle, they're reported through `unconfirmed` instead (alongside newly-
+ * orphaned roots), so `wait`'s `confirm_required` response names the exact ids to add next time.
  */
 export function evaluateAgentEdit(
   canonicalText: string,
@@ -58,7 +66,6 @@ export function evaluateAgentEdit(
   const canonical = parse(canonicalText);
 
   const lost = detectLostComments(canonical, current);
-  const unconfirmed = lost.filter((c) => !confirmed.has(c.id));
 
   const removedSet = new Set(lost.filter((c) => confirmed.has(c.id)).map((c) => c.id));
   for (let grew = true; grew; ) {
@@ -77,7 +84,15 @@ export function evaluateAgentEdit(
     comments: current.comments.filter((c) => !removedSet.has(c.id)),
   };
 
-  const integrityErrors = checkIntegrity(accepted).errors.filter((e) => e.code !== "span_missing_link");
+  // Still-standing replies whose parent is about to be removed but who weren't themselves
+  // confirmed — exactly what would fail as `missing_parent` below, named instead of inferred.
+  const dangling = current.comments.filter((c) => c.parentId !== undefined && removedSet.has(c.parentId) && !removedSet.has(c.id));
+  const danglingIds = new Set(dangling.map((c) => c.id));
+  const unconfirmed = [...lost.filter((c) => !confirmed.has(c.id)), ...dangling];
+
+  const integrityErrors = checkIntegrity(accepted).errors.filter(
+    (e) => e.code !== "span_missing_link" && !(e.code === "missing_parent" && e.commentId !== undefined && danglingIds.has(e.commentId)),
+  );
 
   return {
     integrityOk: integrityErrors.length === 0,

--- a/packages/cli/src/gate.ts
+++ b/packages/cli/src/gate.ts
@@ -30,12 +30,24 @@ export interface AgentEditEvaluation {
 /**
  * Evaluate an agent's edit before accepting it as canonical:
  *  - newly orphaned span comments (anchor link removed) require confirmation;
- *  - on confirmation those comment objects are removed from the document;
+ *  - on confirmation those comment objects — and any of their replies that are
+ *    ALSO explicitly confirmed, transitively — are removed from the document;
  *  - any *structural* corruption (dangling links, duplicate/malformed ids,
  *    a reply with a link, a missing parent) is a hard error.
  *
  * `span_missing_link` is deliberately excluded from the hard-error set because
  * it is the orphaned-comment condition the confirm gate already handles.
+ *
+ * A reply is never itself "lost" (`detectLostComments` only ever reports span
+ * comments — a reply has no anchor link to lose), so confirming just the
+ * orphaned parent's id silently left its replies behind with a dangling
+ * `parentId`, which then failed as `missing_parent` even when the caller HAD
+ * listed those reply ids in `confirmed` — nothing ever cross-referenced them.
+ * The fixpoint loop below closes that gap: it starts from confirmed, newly-
+ * orphaned roots and pulls in each of their descendants in turn, but only
+ * when that descendant's own id is *also* in `confirmed` — an unconfirmed
+ * reply is left in place (and surfaces as `missing_parent`) rather than
+ * silently deleted, so every removed comment is still one the caller named.
  */
 export function evaluateAgentEdit(
   canonicalText: string,
@@ -47,8 +59,18 @@ export function evaluateAgentEdit(
 
   const lost = detectLostComments(canonical, current);
   const unconfirmed = lost.filter((c) => !confirmed.has(c.id));
-  const removedIds = lost.filter((c) => confirmed.has(c.id)).map((c) => c.id);
-  const removedSet = new Set(removedIds);
+
+  const removedSet = new Set(lost.filter((c) => confirmed.has(c.id)).map((c) => c.id));
+  for (let grew = true; grew; ) {
+    grew = false;
+    for (const c of current.comments) {
+      if (c.parentId !== undefined && removedSet.has(c.parentId) && confirmed.has(c.id) && !removedSet.has(c.id)) {
+        removedSet.add(c.id);
+        grew = true;
+      }
+    }
+  }
+  const removedIds = [...removedSet];
 
   const accepted: ParsedDocument = {
     body: current.body,

--- a/packages/cli/test/gate.test.ts
+++ b/packages/cli/test/gate.test.ts
@@ -96,4 +96,32 @@ describe("evaluateAgentEdit — descendant confirmation", () => {
     expect(ev.unconfirmed).toEqual([]);
     expect(ev.integrityOk).toBe(true);
   });
+
+  it("requires confirmation for a reply deleted outright from current, not just left dangling", () => {
+    // This edit didn't just orphan the root and leave the reply in place — it removed the reply
+    // object entirely, so it's present in canonical but absent from current altogether. Nothing in
+    // current alone can reveal that a reply ever existed there, let alone that its removal was never
+    // confirmed — the descendant scan has to fall back to canonical to still catch it.
+    const currentWithoutReply = serialize({ body: "Use SQLite now.", comments: [comment] });
+    const ev = evaluateAgentEdit(canonicalWithReply, currentWithoutReply, new Set(["cmt-abc123"]));
+    expect(ev.removedIds).toEqual(["cmt-abc123"]);
+    expect(ev.unconfirmed.map((c) => c.id)).toEqual(["cmt-rep111"]);
+    expect(ev.integrityOk).toBe(true); // gated via `unconfirmed`, same as any other dangling descendant
+  });
+
+  it("requires confirmation for a grandchild deleted outright, even with its parent reply confirmed and intact", () => {
+    const currentWithoutGrandchild = serialize({ body: "Use SQLite now.", comments: [comment, reply] });
+    const ev = evaluateAgentEdit(canonicalWithGrandchild, currentWithoutGrandchild, new Set(["cmt-abc123", "cmt-rep111"]));
+    expect(new Set(ev.removedIds)).toEqual(new Set(["cmt-abc123", "cmt-rep111"]));
+    expect(ev.unconfirmed.map((c) => c.id)).toEqual(["cmt-rep222"]);
+    expect(ev.integrityOk).toBe(true);
+  });
+
+  it("accepts an outright-deleted descendant once it's also confirmed", () => {
+    const currentWithoutReply = serialize({ body: "Use SQLite now.", comments: [comment] });
+    const ev = evaluateAgentEdit(canonicalWithReply, currentWithoutReply, new Set(["cmt-abc123", "cmt-rep111"]));
+    expect(new Set(ev.removedIds)).toEqual(new Set(["cmt-abc123", "cmt-rep111"]));
+    expect(ev.unconfirmed).toEqual([]);
+    expect(ev.integrityOk).toBe(true);
+  });
 });

--- a/packages/cli/test/gate.test.ts
+++ b/packages/cli/test/gate.test.ts
@@ -39,3 +39,42 @@ describe("evaluateAgentEdit", () => {
     expect(ev.integrityErrors.map((e) => e.code)).toContain("dangling_link");
   });
 });
+
+describe("evaluateAgentEdit — descendant confirmation", () => {
+  const reply = { id: "cmt-rep111", parentId: "cmt-abc123", author: "a", date: "d", resolved: false, text: "reply" };
+  const grandchild = { id: "cmt-rep222", parentId: "cmt-rep111", author: "a", date: "d", resolved: false, text: "reply-of-reply" };
+  const canonicalWithReply = serialize({ body: "Use [Postgres](#cmt-abc123).", comments: [comment, reply] });
+  const lostWithReply = serialize({ body: "Use SQLite now.", comments: [comment, reply] });
+  const canonicalWithGrandchild = serialize({ body: "Use [Postgres](#cmt-abc123).", comments: [comment, reply, grandchild] });
+  const lostWithGrandchild = serialize({ body: "Use SQLite now.", comments: [comment, reply, grandchild] });
+
+  it("leaves an unconfirmed reply behind as a missing_parent error, rather than silently dropping it", () => {
+    const ev = evaluateAgentEdit(canonicalWithReply, lostWithReply, new Set(["cmt-abc123"]));
+    expect(ev.removedIds).toEqual(["cmt-abc123"]);
+    expect(parse(ev.acceptedText).comments.map((c) => c.id)).toEqual(["cmt-rep111"]);
+    expect(ev.integrityOk).toBe(false);
+    expect(ev.integrityErrors.map((e) => e.code)).toContain("missing_parent");
+  });
+
+  it("removes a confirmed reply along with its confirmed orphaned parent", () => {
+    const ev = evaluateAgentEdit(canonicalWithReply, lostWithReply, new Set(["cmt-abc123", "cmt-rep111"]));
+    expect(new Set(ev.removedIds)).toEqual(new Set(["cmt-abc123", "cmt-rep111"]));
+    expect(parse(ev.acceptedText).comments).toEqual([]);
+    expect(ev.integrityOk).toBe(true);
+  });
+
+  it("cascades transitively through a reply-of-reply when the whole chain is confirmed", () => {
+    const ev = evaluateAgentEdit(canonicalWithGrandchild, lostWithGrandchild, new Set(["cmt-abc123", "cmt-rep111", "cmt-rep222"]));
+    expect(new Set(ev.removedIds)).toEqual(new Set(["cmt-abc123", "cmt-rep111", "cmt-rep222"]));
+    expect(parse(ev.acceptedText).comments).toEqual([]);
+    expect(ev.integrityOk).toBe(true);
+  });
+
+  it("does not skip ahead past an unconfirmed middle reply, even if the grandchild is confirmed", () => {
+    const ev = evaluateAgentEdit(canonicalWithGrandchild, lostWithGrandchild, new Set(["cmt-abc123", "cmt-rep222"]));
+    expect(new Set(ev.removedIds)).toEqual(new Set(["cmt-abc123"]));
+    expect(parse(ev.acceptedText).comments.map((c) => c.id).sort()).toEqual(["cmt-rep111", "cmt-rep222"]);
+    expect(ev.integrityOk).toBe(false);
+    expect(ev.integrityErrors.map((e) => e.code)).toContain("missing_parent");
+  });
+});

--- a/packages/cli/test/gate.test.ts
+++ b/packages/cli/test/gate.test.ts
@@ -48,12 +48,15 @@ describe("evaluateAgentEdit — descendant confirmation", () => {
   const canonicalWithGrandchild = serialize({ body: "Use [Postgres](#cmt-abc123).", comments: [comment, reply, grandchild] });
   const lostWithGrandchild = serialize({ body: "Use SQLite now.", comments: [comment, reply, grandchild] });
 
-  it("leaves an unconfirmed reply behind as a missing_parent error, rather than silently dropping it", () => {
+  it("surfaces an unconfirmed dangling reply as `unconfirmed`, naming exactly what to confirm next — rather than a bare missing_parent error", () => {
     const ev = evaluateAgentEdit(canonicalWithReply, lostWithReply, new Set(["cmt-abc123"]));
     expect(ev.removedIds).toEqual(["cmt-abc123"]);
     expect(parse(ev.acceptedText).comments.map((c) => c.id)).toEqual(["cmt-rep111"]);
-    expect(ev.integrityOk).toBe(false);
-    expect(ev.integrityErrors.map((e) => e.code)).toContain("missing_parent");
+    // The reply isn't silently dropped OR left to fail as a generic integrity error — it's named
+    // in `unconfirmed`, same signal as a newly-orphaned root, so `wait`'s confirm_required response
+    // tells the caller exactly which id to add next time instead of them inferring it from an error.
+    expect(ev.unconfirmed.map((c) => c.id)).toEqual(["cmt-rep111"]);
+    expect(ev.integrityOk).toBe(true);
   });
 
   it("removes a confirmed reply along with its confirmed orphaned parent", () => {
@@ -74,7 +77,23 @@ describe("evaluateAgentEdit — descendant confirmation", () => {
     const ev = evaluateAgentEdit(canonicalWithGrandchild, lostWithGrandchild, new Set(["cmt-abc123", "cmt-rep222"]));
     expect(new Set(ev.removedIds)).toEqual(new Set(["cmt-abc123"]));
     expect(parse(ev.acceptedText).comments.map((c) => c.id).sort()).toEqual(["cmt-rep111", "cmt-rep222"]);
-    expect(ev.integrityOk).toBe(false);
-    expect(ev.integrityErrors.map((e) => e.code)).toContain("missing_parent");
+    // Only the middle reply dangles (its parent was removed); the grandchild's own parent — the
+    // middle reply — is still present in the accepted doc, so it isn't itself flagged.
+    expect(ev.unconfirmed.map((c) => c.id)).toEqual(["cmt-rep111"]);
+    expect(ev.integrityOk).toBe(true);
+  });
+
+  it("cascades regardless of array order — a descendant listed before its ancestor still gets pulled in", () => {
+    // Reversed order: grandchild, then reply, then root. A single non-repeating pass over the
+    // array (in this order) would reach the grandchild before its parent (the reply) has been
+    // added to the removal set, and never revisit it — so it would wrongly leave the grandchild
+    // dangling. The fixpoint loop (repeat until nothing new is added) doesn't depend on order.
+    const reversedCanonical = serialize({ body: "Use [Postgres](#cmt-abc123).", comments: [grandchild, reply, comment] });
+    const reversedLost = serialize({ body: "Use SQLite now.", comments: [grandchild, reply, comment] });
+    const ev = evaluateAgentEdit(reversedCanonical, reversedLost, new Set(["cmt-abc123", "cmt-rep111", "cmt-rep222"]));
+    expect(new Set(ev.removedIds)).toEqual(new Set(["cmt-abc123", "cmt-rep111", "cmt-rep222"]));
+    expect(parse(ev.acceptedText).comments).toEqual([]);
+    expect(ev.unconfirmed).toEqual([]);
+    expect(ev.integrityOk).toBe(true);
   });
 });

--- a/packages/cli/test/gate.test.ts
+++ b/packages/cli/test/gate.test.ts
@@ -124,4 +124,17 @@ describe("evaluateAgentEdit — descendant confirmation", () => {
     expect(ev.unconfirmed).toEqual([]);
     expect(ev.integrityOk).toBe(true);
   });
+
+  it("uses canonical parentage to catch a descendant current reparented away, not current's relabeled shape", () => {
+    // The reply's *current* object no longer claims any relation to cmt-abc123 at all — its
+    // parentId is gone and it's now `anchor: "doc"`, as if it had always been an independent
+    // top-level comment. If the graph trusted current's shape for ancestry, this would silently
+    // succeed with the reply detached and never named. Canonical still records it as a reply to
+    // the parent being removed, so it must still be confirmed.
+    const reparented = { id: "cmt-rep111", anchor: "doc" as const, author: "a", date: "d", resolved: false, text: "reply" };
+    const currentReparented = serialize({ body: "Use SQLite now.", comments: [comment, reparented] });
+    const ev = evaluateAgentEdit(canonicalWithReply, currentReparented, new Set(["cmt-abc123"]));
+    expect(ev.removedIds).toEqual(["cmt-abc123"]);
+    expect(ev.unconfirmed.map((c) => c.id)).toEqual(["cmt-rep111"]);
+  });
 });

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -87,6 +87,13 @@ anchored comment is an inline Markdown link whose href is the comment id:
 - **Span comment**: exactly one in-body `[text](#cmt-id)` link; no `parentId`/`anchor`.
 - **Reply / answer**: `parentId` set, no link. An answer carries `selected: [labels]`.
 - **Document-level**: `anchor: "doc"`, no link.
+- **Incorporating an answer**: when you fold a question's answer into the body, keep the
+  anchor link — rewrite the linked text from the open question to the resulting statement,
+  don't delete the link. Anchoring is id-based, not text-based, so the link survives the
+  rewrite (`[Team size is fixed at 3.](#cmt-m4n5o6)` is fine). Signal that the thread is done
+  with `may_resolve` (below), not by removing its anchor. Only actually orphan a span
+  comment (drop its link) when its topic is genuinely gone, not merely answered — and then
+  follow the `confirm_required` protocol (see § Turn-taking).
 - **Question**: `question.multiSelect` false = pick one (radio), true = pick many
   (checkbox); the human may also answer with free text.
 - Generate ids as `cmt-` + 6 base36 characters.
@@ -158,7 +165,15 @@ the plan, then call `wait`.** Do not pass `--cursor` and do not hand-manage it.
      listening. `humanLocked: false`.
    - `confirm_required` — your edit removed an anchored comment (`lost`). If
      intentional, re-run with `--confirmed-comment-deletion=<ids>`; otherwise
-     restore the anchor link and try again.
+     restore the anchor link and try again. Deleting a comment that has replies
+     orphans those replies too — `lost` only lists the comment itself, never its
+     descendants, so include every reply/reply-of-reply id in
+     `--confirmed-comment-deletion` as well, or you'll hit `missing_parent` on
+     the next `wait`. **These two options are the only remedies.** Never change a
+     comment's `anchor` or `parentId` field to dodge this gate — e.g. relabeling
+     an orphaned span comment as `anchor: "doc"` to make the missing-link check
+     stop applying to it. That's not a documented recovery path; it silently
+     miscategorizes the comment and routes around the confirm gate entirely.
    - `integrity_error` — the document violates the comment grammar (`errors`).
      Fix it and wait again.
    - `closed` — the planning session is over; stop the loop. `reason` says what to do next:


### PR DESCRIPTION
- The agent was rewriting a comment's `anchor` field to `"doc"` to sidestep the documented `confirm_required` recovery protocol whenever a body edit removed the comment's in-body anchor link, instead of using either sanctioned path (restore the link, or `--confirmed-comment-deletion`).
- Adds explicit guidance under `## Document format`: when incorporating a question's answer into the body, keep the anchor link (rewrite the linked text, don't delete the link) instead of orphaning the comment.
- Adds explicit guidance under the `confirm_required` status: deleting a comment with replies orphans those replies too (`lost` only reports the comment itself, not descendants) — include every descendant id in `--confirmed-comment-deletion`, and never touch `anchor`/`parentId` to route around the gate.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/59?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated guidance for folding question-answer content into plans: preserve existing anchored references while rewriting linked text, resolve threads appropriately, and only remove links when the topic truly disappears.
  * Expanded “confirmation required” recovery steps, including the exact retry inputs (deleted comment and all reply descendants) and safeguards against attempting to bypass confirmation via metadata changes.
* **Bug Fixes**
  * Improved agent edit evaluation so confirmation correctly includes reply descendants even when they’re removed entirely, preventing premature or inconsistent deletions.
* **Tests**
  * Added new multi-level descendant cases covering deleted-from-current replies and grandchildren, validating correct acceptance once required confirmations are provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->