### PR TITLE
feat(cli): add `inplan comment` to stamp reply/doc comments with a real date

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1328,10 +1328,13 @@ export async function doUpload(file: string, args: string[]): Promise<void> {
 /** `comment` (see ./commentAdd.ts) only knows how to rewrite a local file — reject it before
  *  either cloud path (`--remote DOC_ID`, or a promoted local doc that `routeFor` sends to the
  *  Supabase backend) reaches `runRemote`, which has no "comment" case and would otherwise fall
- *  through into `waitCycle` and silently do the wrong thing. */
-function rejectCommentOnCloud(cmd: string): void {
+ *  through into `waitCycle` and silently do the wrong thing. `hasLocalFile` distinguishes the
+ *  two: a promoted doc genuinely has a local file to hand-edit as a fallback; a pure `--remote
+ *  DOC_ID` has no local file at all, so that advice would be nonsensical there. */
+function rejectCommentOnCloud(cmd: string, hasLocalFile: boolean): void {
   if (cmd !== "comment") return;
-  process.stderr.write("inplan comment: cloud docs aren't supported yet — edit the file directly and `wait`.\n");
+  const fallback = hasLocalFile ? " — edit the file directly and `wait`." : ".";
+  process.stderr.write(`inplan comment: cloud docs aren't supported yet${fallback}\n`);
   process.exit(64);
 }
 
@@ -1428,7 +1431,7 @@ async function main(): Promise<void> {
     process.stderr.write(
       "usage: inplan <open|wait|signal> <file|--remote DOC_ID> [--model NAME] [--cursor N] [--confirmed-comment-deletion=a,b] [--done] [--reload]\n" +
         '       inplan message <file> "your message"   (relay a note to the editor status bar)\n' +
-        "       inplan comment <file> (--parent-id <id>|--doc) --text \"...\" [--model NAME] [--may-resolve] [--question <json>]\n" +
+        "       inplan comment <file> (--parent-id <id>|--doc|--span \"text\") --text \"...\" [--model NAME] [--may-resolve] [--question <json>]\n" +
         "       inplan relay [--hook <kind> | --text <s> [--activity]]   (agent-hook → editor; resolves the active doc)\n" +
         "       inplan status  <file>\n" +
         "       inplan upload  <file> [--org <slug>] [--repo <name>] [--path <p>] [--evict-lru]   (Collaborate on Cloud)\n" +
@@ -1451,7 +1454,7 @@ async function main(): Promise<void> {
   // resolving a local file/sidecar.
   const remoteDocId = getFlag(args, "remote");
   if (remoteDocId) {
-    rejectCommentOnCloud(cmd);
+    rejectCommentOnCloud(cmd, false);
     await runRemote(cmd, remoteDocId, explicitCursor, confirmed, args, undefined, model);
     return;
   }
@@ -1496,7 +1499,7 @@ async function main(): Promise<void> {
     return;
   }
   if (route.kind === "cloud") {
-    rejectCommentOnCloud(cmd);
+    rejectCommentOnCloud(cmd, true);
     // `file` is this promoted local doc — pass it so a Save-locally request can
     // bring the body back to disk here.
     await runRemote(cmd, route.docId, explicitCursor, confirmed, args, file, model);
@@ -1542,20 +1545,21 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  // Append a reply/answer or document-level comment with the CLI's own real timestamp, instead
-  // of the agent hand-writing the JSON block (and having to invent the `date` field itself — see
-  // ./commentAdd.ts). Just rewrites the file; the agent's next `wait` picks it up like any other
-  // edit. Usage: `inplan comment <file> (--parent-id <id>|--doc) --text "..." [--model NAME]
-  // [--may-resolve] [--question <json>]`.
+  // Append a comment (reply/answer, document-level, or span-anchored) with the CLI's own real
+  // timestamp, instead of the agent hand-writing the JSON block (and having to invent the `date`
+  // field itself — see ./commentAdd.ts). Just rewrites the file; the agent's next `wait` picks it
+  // up like any other edit. Usage: `inplan comment <file> (--parent-id <id>|--doc|--span "text")
+  // --text "..." [--model NAME] [--may-resolve] [--question <json>]`.
   if (cmd === "comment") {
     const text = getFlag(args, "text");
     if (!text) {
       process.stderr.write(
-        'inplan comment: usage: inplan comment <file> (--parent-id <id>|--doc) --text "..." [--model NAME] [--may-resolve] [--question <json>]\n',
+        'inplan comment: usage: inplan comment <file> (--parent-id <id>|--doc|--span "exact body text") --text "..." [--model NAME] [--may-resolve] [--question <json>]\n',
       );
       process.exit(64);
     }
     const parentId = getFlag(args, "parent-id");
+    const span = getFlag(args, "span");
     const questionRaw = getFlag(args, "question");
     let question: unknown;
     if (questionRaw !== undefined) {
@@ -1567,12 +1571,17 @@ async function main(): Promise<void> {
       }
     }
     try {
+      // Plain read-modify-write, no lock: a concurrent save from the human (e.g. Instant mode,
+      // live editing) in this window is a last-writer-wins race — no worse than a hand-edit via
+      // Edit/Write ever was, but worth naming now that this is a fast, easily-repeatable command
+      // rather than a one-off manual edit.
       const currentText = readFileSync(file, "utf8");
       const { text: nextText, comment } = addComment(currentText, {
         text,
         author: agentAuthorFor(model),
         ...(parentId ? { parentId } : {}),
         ...(hasFlag(args, "doc") ? { doc: true } : {}),
+        ...(span ? { span } : {}),
         ...(question ? { question } : {}),
         mayResolve: hasFlag(args, "may-resolve"),
       });

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -19,7 +19,6 @@ import {
   type LogEntry,
   LogEventType,
   parse,
-  type Question,
   readGlobalSettings,
   readLog,
   readStatus,
@@ -1326,6 +1325,16 @@ export async function doUpload(file: string, args: string[]): Promise<void> {
   output({ status: "uploaded", cloudDocId, ...(org?.slug ? { locator: { org: org.slug, repo, path } } : {}) });
 }
 
+/** `comment` (see ./commentAdd.ts) only knows how to rewrite a local file — reject it before
+ *  either cloud path (`--remote DOC_ID`, or a promoted local doc that `routeFor` sends to the
+ *  Supabase backend) reaches `runRemote`, which has no "comment" case and would otherwise fall
+ *  through into `waitCycle` and silently do the wrong thing. */
+function rejectCommentOnCloud(cmd: string): void {
+  if (cmd !== "comment") return;
+  process.stderr.write("inplan comment: cloud docs aren't supported yet — edit the file directly and `wait`.\n");
+  process.exit(64);
+}
+
 /** Where an `open`/`wait`/`signal` on a local path should run, per the doc's status. */
 type Route = { kind: "local" } | { kind: "cloud"; docId: string } | { kind: "reconcile"; docId: string };
 
@@ -1442,10 +1451,7 @@ async function main(): Promise<void> {
   // resolving a local file/sidecar.
   const remoteDocId = getFlag(args, "remote");
   if (remoteDocId) {
-    if (cmd === "comment") {
-      process.stderr.write("inplan comment: cloud docs (--remote) aren't supported yet — edit the file directly and `wait`.\n");
-      process.exit(64);
-    }
+    rejectCommentOnCloud(cmd);
     await runRemote(cmd, remoteDocId, explicitCursor, confirmed, args, undefined, model);
     return;
   }
@@ -1490,6 +1496,7 @@ async function main(): Promise<void> {
     return;
   }
   if (route.kind === "cloud") {
+    rejectCommentOnCloud(cmd);
     // `file` is this promoted local doc — pass it so a Save-locally request can
     // bring the body back to disk here.
     await runRemote(cmd, route.docId, explicitCursor, confirmed, args, file, model);
@@ -1550,10 +1557,10 @@ async function main(): Promise<void> {
     }
     const parentId = getFlag(args, "parent-id");
     const questionRaw = getFlag(args, "question");
-    let question: Question | undefined;
+    let question: unknown;
     if (questionRaw !== undefined) {
       try {
-        question = JSON.parse(questionRaw) as Question;
+        question = JSON.parse(questionRaw);
       } catch {
         process.stderr.write("inplan comment: --question must be valid JSON\n");
         process.exit(64);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -19,6 +19,7 @@ import {
   type LogEntry,
   LogEventType,
   parse,
+  type Question,
   readGlobalSettings,
   readLog,
   readStatus,
@@ -34,6 +35,7 @@ import { checkForUpdate, selfUpdate, UPDATE_PKG } from "./update";
 import { runningEditorPid } from "./editorProcess";
 import { applyGatedEdit } from "./applyEdit";
 import { evaluateAgentEdit } from "./gate";
+import { addComment, AddCommentError } from "./commentAdd";
 import { docPaths, sidecarRoot, type DocPaths } from "./paths";
 import { loadPluginGate, type PluginGate } from "./pluginGate";
 import { announcePresence } from "./presence";
@@ -1413,10 +1415,11 @@ async function main(): Promise<void> {
       .filter(Boolean),
   );
 
-  if (!cmd || !["open", "wait", "signal", "message", "relay", "status", "promote", "demote", "upload"].includes(cmd)) {
+  if (!cmd || !["open", "wait", "signal", "message", "comment", "relay", "status", "promote", "demote", "upload"].includes(cmd)) {
     process.stderr.write(
       "usage: inplan <open|wait|signal> <file|--remote DOC_ID> [--model NAME] [--cursor N] [--confirmed-comment-deletion=a,b] [--done] [--reload]\n" +
         '       inplan message <file> "your message"   (relay a note to the editor status bar)\n' +
+        "       inplan comment <file> (--parent-id <id>|--doc) --text \"...\" [--model NAME] [--may-resolve] [--question <json>]\n" +
         "       inplan relay [--hook <kind> | --text <s> [--activity]]   (agent-hook → editor; resolves the active doc)\n" +
         "       inplan status  <file>\n" +
         "       inplan upload  <file> [--org <slug>] [--repo <name>] [--path <p>] [--evict-lru]   (Collaborate on Cloud)\n" +
@@ -1439,6 +1442,10 @@ async function main(): Promise<void> {
   // resolving a local file/sidecar.
   const remoteDocId = getFlag(args, "remote");
   if (remoteDocId) {
+    if (cmd === "comment") {
+      process.stderr.write("inplan comment: cloud docs (--remote) aren't supported yet — edit the file directly and `wait`.\n");
+      process.exit(64);
+    }
     await runRemote(cmd, remoteDocId, explicitCursor, confirmed, args, undefined, model);
     return;
   }
@@ -1526,6 +1533,52 @@ async function main(): Promise<void> {
   if (cmd !== "open" && !existsSync(file)) {
     process.stderr.write(`inplan ${cmd}: file not found: ${file}\n`);
     process.exit(1);
+  }
+
+  // Append a reply/answer or document-level comment with the CLI's own real timestamp, instead
+  // of the agent hand-writing the JSON block (and having to invent the `date` field itself — see
+  // ./commentAdd.ts). Just rewrites the file; the agent's next `wait` picks it up like any other
+  // edit. Usage: `inplan comment <file> (--parent-id <id>|--doc) --text "..." [--model NAME]
+  // [--may-resolve] [--question <json>]`.
+  if (cmd === "comment") {
+    const text = getFlag(args, "text");
+    if (!text) {
+      process.stderr.write(
+        'inplan comment: usage: inplan comment <file> (--parent-id <id>|--doc) --text "..." [--model NAME] [--may-resolve] [--question <json>]\n',
+      );
+      process.exit(64);
+    }
+    const parentId = getFlag(args, "parent-id");
+    const questionRaw = getFlag(args, "question");
+    let question: Question | undefined;
+    if (questionRaw !== undefined) {
+      try {
+        question = JSON.parse(questionRaw) as Question;
+      } catch {
+        process.stderr.write("inplan comment: --question must be valid JSON\n");
+        process.exit(64);
+      }
+    }
+    try {
+      const currentText = readFileSync(file, "utf8");
+      const { text: nextText, comment } = addComment(currentText, {
+        text,
+        author: agentAuthorFor(model),
+        ...(parentId ? { parentId } : {}),
+        ...(hasFlag(args, "doc") ? { doc: true } : {}),
+        ...(question ? { question } : {}),
+        mayResolve: hasFlag(args, "may-resolve"),
+      });
+      writeFileSync(file, nextText);
+      output({ status: "commented", id: comment.id, date: comment.date, author: comment.author });
+    } catch (err) {
+      if (err instanceof AddCommentError) {
+        process.stderr.write(`${err.message}\n`);
+        process.exit(64);
+      }
+      throw err;
+    }
+    return;
   }
 
   if (cmd === "open") {

--- a/packages/cli/src/commentAdd.ts
+++ b/packages/cli/src/commentAdd.ts
@@ -1,16 +1,17 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //
-// Construct and append a reply/answer or document-level comment as a pure text transform, so
-// `date` is stamped from the CLI's own clock instead of a value the agent has to invent by hand
-// when it hand-edits the JSON block (agents have no real clock access, so those values were
-// often rounded guesses — inconsistent with, and sometimes later than, real timestamps the app
-// stamps for the human's own comments, which corrupts `orderComments`' chronological sort).
+// Construct and append a comment (reply/answer, document-level, or span-anchored) as a pure text
+// transform, so `date` is stamped from the CLI's own clock instead of a value the agent has to
+// invent by hand when it hand-edits the JSON block (agents have no real clock access, so those
+// values were often rounded guesses — inconsistent with, and sometimes later than, real
+// timestamps the app stamps for the human's own comments, which corrupts `orderComments`'
+// chronological sort).
 //
-// Deliberately excludes span comments: placing a new `[text](#cmt-id)` anchor link at the right
-// spot in the body is a body edit, which still goes through the normal Edit/Write + `wait` path.
-// The result is just appended to the file — no gate/channel interaction here — because the
-// agent's very next `wait` call evaluates and applies whatever is on disk exactly as it would an
-// agent hand-edit, so this only needs to produce a correctly-shaped, integrity-clean document.
+// A span comment additionally rewrites the body: `span` (the exact text to anchor, which must
+// appear exactly once so the target is unambiguous) gets wrapped in `[span](#cmt-id)` in place.
+// The result is just written to the file — no gate/channel interaction here — because the agent's
+// very next `wait` call evaluates and applies whatever is on disk exactly as it would an agent
+// hand-edit, so this only needs to produce a correctly-shaped, integrity-clean document.
 
 import { checkIntegrity, genId, parse, serialize, type Choice, type Comment, type ParsedDocument, type Question } from "@inplan/core";
 
@@ -19,10 +20,14 @@ export class AddCommentError extends Error {}
 export interface AddCommentInput {
   text: string;
   author: string;
-  /** Reply/answer target. Mutually exclusive with `doc`. */
+  /** Reply/answer target. Mutually exclusive with `doc`/`span`. */
   parentId?: string;
-  /** Document-level root comment (`anchor: "doc"`). Mutually exclusive with `parentId`. */
+  /** Document-level root comment (`anchor: "doc"`). Mutually exclusive with `parentId`/`span`. */
   doc?: boolean;
+  /** Span comment: the exact body text to anchor — wrapped in place as `[span](#cmt-id)`. Must
+   *  appear exactly once in the body (a repeated substring is rejected as ambiguous rather than
+   *  guessing which occurrence was meant). Mutually exclusive with `parentId`/`doc`. */
+  span?: string;
   /** Untyped because the caller (the CLI) only has `JSON.parse` output — validated below rather
    *  than trusted via a type assertion, so a syntactically-valid but wrong-shaped `--question`
    *  (`{}`, `"foo"`, a `choices` missing `label`) is rejected instead of getting written into the
@@ -49,17 +54,32 @@ function isQuestion(v: unknown): v is Question {
   return typeof q.multiSelect === "boolean" && Array.isArray(q.choices) && q.choices.every(isChoice);
 }
 
-/** Build the updated document text with the new comment appended. Throws {@link AddCommentError}
- *  on a usage mistake (bad parent, span-comment attempt, a malformed `question`, or a resulting
- *  integrity violation — the last one is defensive; the construction below shouldn't trigger it). */
-export function addComment(currentText: string, input: AddCommentInput): { text: string; comment: Comment } {
-  if (input.parentId && input.doc) {
-    throw new AddCommentError("comment: --parent-id and --doc are mutually exclusive");
-  }
-  if (!input.parentId && !input.doc) {
+/** Wrap `span` in a fresh `[span](#id)` link, in place, in `body`. Throws if `span` doesn't occur
+ *  in the body, or occurs more than once (an ambiguous target — this never guesses). Only ever
+ *  called with a non-empty `span` — {@link addComment}'s target check treats an empty string the
+ *  same as "no --span given" before this is reached. */
+function placeSpanLink(body: string, span: string, id: string): string {
+  const first = body.indexOf(span);
+  if (first === -1) throw new AddCommentError(`comment: --span text not found in the body: ${JSON.stringify(span)}`);
+  if (body.indexOf(span, first + span.length) !== -1) {
     throw new AddCommentError(
-      "comment: pass --parent-id <id> (reply) or --doc (document-level). Span comments need an in-body " +
-        "[text](#cmt-id) link — edit the body directly instead, then `wait`.",
+      `comment: --span text appears more than once in the body, so the target is ambiguous: ${JSON.stringify(span)}. Include more surrounding context to make it unique.`,
+    );
+  }
+  return body.slice(0, first) + `[${span}](#${id})` + body.slice(first + span.length);
+}
+
+/** Build the updated document text with the new comment appended. Throws {@link AddCommentError}
+ *  on a usage mistake (bad parent, bad/ambiguous `--span` text, a malformed `question`, or a
+ *  resulting integrity violation). */
+export function addComment(currentText: string, input: AddCommentInput): { text: string; comment: Comment } {
+  const targetCount = (input.parentId ? 1 : 0) + (input.doc ? 1 : 0) + (input.span ? 1 : 0);
+  if (targetCount > 1) {
+    throw new AddCommentError("comment: --parent-id, --doc, and --span are mutually exclusive");
+  }
+  if (targetCount === 0) {
+    throw new AddCommentError(
+      'comment: pass --parent-id <id> (reply), --doc (document-level), or --span "<exact body text>" (anchored to that text)',
     );
   }
   if (input.question !== undefined && !isQuestion(input.question)) {
@@ -75,7 +95,7 @@ export function addComment(currentText: string, input: AddCommentInput): { text:
   const now = input.now ?? (() => new Date());
   const comment: Comment = {
     id,
-    ...(input.parentId ? { parentId: input.parentId } : { anchor: "doc" as const }),
+    ...(input.parentId ? { parentId: input.parentId } : input.doc ? { anchor: "doc" as const } : {}),
     text: input.text,
     author: input.author,
     date: now().toISOString(),
@@ -84,10 +104,17 @@ export function addComment(currentText: string, input: AddCommentInput): { text:
     ...(input.mayResolve ? { may_resolve: true } : {}),
   };
 
-  const next: ParsedDocument = { body: doc.body, comments: [...doc.comments, comment], version: doc.version };
+  const body = input.span ? placeSpanLink(doc.body, input.span, id) : doc.body;
+  const next: ParsedDocument = { body, comments: [...doc.comments, comment], version: doc.version };
   const integrity = checkIntegrity(next);
   if (!integrity.ok) {
-    throw new AddCommentError(`comment: resulting document failed integrity check: ${integrity.errors.map((e) => e.message).join("; ")}`);
+    // A well-formed add — reply, doc-level, or span (its id is fresh, and wrapping the located
+    // text only adds characters, never removes an existing `](#id)`) — can't introduce corruption
+    // on its own. If this ever fires, the document already had a structural problem before this
+    // call; it isn't something this comment caused.
+    throw new AddCommentError(
+      `comment: the document already had a structural problem before this call (this comment didn't cause it): ${integrity.errors.map((e) => e.message).join("; ")}`,
+    );
   }
   return { text: serialize(next), comment };
 }

--- a/packages/cli/src/commentAdd.ts
+++ b/packages/cli/src/commentAdd.ts
@@ -12,7 +12,7 @@
 // agent's very next `wait` call evaluates and applies whatever is on disk exactly as it would an
 // agent hand-edit, so this only needs to produce a correctly-shaped, integrity-clean document.
 
-import { checkIntegrity, genId, parse, serialize, type Comment, type ParsedDocument, type Question } from "@inplan/core";
+import { checkIntegrity, genId, parse, serialize, type Choice, type Comment, type ParsedDocument, type Question } from "@inplan/core";
 
 export class AddCommentError extends Error {}
 
@@ -23,7 +23,11 @@ export interface AddCommentInput {
   parentId?: string;
   /** Document-level root comment (`anchor: "doc"`). Mutually exclusive with `parentId`. */
   doc?: boolean;
-  question?: Question;
+  /** Untyped because the caller (the CLI) only has `JSON.parse` output — validated below rather
+   *  than trusted via a type assertion, so a syntactically-valid but wrong-shaped `--question`
+   *  (`{}`, `"foo"`, a `choices` missing `label`) is rejected instead of getting written into the
+   *  document as a comment the editor can't render. */
+  question?: unknown;
   /** Sets `may_resolve: true` — the documented way to flag a thread as incorporated,
    *  without setting `resolved` (which stays the human's/app's call). */
   mayResolve?: boolean;
@@ -31,9 +35,23 @@ export interface AddCommentInput {
   now?: () => Date;
 }
 
+function isChoice(v: unknown): v is Choice {
+  if (typeof v !== "object" || v === null) return false;
+  const c = v as Record<string, unknown>;
+  return typeof c.label === "string" && (c.description === undefined || typeof c.description === "string");
+}
+
+/** Runtime shape check for a `--question` payload — `JSON.parse` only guarantees valid JSON, not
+ *  a valid {@link Question} (e.g. `{}` or `"foo"` parse fine but aren't one). */
+function isQuestion(v: unknown): v is Question {
+  if (typeof v !== "object" || v === null) return false;
+  const q = v as Record<string, unknown>;
+  return typeof q.multiSelect === "boolean" && Array.isArray(q.choices) && q.choices.every(isChoice);
+}
+
 /** Build the updated document text with the new comment appended. Throws {@link AddCommentError}
- *  on a usage mistake (bad parent, span-comment attempt, or a resulting integrity violation —
- *  the last one is defensive; the construction below shouldn't be able to trigger it). */
+ *  on a usage mistake (bad parent, span-comment attempt, a malformed `question`, or a resulting
+ *  integrity violation — the last one is defensive; the construction below shouldn't trigger it). */
 export function addComment(currentText: string, input: AddCommentInput): { text: string; comment: Comment } {
   if (input.parentId && input.doc) {
     throw new AddCommentError("comment: --parent-id and --doc are mutually exclusive");
@@ -43,6 +61,9 @@ export function addComment(currentText: string, input: AddCommentInput): { text:
       "comment: pass --parent-id <id> (reply) or --doc (document-level). Span comments need an in-body " +
         "[text](#cmt-id) link — edit the body directly instead, then `wait`.",
     );
+  }
+  if (input.question !== undefined && !isQuestion(input.question)) {
+    throw new AddCommentError('comment: --question must be shaped like { "multiSelect": boolean, "choices": [{ "label": string }, ...] }');
   }
 
   const doc = parse(currentText);

--- a/packages/cli/src/commentAdd.ts
+++ b/packages/cli/src/commentAdd.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Construct and append a reply/answer or document-level comment as a pure text transform, so
+// `date` is stamped from the CLI's own clock instead of a value the agent has to invent by hand
+// when it hand-edits the JSON block (agents have no real clock access, so those values were
+// often rounded guesses — inconsistent with, and sometimes later than, real timestamps the app
+// stamps for the human's own comments, which corrupts `orderComments`' chronological sort).
+//
+// Deliberately excludes span comments: placing a new `[text](#cmt-id)` anchor link at the right
+// spot in the body is a body edit, which still goes through the normal Edit/Write + `wait` path.
+// The result is just appended to the file — no gate/channel interaction here — because the
+// agent's very next `wait` call evaluates and applies whatever is on disk exactly as it would an
+// agent hand-edit, so this only needs to produce a correctly-shaped, integrity-clean document.
+
+import { checkIntegrity, genId, parse, serialize, type Comment, type ParsedDocument, type Question } from "@inplan/core";
+
+export class AddCommentError extends Error {}
+
+export interface AddCommentInput {
+  text: string;
+  author: string;
+  /** Reply/answer target. Mutually exclusive with `doc`. */
+  parentId?: string;
+  /** Document-level root comment (`anchor: "doc"`). Mutually exclusive with `parentId`. */
+  doc?: boolean;
+  question?: Question;
+  /** Sets `may_resolve: true` — the documented way to flag a thread as incorporated,
+   *  without setting `resolved` (which stays the human's/app's call). */
+  mayResolve?: boolean;
+  /** Injectable for tests; defaults to the real clock. */
+  now?: () => Date;
+}
+
+/** Build the updated document text with the new comment appended. Throws {@link AddCommentError}
+ *  on a usage mistake (bad parent, span-comment attempt, or a resulting integrity violation —
+ *  the last one is defensive; the construction below shouldn't be able to trigger it). */
+export function addComment(currentText: string, input: AddCommentInput): { text: string; comment: Comment } {
+  if (input.parentId && input.doc) {
+    throw new AddCommentError("comment: --parent-id and --doc are mutually exclusive");
+  }
+  if (!input.parentId && !input.doc) {
+    throw new AddCommentError(
+      "comment: pass --parent-id <id> (reply) or --doc (document-level). Span comments need an in-body " +
+        "[text](#cmt-id) link — edit the body directly instead, then `wait`.",
+    );
+  }
+
+  const doc = parse(currentText);
+  if (input.parentId && !doc.comments.some((c) => c.id === input.parentId)) {
+    throw new AddCommentError(`comment: no such parent id: ${input.parentId}`);
+  }
+
+  const id = genId(new Set(doc.comments.map((c) => c.id)));
+  const now = input.now ?? (() => new Date());
+  const comment: Comment = {
+    id,
+    ...(input.parentId ? { parentId: input.parentId } : { anchor: "doc" as const }),
+    text: input.text,
+    author: input.author,
+    date: now().toISOString(),
+    resolved: false,
+    ...(input.question ? { question: input.question } : {}),
+    ...(input.mayResolve ? { may_resolve: true } : {}),
+  };
+
+  const next: ParsedDocument = { body: doc.body, comments: [...doc.comments, comment], version: doc.version };
+  const integrity = checkIntegrity(next);
+  if (!integrity.ok) {
+    throw new AddCommentError(`comment: resulting document failed integrity check: ${integrity.errors.map((e) => e.message).join("; ")}`);
+  }
+  return { text: serialize(next), comment };
+}

--- a/packages/cli/test/commentAdd.test.ts
+++ b/packages/cli/test/commentAdd.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { parse, serialize } from "@inplan/core";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { addComment, AddCommentError } from "../src/commentAdd";
 
 const parentComment = { id: "cmt-abc123", author: "Someone <a@b.c>", date: "2020-01-01T00:00:00.000Z", resolved: false, text: "Confirm the datastore?" };
@@ -50,6 +50,19 @@ describe("addComment", () => {
     expect(comment.question).toEqual(question);
   });
 
+  it.each([
+    ["not an object", "just a string"],
+    ["missing multiSelect", { choices: [{ label: "x" }] }],
+    ["missing choices", { multiSelect: false }],
+    ["multiSelect not a boolean", { multiSelect: "false", choices: [] }],
+    ["choices not an array", { multiSelect: false, choices: "x" }],
+    ["a choice missing label", { multiSelect: false, choices: [{ description: "no label" }] }],
+    ["a null choice", { multiSelect: false, choices: [null] }],
+    ["a choice with a non-string description", { multiSelect: false, choices: [{ label: "x", description: 1 }] }],
+  ])("rejects a --question payload that's syntactically valid JSON but not shaped like a Question (%s)", (_case, question) => {
+    expect(() => addComment(baseText, { text: "x", author: "a", doc: true, question, now: () => REAL_DATE })).toThrow(/must be shaped like/);
+  });
+
   it("sets may_resolve when asked, and omits it otherwise", () => {
     const withFlag = addComment(baseText, { text: "done", author: "a", parentId: "cmt-abc123", mayResolve: true, now: () => REAL_DATE });
     expect(withFlag.comment.may_resolve).toBe(true);
@@ -75,9 +88,10 @@ describe("addComment", () => {
     expect(() => addComment(danglingText, { text: "x", author: "a", doc: true, now: () => REAL_DATE })).toThrow(/failed integrity check/);
   });
 
-  it("never collides with an existing comment id", () => {
-    // Force genId's random space down to make a collision likely, then confirm every id
-    // that comes out is still unique against what was already in the document.
+  it("produces a distinct id on each of several sequential calls", () => {
+    // genId's random space (36^6) makes a natural collision here astronomically unlikely, so this
+    // is only a basic sanity check (ids come out distinct in normal repeated use) — it can't tell
+    // a broken exclusion-set path from a working one. See the next test for that.
     let text = baseText;
     const seen = new Set(["cmt-abc123"]);
     for (let i = 0; i < 20; i++) {
@@ -87,5 +101,29 @@ describe("addComment", () => {
       text = next;
     }
     expect(parse(text).comments).toHaveLength(21);
+  });
+
+  it("retries when the random candidate collides with an existing comment id", () => {
+    const collidingId = "cmt-000000"; // what an all-zero byte fill decodes to (0 % 36 = "0", ×6)
+    const withCollisionTarget = serialize({
+      body: "Use [Postgres](#cmt-abc123).",
+      comments: [parentComment, { id: collidingId, parentId: "cmt-abc123", author: "a", date: "d", resolved: false, text: "existing" }],
+    });
+    const spy = vi.spyOn(globalThis.crypto, "getRandomValues");
+    let call = 0;
+    // @ts-expect-error — narrow test double, not the full getRandomValues overload set
+    spy.mockImplementation((arr: Uint8Array) => {
+      call++;
+      arr.fill(call === 1 ? 0 : 1); // 1st candidate: all-zero bytes -> "cmt-000000" (collides, forces a retry); 2nd: all-one -> "cmt-111111"
+      return arr;
+    });
+    try {
+      const { comment } = addComment(withCollisionTarget, { text: "x", author: "a", parentId: "cmt-abc123", now: () => REAL_DATE });
+      expect(comment.id).toBe("cmt-111111");
+      expect(comment.id).not.toBe(collidingId);
+      expect(spy).toHaveBeenCalledTimes(2);
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/packages/cli/test/commentAdd.test.ts
+++ b/packages/cli/test/commentAdd.test.ts
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { parse, serialize } from "@inplan/core";
+import { describe, expect, it } from "vitest";
+import { addComment, AddCommentError } from "../src/commentAdd";
+
+const parentComment = { id: "cmt-abc123", author: "Someone <a@b.c>", date: "2020-01-01T00:00:00.000Z", resolved: false, text: "Confirm the datastore?" };
+const baseText = serialize({ body: "Use [Postgres](#cmt-abc123).", comments: [parentComment] });
+const REAL_DATE = new Date("2026-07-28T05:18:11.421Z");
+
+describe("addComment", () => {
+  it("stamps the real clock, not a value the caller has to invent", () => {
+    const { text, comment } = addComment(baseText, {
+      text: "Confirmed, use Postgres.",
+      author: "Opus 4.8 <claude@inplan.ai>",
+      parentId: "cmt-abc123",
+      now: () => REAL_DATE,
+    });
+    expect(comment.date).toBe("2026-07-28T05:18:11.421Z");
+    expect(comment.parentId).toBe("cmt-abc123");
+    expect(comment.resolved).toBe(false);
+    expect(comment.id).toMatch(/^cmt-[0-9a-z]{6}$/);
+    const doc = parse(text);
+    expect(doc.comments.map((c) => c.id)).toEqual(["cmt-abc123", comment.id]);
+  });
+
+  it("defaults to the real system clock when `now` isn't injected", () => {
+    const before = Date.now();
+    const { comment } = addComment(baseText, { text: "x", author: "a", doc: true });
+    const after = Date.now();
+    const stamped = new Date(comment.date).getTime();
+    expect(stamped).toBeGreaterThanOrEqual(before);
+    expect(stamped).toBeLessThanOrEqual(after);
+  });
+
+  it("appends a document-level comment with anchor: doc and no parentId", () => {
+    const { comment } = addComment(baseText, {
+      text: "New top-level question.",
+      author: "a",
+      doc: true,
+      now: () => REAL_DATE,
+    });
+    expect(comment.anchor).toBe("doc");
+    expect(comment.parentId).toBeUndefined();
+  });
+
+  it("carries an optional question payload", () => {
+    const question = { multiSelect: false, choices: [{ label: "Postgres" }, { label: "SQLite" }] };
+    const { comment } = addComment(baseText, { text: "Pick one", author: "a", doc: true, question, now: () => REAL_DATE });
+    expect(comment.question).toEqual(question);
+  });
+
+  it("sets may_resolve when asked, and omits it otherwise", () => {
+    const withFlag = addComment(baseText, { text: "done", author: "a", parentId: "cmt-abc123", mayResolve: true, now: () => REAL_DATE });
+    expect(withFlag.comment.may_resolve).toBe(true);
+
+    const without = addComment(baseText, { text: "done", author: "a", parentId: "cmt-abc123", now: () => REAL_DATE });
+    expect(without.comment.may_resolve).toBeUndefined();
+  });
+
+  it("rejects both --parent-id and --doc together", () => {
+    expect(() => addComment(baseText, { text: "x", author: "a", parentId: "cmt-abc123", doc: true })).toThrow(AddCommentError);
+  });
+
+  it("rejects neither --parent-id nor --doc (span comments aren't supported here)", () => {
+    expect(() => addComment(baseText, { text: "x", author: "a" })).toThrow(AddCommentError);
+  });
+
+  it("rejects a --parent-id that doesn't exist in the document", () => {
+    expect(() => addComment(baseText, { text: "x", author: "a", parentId: "cmt-zzzzzz" })).toThrow(/no such parent id/);
+  });
+
+  it("refuses to add onto a document that's already structurally corrupt", () => {
+    const danglingText = serialize({ body: "Use [x](#cmt-zzzzzz).", comments: [] });
+    expect(() => addComment(danglingText, { text: "x", author: "a", doc: true, now: () => REAL_DATE })).toThrow(/failed integrity check/);
+  });
+
+  it("never collides with an existing comment id", () => {
+    // Force genId's random space down to make a collision likely, then confirm every id
+    // that comes out is still unique against what was already in the document.
+    let text = baseText;
+    const seen = new Set(["cmt-abc123"]);
+    for (let i = 0; i < 20; i++) {
+      const { text: next, comment } = addComment(text, { text: `reply ${i}`, author: "a", parentId: "cmt-abc123", now: () => REAL_DATE });
+      expect(seen.has(comment.id)).toBe(false);
+      seen.add(comment.id);
+      text = next;
+    }
+    expect(parse(text).comments).toHaveLength(21);
+  });
+});

--- a/packages/cli/test/commentAdd.test.ts
+++ b/packages/cli/test/commentAdd.test.ts
@@ -71,11 +71,15 @@ describe("addComment", () => {
     expect(without.comment.may_resolve).toBeUndefined();
   });
 
-  it("rejects both --parent-id and --doc together", () => {
-    expect(() => addComment(baseText, { text: "x", author: "a", parentId: "cmt-abc123", doc: true })).toThrow(AddCommentError);
+  it.each([
+    ["--parent-id + --doc", { parentId: "cmt-abc123", doc: true }],
+    ["--parent-id + --span", { parentId: "cmt-abc123", span: "Postgres" }],
+    ["--doc + --span", { doc: true, span: "Postgres" }],
+  ])("rejects combining more than one of --parent-id/--doc/--span (%s)", (_case, extra) => {
+    expect(() => addComment(baseText, { text: "x", author: "a", ...extra })).toThrow(/mutually exclusive/);
   });
 
-  it("rejects neither --parent-id nor --doc (span comments aren't supported here)", () => {
+  it("rejects when none of --parent-id/--doc/--span is given", () => {
     expect(() => addComment(baseText, { text: "x", author: "a" })).toThrow(AddCommentError);
   });
 
@@ -83,9 +87,48 @@ describe("addComment", () => {
     expect(() => addComment(baseText, { text: "x", author: "a", parentId: "cmt-zzzzzz" })).toThrow(/no such parent id/);
   });
 
-  it("refuses to add onto a document that's already structurally corrupt", () => {
+  it("refuses to add onto a document that's already structurally corrupt, and says so rather than blaming the new comment", () => {
     const danglingText = serialize({ body: "Use [x](#cmt-zzzzzz).", comments: [] });
-    expect(() => addComment(danglingText, { text: "x", author: "a", doc: true, now: () => REAL_DATE })).toThrow(/failed integrity check/);
+    expect(() => addComment(danglingText, { text: "x", author: "a", doc: true, now: () => REAL_DATE })).toThrow(
+      /already had a structural problem before this call \(this comment didn't cause it\)/,
+    );
+  });
+
+  describe("--span", () => {
+    // A fresh, link-free body — baseText already has "Postgres" wrapped in cmt-abc123's own
+    // link, which is exactly the overlap case exercised separately below.
+    const plainText = serialize({ body: "Use Postgres for storage.", comments: [] });
+
+    it("wraps the exact span text in a fresh anchor link, with no parentId/anchor field", () => {
+      const { text, comment } = addComment(plainText, { text: "Confirm.", author: "a", span: "Postgres", now: () => REAL_DATE });
+      expect(comment.parentId).toBeUndefined();
+      expect(comment.anchor).toBeUndefined();
+      const doc = parse(text);
+      expect(doc.body).toBe(`Use [Postgres](#${comment.id}) for storage.`);
+      expect(doc.comments.map((c) => c.id)).toEqual([comment.id]);
+    });
+
+    it("rejects span text that isn't in the body", () => {
+      expect(() => addComment(plainText, { text: "x", author: "a", span: "SQLite", now: () => REAL_DATE })).toThrow(/not found in the body/);
+    });
+
+    it("rejects span text that appears more than once, rather than guessing", () => {
+      const ambiguousText = serialize({ body: "Postgres or Postgres?", comments: [] });
+      expect(() => addComment(ambiguousText, { text: "x", author: "a", span: "Postgres", now: () => REAL_DATE })).toThrow(/appears more than once/);
+    });
+
+    it("treats an empty --span the same as not passing --span at all", () => {
+      expect(() => addComment(plainText, { text: "x", author: "a", span: "", now: () => REAL_DATE })).toThrow(
+        /pass --parent-id .* --doc .* or --span/,
+      );
+    });
+
+    it("refuses to add onto a document that's already structurally corrupt via --span too", () => {
+      const danglingText = serialize({ body: "Use [x](#cmt-zzzzzz) for storage.", comments: [] });
+      expect(() => addComment(danglingText, { text: "x", author: "a", span: "storage", now: () => REAL_DATE })).toThrow(
+        /already had a structural problem before this call \(this comment didn't cause it\)/,
+      );
+    });
   });
 
   it("produces a distinct id on each of several sequential calls", () => {

--- a/packages/cli/test/commentCli.test.ts
+++ b/packages/cli/test/commentCli.test.ts
@@ -101,18 +101,51 @@ describe("inplan comment", () => {
     expect(r.err).toMatch(/must be shaped like/);
   });
 
-  it("rejects a promoted cloud doc instead of silently falling through to wait", () => {
+  it("rejects a promoted cloud doc, and the message points at the local file it has to fall back to", () => {
     // Promote the doc's status to "cloud" the same way `inplan promote` would, without needing a
     // real Supabase backend — routeFor only reads status.json.
     writeStatus(docPaths(file).statusPath, { location: "cloud", cloudDocId: "doc-123", originalPath: file });
     const r = run("comment", file, "--doc", "--text", "x");
     expect(r.code).toBe(64);
-    expect(r.err).toMatch(/cloud docs aren't supported/);
+    expect(r.err).toMatch(/cloud docs aren't supported yet — edit the file directly and `wait`/);
+  });
+
+  it("rejects a pure --remote doc without the 'edit the file directly' advice (there is no local file)", () => {
+    const r = run("comment", "--remote", "doc-123", "--doc", "--text", "x");
+    expect(r.code).toBe(64);
+    expect(r.err).toMatch(/cloud docs aren't supported yet\./);
+    expect(r.err).not.toMatch(/edit the file directly/);
   });
 
   it("errors cleanly on a nonexistent file", () => {
     const r = run("comment", join(home, "missing.plan.md"), "--doc", "--text", "x");
     expect(r.code).toBe(1);
     expect(r.err).toMatch(/file not found/);
+  });
+
+  describe("--span", () => {
+    it("anchors a span comment to the exact body text", () => {
+      const r = run("comment", file, "--span", "Postgres", "--text", "Reconsider this.");
+      expect(r.code).toBe(0);
+      const result = JSON.parse(r.out);
+      const body = readFileSync(file, "utf8");
+      expect(body).toContain(`[Postgres](#${result.id})`);
+      const doc = parse(body);
+      const added = doc.comments.find((c) => c.id === result.id);
+      expect(added?.parentId).toBeUndefined();
+      expect(added?.anchor).toBeUndefined();
+    });
+
+    it("rejects span text not present in the body", () => {
+      const r = run("comment", file, "--span", "SQLite", "--text", "x");
+      expect(r.code).toBe(64);
+      expect(r.err).toMatch(/not found in the body/);
+    });
+
+    it("rejects combining --span with --parent-id", () => {
+      const r = run("comment", file, "--span", "Postgres", "--parent-id", "cmt-abc123", "--text", "x");
+      expect(r.code).toBe(64);
+      expect(r.err).toMatch(/mutually exclusive/);
+    });
   });
 });

--- a/packages/cli/test/commentCli.test.ts
+++ b/packages/cli/test/commentCli.test.ts
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// `inplan comment <file> (--parent-id <id>|--doc) --text "..."` — a typed writer for a
+// reply/answer or document-level comment, so `date` comes from the CLI's own real clock
+// instead of the agent hand-writing the JSON block and guessing it. Smoke-tests the wiring
+// (flag parsing, file write, exit codes); the construction logic itself is unit-tested in
+// commentAdd.test.ts.
+
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { parse } from "@inplan/core";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const CLI = join(dirname(fileURLToPath(import.meta.url)), "..", "dist", "cli.js");
+
+let home: string;
+let file: string;
+let env: NodeJS.ProcessEnv;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "inplan-comment-"));
+  file = join(home, "plan.md");
+  writeFileSync(file, 'Use [Postgres](#cmt-abc123).\n\n<!--inplan v1\n[{"id":"cmt-abc123","author":"a","date":"2020-01-01T00:00:00.000Z","resolved":false,"text":"Confirm the datastore?"}]\n-->\n');
+  process.env.INPLAN_SIDECAR_DIR = join(home, "sidecars");
+  env = { ...process.env, INPLAN_HOME: home };
+});
+afterEach(() => {
+  delete process.env.INPLAN_SIDECAR_DIR;
+  rmSync(home, { recursive: true, force: true });
+});
+
+function run(...args: string[]) {
+  const r = spawnSync(process.execPath, [CLI, ...args], { env, encoding: "utf8" });
+  return { code: r.status, out: r.stdout.trim(), err: r.stderr.trim() };
+}
+
+describe("inplan comment", () => {
+  it("appends a reply with a real timestamp and the model-qualified author", () => {
+    const before = Date.now();
+    const r = run("comment", file, "--parent-id", "cmt-abc123", "--text", "Confirmed.", "--model", "Opus 4.8");
+    expect(r.code).toBe(0);
+    const result = JSON.parse(r.out);
+    expect(result.status).toBe("commented");
+    expect(result.author).toBe("Opus 4.8 <claude@inplan.ai>");
+    expect(new Date(result.date).getTime()).toBeGreaterThanOrEqual(before);
+
+    const doc = parse(readFileSync(file, "utf8"));
+    const reply = doc.comments.find((c) => c.id === result.id);
+    expect(reply?.parentId).toBe("cmt-abc123");
+    expect(reply?.text).toBe("Confirmed.");
+  });
+
+  it("appends a document-level comment with --doc", () => {
+    const r = run("comment", file, "--doc", "--text", "New question.");
+    expect(r.code).toBe(0);
+    const result = JSON.parse(r.out);
+    const doc = parse(readFileSync(file, "utf8"));
+    const added = doc.comments.find((c) => c.id === result.id);
+    expect(added?.anchor).toBe("doc");
+    expect(added?.parentId).toBeUndefined();
+  });
+
+  it("sets may_resolve when --may-resolve is passed", () => {
+    const r = run("comment", file, "--parent-id", "cmt-abc123", "--text", "done", "--may-resolve");
+    const result = JSON.parse(r.out);
+    const doc = parse(readFileSync(file, "utf8"));
+    expect(doc.comments.find((c) => c.id === result.id)?.may_resolve).toBe(true);
+  });
+
+  it("rejects a missing --text", () => {
+    const r = run("comment", file, "--parent-id", "cmt-abc123");
+    expect(r.code).toBe(64);
+    expect(r.err).toMatch(/usage: inplan comment/);
+  });
+
+  it("rejects both --parent-id and --doc", () => {
+    const r = run("comment", file, "--parent-id", "cmt-abc123", "--doc", "--text", "x");
+    expect(r.code).toBe(64);
+    expect(r.err).toMatch(/mutually exclusive/);
+  });
+
+  it("rejects an unknown parent id", () => {
+    const r = run("comment", file, "--parent-id", "cmt-zzzzzz", "--text", "x");
+    expect(r.code).toBe(64);
+    expect(r.err).toMatch(/no such parent id/);
+  });
+
+  it("errors cleanly on a nonexistent file", () => {
+    const r = run("comment", join(home, "missing.plan.md"), "--doc", "--text", "x");
+    expect(r.code).toBe(1);
+    expect(r.err).toMatch(/file not found/);
+  });
+});

--- a/packages/cli/test/commentCli.test.ts
+++ b/packages/cli/test/commentCli.test.ts
@@ -12,6 +12,7 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { parse } from "@inplan/core";
+import { docPaths, writeStatus } from "@inplan/core/node";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 const CLI = join(dirname(fileURLToPath(import.meta.url)), "..", "dist", "cli.js");
@@ -86,6 +87,27 @@ describe("inplan comment", () => {
     const r = run("comment", file, "--parent-id", "cmt-zzzzzz", "--text", "x");
     expect(r.code).toBe(64);
     expect(r.err).toMatch(/no such parent id/);
+  });
+
+  it("rejects malformed --question JSON", () => {
+    const r = run("comment", file, "--doc", "--text", "x", "--question", "not json");
+    expect(r.code).toBe(64);
+    expect(r.err).toMatch(/must be valid JSON/);
+  });
+
+  it("rejects a --question that's valid JSON but not shaped like a Question", () => {
+    const r = run("comment", file, "--doc", "--text", "x", "--question", "{}");
+    expect(r.code).toBe(64);
+    expect(r.err).toMatch(/must be shaped like/);
+  });
+
+  it("rejects a promoted cloud doc instead of silently falling through to wait", () => {
+    // Promote the doc's status to "cloud" the same way `inplan promote` would, without needing a
+    // real Supabase backend — routeFor only reads status.json.
+    writeStatus(docPaths(file).statusPath, { location: "cloud", cloudDocId: "doc-123", originalPath: file });
+    const r = run("comment", file, "--doc", "--text", "x");
+    expect(r.code).toBe(64);
+    expect(r.err).toMatch(/cloud docs aren't supported/);
   });
 
   it("errors cleanly on a nonexistent file", () => {

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -90,14 +90,14 @@ anchored comment is an inline Markdown link whose href is the comment id:
 - **Question**: `question.multiSelect` false = pick one (radio), true = pick many
   (checkbox); the human may also answer with free text.
 - Generate ids as `cmt-` + 6 base36 characters.
-- **`date`**: you have no reliable clock, so never invent this by hand. For a reply/answer
-  or a document-level comment, use `inplan comment <file> (--parent-id <id>|--doc) --text
-  "..." [--model NAME] [--may-resolve] [--question <json>]` instead of hand-editing the JSON
-  block — it stamps `date` from the real system clock and fills `author` from `--model` for
-  you (same as `open`/`wait`), and prints the new comment's `id`/`date`/`author` back. A span
-  comment still needs a direct body edit (it must sit inline with its anchor link), so this
-  doesn't cover it — keep its `date` as close to real as you can, e.g. by reusing the date a
-  nearby `comment`/`wait` call just returned, rather than guessing a round number.
+- **`date`**: you have no reliable clock, so never invent this by hand. Use `inplan comment
+  <file> (--parent-id <id>|--doc|--span "exact body text") --text "..." [--model NAME]
+  [--may-resolve] [--question <json>]` instead of hand-editing the JSON block — it stamps
+  `date` from the real system clock and fills `author` from `--model` for you (same as
+  `open`/`wait`), and prints the new comment's `id`/`date`/`author` back. `--span` covers the
+  span-comment case too: give it the exact, currently-unlinked body text to anchor to (it must
+  occur exactly once — add surrounding context if it's ambiguous) and it wraps that text in
+  the link itself, so you never hand-edit the body for this either.
 - **`author`**: sign **every** comment you write with **your own model identity**, so
   the human sees which model is talking. Always pass `--model "<your model>"` (e.g.
   `--model "Opus 4.8"`) on `open`/`wait`; the wait result echoes the exact string to

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -90,6 +90,14 @@ anchored comment is an inline Markdown link whose href is the comment id:
 - **Question**: `question.multiSelect` false = pick one (radio), true = pick many
   (checkbox); the human may also answer with free text.
 - Generate ids as `cmt-` + 6 base36 characters.
+- **`date`**: you have no reliable clock, so never invent this by hand. For a reply/answer
+  or a document-level comment, use `inplan comment <file> (--parent-id <id>|--doc) --text
+  "..." [--model NAME] [--may-resolve] [--question <json>]` instead of hand-editing the JSON
+  block — it stamps `date` from the real system clock and fills `author` from `--model` for
+  you (same as `open`/`wait`), and prints the new comment's `id`/`date`/`author` back. A span
+  comment still needs a direct body edit (it must sit inline with its anchor link), so this
+  doesn't cover it — keep its `date` as close to real as you can, e.g. by reusing the date a
+  nearby `comment`/`wait` call just returned, rather than guessing a round number.
 - **`author`**: sign **every** comment you write with **your own model identity**, so
   the human sees which model is talking. Always pass `--model "<your model>"` (e.g.
   `--model "Opus 4.8"`) on `open`/`wait`; the wait result echoes the exact string to


### PR DESCRIPTION
## Summary
- The agent has no reliable clock, so hand-writing a reply or document-level comment's `date` field in the JSON block meant guessing — often a round, plausible-looking value that didn't reflect when the comment was actually written. Those fabricated timestamps then fed straight into `orderComments`' chronological sort, next to comments the app stamps for real with the system clock, corrupting thread order.
- Adds `inplan comment <file> (--parent-id <id>|--doc) --text "..." [--model NAME] [--may-resolve] [--question <json>]`: a typed writer that constructs the comment (real `Date.now()`, generated id, `--model`-derived author) and appends it to the file, the same way a hand-edit would — the agent's next `wait` picks it up like any other change.
- Span comments are out of scope — placing the anchor link is a body edit either way, so those still need a direct edit.
- Points `skill/SKILL.md` at the new command for the reply/doc-level case.

## Test plan
- [x] `commentAdd.test.ts` — pure construction logic, 100% coverage (reply/doc-level creation, real-clock default, `may_resolve`, invalid arg combos, unknown parent, refuses to add onto an already-corrupt doc, no id collisions)
- [x] `commentCli.test.ts` — spawns the built `dist/cli.js` end-to-end (flag parsing, file write, exit codes)
- [x] Full suite: 857 tests passing, coverage 96.08% (gate ≥95%), typecheck clean across all workspaces
- [x] Verified against the real Electron app via Playwright `_electron` (CDP): launched the app on a seed doc, ran `inplan comment` from a separate process while the app had the file open, confirmed the file-only write does NOT live-update the UI by itself (no control-log event), then ran `inplan wait` and confirmed the reply appears live with the correct author badge and real relative timestamp
- [x] Existing `e2e/comments.spec.ts` (5 tests) still passes — no regression to existing comment flows

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/60?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `inplan comment` command for adding replies and document-level comments to local plans.
  * Supports optional questions, model attribution, and resolution permissions.
  * Returns comment details, including ID, timestamp, and author.

* **Bug Fixes**
  * Added validation for missing or invalid comment targets and duplicate options.
  * Prevented comment creation on remote documents with guidance to edit locally.

* **Documentation**
  * Updated comment guidance to use the CLI for reliable timestamps and author information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->