### PR TITLE
test(e2e): harden desktop plugin trust-path spec against CI cold-load flake (#58)

### DIFF
--- a/e2e/desktopPlugin.spec.ts
+++ b/e2e/desktopPlugin.spec.ts
@@ -95,13 +95,17 @@ test("main verified + the renderer imported and activated the signed plugin bund
   // The marker is set by the stub's activate() — reached only if main verified the lease + both
   // files, ran the main entry (start), served the renderer entry over the scheme, and the renderer
   // imported + activated it with the session.
-  await expect.poll(() => win.evaluate(() => (globalThis as { __E2E_PLUGIN?: { active?: boolean } }).__E2E_PLUGIN?.active ?? false), { timeout: 8_000 }).toBe(true);
+  // Generous timeout: this whole trust path is a cold load (node verify + import → serve over the
+  // inplan-plugin: scheme → browser dynamic-import under CSP → activate). On a loaded CI runner it
+  // can legitimately take well over 8s; a tighter bound just flakes without proving anything.
+  await expect.poll(() => win.evaluate(() => (globalThis as { __E2E_PLUGIN?: { active?: boolean } }).__E2E_PLUGIN?.active ?? false), { timeout: 30_000 }).toBe(true);
 });
 
 test("the editor advertises the plugin's mode from its extraModes", async () => {
   // The cadence toggle only renders with >1 mode, so an Instant button proves extraModes merged
   // through setHostApi onto the host api the editor reads.
   // exact, so "Turn" doesn't also match the "Finish turn" button.
-  await expect(win.getByRole("button", { name: "Turn", exact: true })).toBeVisible();
-  await expect(win.getByRole("button", { name: "Instant", exact: true })).toBeVisible();
+  // Allow for the merge→render lag after activation on a slow runner (see the timeout note above).
+  await expect(win.getByRole("button", { name: "Turn", exact: true })).toBeVisible({ timeout: 15_000 });
+  await expect(win.getByRole("button", { name: "Instant", exact: true })).toBeVisible({ timeout: 15_000 });
 });


### PR DESCRIPTION
## What

The nightly Electron e2e (#58) went red on 2026-07-28 with `desktopPlugin.spec.ts` failing **both** tests across all 3 retries — then the **next** nightly passed on the **same commit** (`b1d40d0`). That's the signature of a timing flake, not a regression.

## Root cause

`desktopPlugin.spec.ts` drives the full runtime-plugin trust path end to end:

> main verifies the lease + bundle files (Ed25519 + sha384) → imports the main entry → serves the renderer entry over the `inplan-plugin:` scheme → the renderer dynamic-imports it under CSP → `activate(session)` sets `globalThis.__E2E_PLUGIN.active`.

The first test polls that marker with an **8s** timeout. The downloaded trace shows no verify/CSP/import error — just `Timeout 8000ms exceeded`: on a loaded runner the cold load simply didn't finish activation inside 8s (three launches in a row that night; fine the next night). The second test then races because activation hadn't merged the extra mode yet.

This spec only runs in the nightly (PR CI skips Electron e2e — they need a display), so the flake surfaces here rather than on PRs.

## Fix

Test-only, no product-code change:
- activation poll `8s → 30s` (the cold verify→import→serve→import→activate chain legitimately needs it under CI load)
- `extraModes` button assertions get an explicit `15s` for the merge→render lag after activation

## Verifying

Can't reproduce locally (Electron e2e need a GUI session); this rides the nightly. Merge closes #58; the next scheduled run should stay green with headroom.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/61?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability for offline plugin activation and editor mode controls by allowing additional time for initialization and rendering on slower environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->