### PR TITLE
release: 0.1.23 — `inplan comment` + stronger confirm-gate skill guidance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5335,7 +5335,7 @@
     },
     "packages/cli": {
       "name": "@inplan/cli",
-      "version": "0.1.22",
+      "version": "0.1.23",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@hocuspocus/provider": "^2.15.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inplan/cli",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "private": true,
   "description": "inplan CLI: open / wait / signal orchestration over the document core.",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
Version bump 0.1.22 → 0.1.23 to publish the changes merged since the last release. On merge, tagging `v0.1.23` triggers `release.yml` to publish `inplan` to npm via OIDC.

## Ships
- **feat(cli): `inplan comment` (#60)** — append a reply, document-level, or span-anchored (`--span "<exact text>"`) comment with a `date` stamped from the CLI's own clock, instead of the agent hand-editing the JSON block with an invented timestamp (which corrupted `orderComments`' chronological sort).
- **skill (#59)** — don't fake-orphan comments to dodge the confirm gate: deleting a comment that has replies now requires confirming the descendant ids too, and the gate catches outright-deleted / reparented descendants.

(#61, a test-only e2e hardening, also landed since 0.1.22 but ships nothing user-facing.)

## Diff
Two lines: `packages/cli/package.json` + `package-lock.json`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/62?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

