### PR TITLE
feat(renderer): paste an image from the clipboard into the plan

### DIFF
--- a/packages/app/src/renderer/index.html
+++ b/packages/app/src/renderer/index.html
@@ -9,13 +9,16 @@
          img-src adds file: so a Markdown image (pasted/picked, saved as a sibling
          `<docname>.assets/*` file and embedded as a `file://` URL by renderMarkdown — see
          markdown.ts) can actually load; the plan doc lives outside the app's own bundle
-         directory, so 'self' alone can't cover it. http:/https: let a Markdown image whose
-         destination is a plain remote URL (typed directly, e.g. ![](https://...)) load too —
-         markdown.ts already leaves absolute URLs untouched, so this was the only thing
-         blocking them. -->
+         directory, so 'self' alone can't cover it. https: (not http:) lets a Markdown image
+         whose destination is a plain remote URL (typed directly, e.g. ![](https://...)) load
+         too — markdown.ts already leaves absolute URLs untouched, so this was the only thing
+         blocking them. http: is deliberately NOT included: any doc (agent-authored, shared via
+         a repo) can embed a remote image as a tracking pixel that leaks the viewer's IP the
+         moment the doc merely renders, and plaintext http adds an on-path tampering risk on top
+         of that with no offsetting benefit. -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' inplan-plugin:; img-src 'self' file: http: https:; connect-src 'self' inplan-plugin: ws://127.0.0.1:* ws://localhost:*; frame-src https://inplan.ai http://127.0.0.1:* http://localhost:*"
+      content="default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' inplan-plugin:; img-src 'self' file: https:; connect-src 'self' inplan-plugin: ws://127.0.0.1:* ws://localhost:*; frame-src https://inplan.ai http://127.0.0.1:* http://localhost:*"
     />
     <title>inplan</title>
   </head>

--- a/packages/app/src/renderer/index.html
+++ b/packages/app/src/renderer/index.html
@@ -9,10 +9,13 @@
          img-src adds file: so a Markdown image (pasted/picked, saved as a sibling
          `<docname>.assets/*` file and embedded as a `file://` URL by renderMarkdown — see
          markdown.ts) can actually load; the plan doc lives outside the app's own bundle
-         directory, so 'self' alone can't cover it. -->
+         directory, so 'self' alone can't cover it. http:/https: let a Markdown image whose
+         destination is a plain remote URL (typed directly, e.g. ![](https://...)) load too —
+         markdown.ts already leaves absolute URLs untouched, so this was the only thing
+         blocking them. -->
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' inplan-plugin:; img-src 'self' file:; connect-src 'self' inplan-plugin: ws://127.0.0.1:* ws://localhost:*; frame-src https://inplan.ai http://127.0.0.1:* http://localhost:*"
+      content="default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' inplan-plugin:; img-src 'self' file: http: https:; connect-src 'self' inplan-plugin: ws://127.0.0.1:* ws://localhost:*; frame-src https://inplan.ai http://127.0.0.1:* http://localhost:*"
     />
     <title>inplan</title>
   </head>

--- a/packages/renderer/src/App.tsx
+++ b/packages/renderer/src/App.tsx
@@ -724,7 +724,11 @@ export function App(props: EditorProps = {}): JSX.Element {
       const lines = cur.body.split("\n");
       let insertAfter = lines.length - 1;
       if (activePreviewLine != null) {
-        const blockEl = previewRef.current?.querySelector(`[data-line="${activePreviewLine}"]`);
+        // Same tie-break as the active-line highlight effect above: when a container and its
+        // first child share a source line (`<ul>`/`<li>`, `<blockquote>`/`<p>`), take the LAST
+        // match (the more specific child) so this lines up with what's actually highlighted.
+        const matches = previewRef.current?.querySelectorAll(`[data-line="${activePreviewLine}"]`);
+        const blockEl = matches && matches.length > 0 ? matches[matches.length - 1] : null;
         const endLine = blockEl?.getAttribute("data-end-line");
         insertAfter = endLine != null ? Number(endLine) : activePreviewLine;
       }
@@ -1850,7 +1854,7 @@ export function App(props: EditorProps = {}): JSX.Element {
           ) : (
           <div
             className="ap-rendered"
-            tabIndex={0}
+            tabIndex={-1}
             dangerouslySetInnerHTML={{ __html: previewHtml }}
             onPaste={onPreviewPasteImage}
             onClick={(e) => {

--- a/packages/renderer/src/App.tsx
+++ b/packages/renderer/src/App.tsx
@@ -692,10 +692,10 @@ export function App(props: EditorProps = {}): JSX.Element {
     [apply],
   );
 
-  // An image picked via the Source toolbar's file dialog: hand its raw bytes to the host, which
-  // writes them next to the open doc (e.g. `<docname>.assets/image-...png`) and returns the
-  // relative link to embed. Absent `saveAsset` (a host with nowhere to write a sibling file,
-  // e.g. a cloud doc) ⇒ no-op — the toolbar just leaves the doc untouched.
+  // An image picked via the Source toolbar's file dialog OR pasted from the clipboard: hand its
+  // raw bytes to the host, which writes them next to the open doc (e.g.
+  // `<docname>.assets/image-...png`) and returns the relative link to embed. Absent `saveAsset`
+  // (a host with nowhere to write a sibling file, e.g. a cloud doc) ⇒ no-op.
   const onPickImage = useCallback(async (bytes: ArrayBuffer, mime: string): Promise<string | null> => {
     const saveAsset = hostApi().saveAsset;
     if (!saveAsset) return null;
@@ -706,6 +706,34 @@ export function App(props: EditorProps = {}): JSX.Element {
     const saved = await saveAsset(bytes, ext);
     return saved?.relPath ?? null;
   }, []);
+
+  // Pasting an image directly into the (read-only) preview: insert the link on a new line
+  // right after the active (blue-highlighted) block — its data-end-line, not just data-line, so
+  // a paste into a multi-line paragraph lands after the WHOLE paragraph rather than splitting
+  // it. No active block (nothing clicked/synced yet) ⇒ append at the end of the document.
+  const onPreviewPasteImage = useCallback(
+    async (e: React.ClipboardEvent<HTMLDivElement>) => {
+      if (editingLocked) return;
+      const file = [...(e.clipboardData?.files ?? [])].find((f) => f.type.startsWith("image/"));
+      if (!file) return; // no image on the clipboard — leave native paste (a no-op here) alone
+      e.preventDefault();
+      const bytes = await file.arrayBuffer();
+      const relPath = await onPickImage(bytes, file.type);
+      if (!relPath) return;
+      const cur = docRef.current;
+      const lines = cur.body.split("\n");
+      let insertAfter = lines.length - 1;
+      if (activePreviewLine != null) {
+        const blockEl = previewRef.current?.querySelector(`[data-line="${activePreviewLine}"]`);
+        const endLine = blockEl?.getAttribute("data-end-line");
+        insertAfter = endLine != null ? Number(endLine) : activePreviewLine;
+      }
+      insertAfter = Math.min(Math.max(insertAfter, 0), lines.length - 1);
+      lines.splice(insertAfter + 1, 0, "", `![](${relPath})`);
+      apply({ ...cur, body: lines.join("\n") }, { type: "image_pasted", payload: {} });
+    },
+    [editingLocked, onPickImage, activePreviewLine, apply],
+  );
 
   // Auto-resolve: when the setting is on, resolve threads the agent suggested (its `may_resolve`
   // on the thread's last comment). Runs on load + when the setting flips on. We remember which
@@ -1819,7 +1847,9 @@ export function App(props: EditorProps = {}): JSX.Element {
           ) : (
           <div
             className="ap-rendered"
+            tabIndex={0}
             dangerouslySetInnerHTML={{ __html: previewHtml }}
+            onPaste={onPreviewPasteImage}
             onClick={(e) => {
               const target = e.target as HTMLElement;
               const a = target.closest("a");
@@ -1884,6 +1914,7 @@ export function App(props: EditorProps = {}): JSX.Element {
                 commentsForCopy={commentsForCopy}
                 onCutComments={editingLocked ? undefined : onCutComments}
                 onPasteComments={editingLocked ? undefined : onPasteComments}
+                onPasteImage={editingLocked ? undefined : onPickImage}
               />
               </EditorErrorBoundary>
             )}

--- a/packages/renderer/src/App.tsx
+++ b/packages/renderer/src/App.tsx
@@ -725,12 +725,23 @@ export function App(props: EditorProps = {}): JSX.Element {
       const file = [...(e.clipboardData?.files ?? [])].find((f) => f.type.startsWith("image/"));
       if (!file) return; // no image on the clipboard — leave native paste (a no-op here) alone
       e.preventDefault();
-      const bytes = await file.arrayBuffer();
-      const relPath = await onPickImage(bytes, file.type);
+      let relPath: string | null;
+      try {
+        const bytes = await file.arrayBuffer();
+        relPath = await onPickImage(bytes, file.type);
+      } catch {
+        // arrayBuffer()/onPickImage() rejected (e.g. the host write failed) — preventDefault()
+        // already ran, so silence here would drop the paste with no feedback at all.
+        setStatus(t("msg.imagePasteFailed"));
+        return;
+      }
       if (!relPath) return;
       const cur = docRef.current;
       const lines = cur.body.split("\n");
       let insertAfter = lines.length - 1;
+      // activePreviewLine/docRef are both read fresh here, after the awaits above — a concurrent
+      // edit during the (host-write) round trip can still land the insert a line off (rare, and
+      // clamped below to stay in-bounds either way), but never crashes or targets a stale doc.
       if (activePreviewLine != null) {
         // Same lookup as the active-line highlight effect, so this always targets the block
         // that's actually highlighted — including when activePreviewLine lands mid-block (the
@@ -1928,7 +1939,7 @@ export function App(props: EditorProps = {}): JSX.Element {
                 commentsForCopy={commentsForCopy}
                 onCutComments={editingLocked ? undefined : onCutComments}
                 onPasteComments={editingLocked ? undefined : onPasteComments}
-                onPasteImage={editingLocked ? undefined : onPickImage}
+                onPasteImage={editingLocked || !hostApi().saveAsset ? undefined : onPickImage}
               />
               </EditorErrorBoundary>
             )}

--- a/packages/renderer/src/App.tsx
+++ b/packages/renderer/src/App.tsx
@@ -725,6 +725,7 @@ export function App(props: EditorProps = {}): JSX.Element {
       const file = [...(e.clipboardData?.files ?? [])].find((f) => f.type.startsWith("image/"));
       if (!file) return; // no image on the clipboard — leave native paste (a no-op here) alone
       e.preventDefault();
+      const pasteDocPath = docPathRef.current; // so we can detect a navigation mid-save, below
       let relPath: string | null;
       try {
         const bytes = await file.arrayBuffer();
@@ -735,13 +736,15 @@ export function App(props: EditorProps = {}): JSX.Element {
         setStatus(t("msg.imagePasteFailed"));
         return;
       }
-      if (!relPath) return;
+      // If the user navigated to a different doc while the write was in flight, docRef.current
+      // now belongs to THAT doc — inserting into it would drop the image into the wrong document.
+      if (!relPath || docPathRef.current !== pasteDocPath) return;
       const cur = docRef.current;
       const lines = cur.body.split("\n");
       let insertAfter = lines.length - 1;
       // activePreviewLine/docRef are both read fresh here, after the awaits above — a concurrent
-      // edit during the (host-write) round trip can still land the insert a line off (rare, and
-      // clamped below to stay in-bounds either way), but never crashes or targets a stale doc.
+      // edit (same doc) during the (host-write) round trip can still land the insert a line off
+      // (rare, and clamped below to stay in-bounds either way), but never crashes.
       if (activePreviewLine != null) {
         // Same lookup as the active-line highlight effect, so this always targets the block
         // that's actually highlighted — including when activePreviewLine lands mid-block (the

--- a/packages/renderer/src/App.tsx
+++ b/packages/renderer/src/App.tsx
@@ -729,7 +729,10 @@ export function App(props: EditorProps = {}): JSX.Element {
         insertAfter = endLine != null ? Number(endLine) : activePreviewLine;
       }
       insertAfter = Math.min(Math.max(insertAfter, 0), lines.length - 1);
-      lines.splice(insertAfter + 1, 0, "", `![](${relPath})`);
+      // Angle-bracket destination, not bare `![](relPath)`: relPath is `<docname>.assets/…`, and
+      // a doc name with a space/paren (e.g. "Product Plan.md") makes that a path markdown-it's
+      // bare destination syntax can't parse as a link at all.
+      lines.splice(insertAfter + 1, 0, "", `![](<${relPath}>)`);
       apply({ ...cur, body: lines.join("\n") }, { type: "image_pasted", payload: {} });
     },
     [editingLocked, onPickImage, activePreviewLine, apply],

--- a/packages/renderer/src/App.tsx
+++ b/packages/renderer/src/App.tsx
@@ -77,6 +77,25 @@ function anchorLine(body: string, id: string): number | null {
   return body.slice(0, idx).split("\n").length - 1;
 }
 
+/** The preview block that should be treated as "active" for source `line`: the closest
+ *  `[data-line]` element at or before it. `line` need not be a block's own start line — it may
+ *  land mid-block (the source editor's cursor line, via onCursorLine, isn't clamped to a block
+ *  boundary the way a preview click is). On a tie (a container and its first child share a
+ *  source line — `<ul>`/`<li>`, `<blockquote>`/`<p>`), the LATER DOM node wins, i.e. the more
+ *  specific child. */
+function closestPreviewBlock(root: Element | null | undefined, line: number): Element | null {
+  let best: Element | null = null;
+  let bestLine = -1;
+  root?.querySelectorAll("[data-line]").forEach((el) => {
+    const l = Number(el.getAttribute("data-line") ?? -1);
+    if (l <= line && l >= bestLine) {
+      bestLine = l;
+      best = el;
+    }
+  });
+  return best;
+}
+
 const liveSelection = (): string => window.getSelection()?.toString().trim() ?? "";
 
 /** Restart a one-shot CSS flash animation on `el` (remove → reflow → re-add) so it
@@ -397,6 +416,7 @@ export function App(props: EditorProps = {}): JSX.Element {
         setAgentThinking(false);
         setAgentDone(false);
         setAgentMessages([]); // notes belong to the doc we just left — don't carry them over
+        setActivePreviewLine(null); // a synced line belongs to the doc we just left, not this one
         setStatus(`opened ${path.split("/").pop() ?? path}`);
         void hostApi().getProposal().then((parked) => parked != null && showProposal(parked));
       }),
@@ -596,24 +616,12 @@ export function App(props: EditorProps = {}): JSX.Element {
     if (!root) return;
     root.querySelectorAll(".ap-active-line").forEach((el) => el.classList.remove("ap-active-line"));
     if (activePreviewLine == null) return;
-    let best: Element | null = null;
-    let bestLine = -1;
-    // Among blocks at or before the active line, pick the closest one. On a tie
-    // (a container and its first child share a source line — `<ul>`/`<li>`,
-    // `<blockquote>`/`<p>`), `>=` lets the later DOM node win, i.e. the more
-    // specific child, so we highlight just that item rather than the whole list.
-    root.querySelectorAll("[data-line]").forEach((el) => {
-      const l = Number(el.getAttribute("data-line") ?? -1);
-      if (l <= activePreviewLine && l >= bestLine) {
-        bestLine = l;
-        best = el;
-      }
-    });
+    const best = closestPreviewBlock(root, activePreviewLine);
     if (best) {
-      (best as Element).classList.add("ap-active-line");
+      best.classList.add("ap-active-line");
       // Don't scroll the preview when the click originated here — only re-center
       // when the active line was driven from another pane (the source editor).
-      if (!skipPreviewScroll.current) (best as Element).scrollIntoView({ block: "center" });
+      if (!skipPreviewScroll.current) best.scrollIntoView({ block: "center" });
     }
     skipPreviewScroll.current = false;
   }, [activePreviewLine, doc.body]);
@@ -724,11 +732,10 @@ export function App(props: EditorProps = {}): JSX.Element {
       const lines = cur.body.split("\n");
       let insertAfter = lines.length - 1;
       if (activePreviewLine != null) {
-        // Same tie-break as the active-line highlight effect above: when a container and its
-        // first child share a source line (`<ul>`/`<li>`, `<blockquote>`/`<p>`), take the LAST
-        // match (the more specific child) so this lines up with what's actually highlighted.
-        const matches = previewRef.current?.querySelectorAll(`[data-line="${activePreviewLine}"]`);
-        const blockEl = matches && matches.length > 0 ? matches[matches.length - 1] : null;
+        // Same lookup as the active-line highlight effect, so this always targets the block
+        // that's actually highlighted — including when activePreviewLine lands mid-block (the
+        // source editor's cursor line need not be a block's own start line).
+        const blockEl = closestPreviewBlock(previewRef.current, activePreviewLine);
         const endLine = blockEl?.getAttribute("data-end-line");
         insertAfter = endLine != null ? Number(endLine) : activePreviewLine;
       }

--- a/packages/renderer/src/SourceEditor.tsx
+++ b/packages/renderer/src/SourceEditor.tsx
@@ -264,11 +264,12 @@ export const SourceEditor = forwardRef<
               const imgFile = [...(e.clipboardData?.files ?? [])].find((f) => f.type.startsWith("image/"));
               if (imgFile && onPasteImageRef.current) {
                 e.preventDefault();
-                const pos = v.state.selection.main.from;
                 const onPasteImage = onPasteImageRef.current;
                 void imgFile.arrayBuffer().then(async (bytes) => {
                   const relPath = await onPasteImage(bytes, imgFile.type);
-                  if (relPath) v.dispatch(imageEdit(v.state.doc.toString(), pos, pos, relPath));
+                  if (!relPath) return;
+                  const pos = v.state.selection.main.from;
+                  v.dispatch(imageEdit(v.state.doc.toString(), pos, pos, relPath));
                 });
                 return true;
               }

--- a/packages/renderer/src/SourceEditor.tsx
+++ b/packages/renderer/src/SourceEditor.tsx
@@ -268,7 +268,7 @@ export const SourceEditor = forwardRef<
                 const onPasteImage = onPasteImageRef.current;
                 void imgFile.arrayBuffer().then(async (bytes) => {
                   const relPath = await onPasteImage(bytes, imgFile.type);
-                  if (relPath) v.dispatch({ changes: { from: pos, to: pos, insert: `![](${relPath})` } });
+                  if (relPath) v.dispatch(imageEdit(v.state.doc.toString(), pos, pos, relPath));
                 });
                 return true;
               }

--- a/packages/renderer/src/SourceEditor.tsx
+++ b/packages/renderer/src/SourceEditor.tsx
@@ -93,8 +93,12 @@ export const SourceEditor = forwardRef<
     onCutComments?: (text: string, from: number, to: number) => void;
     /** Paste a fragment carrying comments: the app re-IDs them, rewrites anchors, and splices. */
     onPasteComments?: (text: string, payload: ClipboardPayload, from: number, to: number) => void;
+    /** A pasted image's raw bytes + MIME type: the app writes it to disk and resolves the
+     *  relative link to embed, or null if it couldn't (host has nowhere to write it — e.g. a
+     *  cloud doc). Absent ⇒ pasting an image is a no-op (no host to save it against). */
+    onPasteImage?: (bytes: ArrayBuffer, mime: string) => Promise<string | null>;
   }
->(function SourceEditor({ value, editable, onChange, onCursorLine, onFind, find, binding, commentsForCopy, onCutComments, onPasteComments }, ref): JSX.Element {
+>(function SourceEditor({ value, editable, onChange, onCursorLine, onFind, find, binding, commentsForCopy, onCutComments, onPasteComments, onPasteImage }, ref): JSX.Element {
   const host = useRef<HTMLDivElement>(null);
   const view = useRef<EditorView | null>(null);
   const editableComp = useRef(new Compartment());
@@ -112,6 +116,8 @@ export const SourceEditor = forwardRef<
   onCutCommentsRef.current = onCutComments;
   const onPasteCommentsRef = useRef(onPasteComments);
   onPasteCommentsRef.current = onPasteComments;
+  const onPasteImageRef = useRef(onPasteImage);
+  onPasteImageRef.current = onPasteImage;
 
   useImperativeHandle(ref, () => ({
     scrollToLine(line: number) {
@@ -250,6 +256,22 @@ export const SourceEditor = forwardRef<
             copy: (e, v) => handleCopyCut(e, v, false),
             cut: (e, v) => handleCopyCut(e, v, true),
             paste: (e, v) => {
+              // An image on the clipboard (screenshot tool, browser "copy image", etc.) — write
+              // it to disk and embed a Markdown image link, instead of falling through to
+              // CodeMirror's native paste (which has no text/plain to insert for an image-only
+              // clipboard anyway). Checked first: an image clipboard doesn't also carry the
+              // inplan comment payload the branch below looks for.
+              const imgFile = [...(e.clipboardData?.files ?? [])].find((f) => f.type.startsWith("image/"));
+              if (imgFile && onPasteImageRef.current) {
+                e.preventDefault();
+                const pos = v.state.selection.main.from;
+                const onPasteImage = onPasteImageRef.current;
+                void imgFile.arrayBuffer().then(async (bytes) => {
+                  const relPath = await onPasteImage(bytes, imgFile.type);
+                  if (relPath) v.dispatch({ changes: { from: pos, to: pos, insert: `![](${relPath})` } });
+                });
+                return true;
+              }
               if (!onPasteCommentsRef.current) return false;
               const html = e.clipboardData?.getData("text/html") ?? "";
               const payload = html ? readClipHtml(html) : null;

--- a/packages/renderer/src/SourceEditor.tsx
+++ b/packages/renderer/src/SourceEditor.tsx
@@ -265,12 +265,18 @@ export const SourceEditor = forwardRef<
               if (imgFile && onPasteImageRef.current) {
                 e.preventDefault();
                 const onPasteImage = onPasteImageRef.current;
-                void imgFile.arrayBuffer().then(async (bytes) => {
-                  const relPath = await onPasteImage(bytes, imgFile.type);
-                  if (!relPath) return;
-                  const pos = v.state.selection.main.from;
-                  v.dispatch(imageEdit(v.state.doc.toString(), pos, pos, relPath));
-                });
+                void imgFile
+                  .arrayBuffer()
+                  .then(async (bytes) => {
+                    const relPath = await onPasteImage(bytes, imgFile.type);
+                    if (!relPath) return;
+                    const pos = v.state.selection.main.from;
+                    v.dispatch(imageEdit(v.state.doc.toString(), pos, pos, relPath));
+                  })
+                  // arrayBuffer()/onPasteImage() rejected (e.g. the host write failed) — this
+                  // component has no error-reporting channel of its own; drop it rather than an
+                  // unhandled rejection. The preview pane's paste handler (App.tsx) does have one.
+                  .catch(() => {});
                 return true;
               }
               if (!onPasteCommentsRef.current) return false;

--- a/packages/renderer/src/i18n.tsx
+++ b/packages/renderer/src/i18n.tsx
@@ -156,6 +156,7 @@ export const EN: Catalog = {
   "msg.turnFinished": "turn finished — waiting for agent",
   "msg.unsavedAnswer": "You have an unsaved answer — click “Answer” to save it, or Send again to skip.",
   "msg.cantAnchor": "Comments can't be anchored to this selection",
+  "msg.imagePasteFailed": "couldn't paste image",
   // status bar
   "status.ready": "ready",
   "status.thinking": "Agent is thinking",

--- a/packages/renderer/src/markdown.ts
+++ b/packages/renderer/src/markdown.ts
@@ -99,12 +99,17 @@ md.renderer.rules.image = (tokens, idx, opts, env, self) => {
 // Tag block-level elements with their 0-based source line for cross-pane sync.
 // `tr_open` is tagged too so clicking a table cell syncs to the clicked ROW's source
 // line, not the table's first line (the cells themselves carry no line map).
+// data-end-line (tok.map's exclusive end, minus one) is the block's own LAST source line —
+// used to insert content (e.g. a pasted image) after the whole block, not mid-paragraph.
 const BLOCK_RULES = ["paragraph_open", "heading_open", "blockquote_open", "bullet_list_open", "ordered_list_open", "list_item_open", "table_open", "tr_open", "hr"];
 for (const name of BLOCK_RULES) {
   const orig = md.renderer.rules[name];
   md.renderer.rules[name] = (tokens, idx, options, env, self) => {
     const tok = tokens[idx]!;
-    if (tok.map) tok.attrSet("data-line", String(tok.map[0]));
+    if (tok.map) {
+      tok.attrSet("data-line", String(tok.map[0]));
+      tok.attrSet("data-end-line", String(tok.map[1] - 1));
+    }
     return orig ? orig(tokens, idx, options, env, self) : self.renderToken(tokens, idx, options);
   };
 }

--- a/packages/renderer/src/styles.css
+++ b/packages/renderer/src/styles.css
@@ -224,6 +224,7 @@ body {
 .ap-preview { flex: 1; min-width: 0; overflow: auto; padding: 28px 36px; border-right: 1px solid var(--line); background: var(--bg); }
 .ap-rendered { max-width: 760px; }
 .ap-rendered img { max-width: 100%; height: auto; } /* a pasted/picked image is embedded at its native pixel size otherwise */
+.ap-rendered:focus { outline: none; } /* focusable (tabIndex) only so it can receive a native paste event */
 .ap-rendered h1, .ap-rendered h2, .ap-rendered h3 { font-family: var(--serif); font-weight: 500; letter-spacing: -0.01em; line-height: 1.15; }
 .ap-rendered .ap-anchor { background: var(--anchor); border-bottom: 2px solid var(--amber); color: inherit; text-decoration: none; cursor: pointer; border-radius: 2px; }
 /* Click-to-focus flash: anchored comment pulses darker yellow then fades to normal (1s). */

--- a/packages/renderer/src/styles.css
+++ b/packages/renderer/src/styles.css
@@ -224,7 +224,7 @@ body {
 .ap-preview { flex: 1; min-width: 0; overflow: auto; padding: 28px 36px; border-right: 1px solid var(--line); background: var(--bg); }
 .ap-rendered { max-width: 760px; }
 .ap-rendered img { max-width: 100%; height: auto; } /* a pasted/picked image is embedded at its native pixel size otherwise */
-.ap-rendered:focus { outline: none; } /* focusable (tabIndex) only so it can receive a native paste event */
+.ap-rendered:focus { outline: none; } /* tabIndex={-1}: click-focusable (to receive a native paste event) but not Tab-reachable, so there's no keyboard focus ring to suppress here */
 .ap-rendered h1, .ap-rendered h2, .ap-rendered h3 { font-family: var(--serif); font-weight: 500; letter-spacing: -0.01em; line-height: 1.15; }
 .ap-rendered .ap-anchor { background: var(--anchor); border-bottom: 2px solid var(--amber); color: inherit; text-decoration: none; cursor: pointer; border-radius: 2px; }
 /* Click-to-focus flash: anchored comment pulses darker yellow then fades to normal (1s). */

--- a/packages/renderer/test/App.navigation.test.tsx
+++ b/packages/renderer/test/App.navigation.test.tsx
@@ -69,6 +69,21 @@ describe("editor navigation (desktop)", () => {
     expect(document.body.textContent).not.toContain("Doc A body.");
   });
 
+  it("onNavigated clears the synced active-preview-line — a line highlighted in doc A must not carry over as 'active' in doc B", async () => {
+    const { fireNavigated } = mountWithNav("# A\n\nfirst line.\n\nsecond line.\n\n<!--inplan v1\n[]\n-->\n");
+    const { App } = await import("../src/App");
+    render(<App />);
+    await waitFor(() => expect(document.body.textContent).toContain("second line."));
+
+    const block = screen.getByText("first line.").closest("[data-line]")!;
+    fireEvent.click(block);
+    await waitFor(() => expect(document.querySelector(".ap-active-line")).not.toBeNull());
+
+    fireNavigated({ path: "docs/B.md", content: "# B\n\nDoc B body.\n\n<!--inplan v1\n[]\n-->\n" });
+    await waitFor(() => expect(document.body.textContent).toContain("Doc B body."));
+    expect(document.querySelector(".ap-active-line")).toBeNull();
+  });
+
   it("hides the nav buttons when the host has no navigate (web/tests)", async () => {
     document.body.innerHTML = '<div id="root"></div>';
     (window as unknown as { api: unknown }).api = createMemoryApi({ content: "# X\n\nbody\n\n<!--inplan v1\n[]\n-->\n" }).api;

--- a/packages/renderer/test/App.pasteImage.test.tsx
+++ b/packages/renderer/test/App.pasteImage.test.tsx
@@ -3,7 +3,8 @@
 //
 // App.tsx's onPasteImage wiring: derives a file extension from the pasted image's MIME type,
 // calls the host's optional saveAsset(bytes, ext), and hands the SourceEditor the resulting
-// relative link (or null when the host can't save one — e.g. no saveAsset at all).
+// relative link. Without saveAsset (e.g. a cloud doc), SourceEditor doesn't get an
+// onPasteImage prop at all — same gating as the toolbar's image button.
 
 import { cleanup, render, waitFor } from "@testing-library/react";
 import { forwardRef, useImperativeHandle } from "react";
@@ -62,11 +63,9 @@ describe("App onPasteImage wiring", () => {
     expect(saveAsset).toHaveBeenCalledWith(expect.any(ArrayBuffer), "jpg");
   });
 
-  it("resolves null without crashing when the host has no saveAsset (e.g. a cloud doc)", async () => {
+  it("passes no onPasteImage at all when the host has no saveAsset (e.g. a cloud doc) — same gating as the toolbar's image button", async () => {
     await mountApp(); // memoryApi never sets api.saveAsset
 
-    const result = await onPasteImage!(new ArrayBuffer(3), "image/png");
-
-    expect(result).toBeNull();
+    expect(onPasteImage).toBeUndefined();
   });
 });

--- a/packages/renderer/test/App.pasteImage.test.tsx
+++ b/packages/renderer/test/App.pasteImage.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment happy-dom
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// App.tsx's onPasteImage wiring: derives a file extension from the pasted image's MIME type,
+// calls the host's optional saveAsset(bytes, ext), and hands the SourceEditor the resulting
+// relative link (or null when the host can't save one — e.g. no saveAsset at all).
+
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { forwardRef, useImperativeHandle } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createMemoryApi } from "../src/memoryApi";
+
+type OnPasteImage = (bytes: ArrayBuffer, mime: string) => Promise<string | null>;
+let onPasteImage: OnPasteImage | undefined;
+
+vi.mock("../src/SourceEditor", () => ({
+  SourceEditor: forwardRef(function SourceEditorStub(props: { onPasteImage?: OnPasteImage }, ref: React.Ref<unknown>) {
+    onPasteImage = props.onPasteImage;
+    useImperativeHandle(ref, () => ({ scrollToLine() {}, selectRange() {} }));
+    return null;
+  }),
+}));
+
+const DOC = "# Plan\n\nHello world.\n\n<!--inplan v1\n[]\n-->\n";
+
+beforeEach(() => {
+  // 3-pane layout so the source pane (and its SourceEditor) actually mounts — the default
+  // 2-pane layout starts on the Comments tab, which never renders SourceEditor at all.
+  localStorage.setItem("ap-layout", JSON.stringify({ panes: 3, zoom: 1, showResolvedOrphaned: false, cadence: "turn", srcW: 380, cmtW: 380 }));
+  document.body.innerHTML = '<div id="root"></div>';
+  const session = createMemoryApi({ content: DOC });
+  (window as unknown as { api: unknown }).api = session.api;
+  onPasteImage = undefined;
+});
+afterEach(cleanup);
+
+async function mountApp() {
+  const { App } = await import("../src/App");
+  render(<App />);
+  await waitFor(() => expect(document.body.textContent).toContain("Hello world."));
+}
+
+describe("App onPasteImage wiring", () => {
+  it("derives the extension from MIME type and returns the host's relPath", async () => {
+    const saveAsset = vi.fn(async (_bytes: ArrayBuffer, ext: string) => ({ relPath: `plan.assets/x.${ext}` }));
+    (window as unknown as { api: { saveAsset: unknown } }).api.saveAsset = saveAsset;
+    await mountApp();
+
+    const result = await onPasteImage!(new ArrayBuffer(3), "image/png");
+
+    expect(saveAsset).toHaveBeenCalledWith(expect.any(ArrayBuffer), "png");
+    expect(result).toBe("plan.assets/x.png");
+  });
+
+  it("maps image/jpeg to the .jpg extension", async () => {
+    const saveAsset = vi.fn(async (_bytes: ArrayBuffer, ext: string) => ({ relPath: `plan.assets/x.${ext}` }));
+    (window as unknown as { api: { saveAsset: unknown } }).api.saveAsset = saveAsset;
+    await mountApp();
+
+    await onPasteImage!(new ArrayBuffer(3), "image/jpeg");
+
+    expect(saveAsset).toHaveBeenCalledWith(expect.any(ArrayBuffer), "jpg");
+  });
+
+  it("resolves null without crashing when the host has no saveAsset (e.g. a cloud doc)", async () => {
+    await mountApp(); // memoryApi never sets api.saveAsset
+
+    const result = await onPasteImage!(new ArrayBuffer(3), "image/png");
+
+    expect(result).toBeNull();
+  });
+});

--- a/packages/renderer/test/App.previewPasteImage.test.tsx
+++ b/packages/renderer/test/App.previewPasteImage.test.tsx
@@ -11,9 +11,13 @@ import { forwardRef, useImperativeHandle } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createMemoryApi } from "../src/memoryApi";
 
+// Exposes the SourceEditor's onCursorLine prop on window so a test can fire it directly — this
+// is how activePreviewLine gets set from the SOURCE pane's cursor (as opposed to a preview
+// click, which always lands on a block's own data-line), and it need not be a block boundary.
 vi.mock("../src/SourceEditor", () => ({
-  SourceEditor: forwardRef(function SourceEditorStub(_props: unknown, ref: React.Ref<unknown>) {
+  SourceEditor: forwardRef(function SourceEditorStub(props: { onCursorLine?: (line: number) => void }, ref: React.Ref<unknown>) {
     useImperativeHandle(ref, () => ({ scrollToLine() {}, selectRange() {} }));
+    (window as unknown as { __fireCursorLine?: (line: number) => void }).__fireCursorLine = (line) => props.onCursorLine?.(line);
     return null;
   }),
 }));
@@ -96,6 +100,36 @@ describe("preview pane image paste", () => {
     const html = document.querySelector(".ap-rendered")!.innerHTML;
     expect(html.indexOf("item one")).toBeLessThan(html.indexOf("plan.assets/x.png"));
     expect(html.indexOf("plan.assets/x.png")).toBeLessThan(html.indexOf("item two"));
+  });
+
+  it("with the active line synced mid-paragraph (source cursor, not a preview click), still inserts after the WHOLE paragraph instead of splitting it", async () => {
+    const { App } = await import("../src/App");
+    document.body.innerHTML = '<div id="root"></div>';
+    const midDoc = "# Plan\n\nline one\nline two\nline three continues\n\nSecond paragraph.\n";
+    const session = createMemoryApi({ content: midDoc });
+    (session.api as unknown as { saveAsset: unknown }).saveAsset = vi.fn(async () => ({ relPath: "plan.assets/x.png" }));
+    (window as unknown as { api: unknown }).api = session.api;
+    render(<App />);
+    await waitFor(() => expect(document.body.textContent).toContain("Second paragraph."));
+
+    // The (mocked) SourceEditor only mounts once the Source tab is open.
+    fireEvent.click(screen.getByRole("button", { name: "Source" }));
+    await waitFor(() => expect((window as unknown as { __fireCursorLine?: unknown }).__fireCursorLine).toBeTypeOf("function"));
+
+    // The paragraph ("line one\nline two\nline three continues") spans source lines 2-4 as ONE
+    // block (data-line=2, data-end-line=4). Sync to its MIDDLE line (3, "line two") — a line with
+    // no [data-line] element of its own, the case an exact-match lookup can't resolve.
+    act(() => (window as unknown as { __fireCursorLine: (line: number) => void }).__fireCursorLine(3));
+
+    const rendered = document.querySelector(".ap-rendered")!;
+    await act(async () => firePasteImage(rendered, PNG));
+    await waitFor(() => expect(document.querySelector(".ap-rendered")?.innerHTML).toContain("plan.assets/x.png"));
+
+    // Must land after "line three continues" (the paragraph's actual last line), not right after
+    // "line two" (which would split the paragraph mid-block).
+    const html = document.querySelector(".ap-rendered")!.innerHTML;
+    expect(html.indexOf("line three continues")).toBeLessThan(html.indexOf("plan.assets/x.png"));
+    expect(html.indexOf("plan.assets/x.png")).toBeLessThan(html.indexOf("Second paragraph."));
   });
 
   it("still renders as an actual <img> when relPath has a space (from a doc name like 'Product Plan.md') — a bare, unbracketed destination wouldn't parse as an image at all", async () => {

--- a/packages/renderer/test/App.previewPasteImage.test.tsx
+++ b/packages/renderer/test/App.previewPasteImage.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment happy-dom
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Pasting an image directly into the (read-only) rendered preview — not just the Source pane:
+// it's inserted right after the active (blue-highlighted, click-synced) block, using that
+// block's data-end-line so a paste into a multi-line paragraph lands after the WHOLE paragraph
+// rather than splitting it. No active block yet ⇒ appended at the end of the document.
+
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { forwardRef, useImperativeHandle } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createMemoryApi } from "../src/memoryApi";
+
+vi.mock("../src/SourceEditor", () => ({
+  SourceEditor: forwardRef(function SourceEditorStub(_props: unknown, ref: React.Ref<unknown>) {
+    useImperativeHandle(ref, () => ({ scrollToLine() {}, selectRange() {} }));
+    return null;
+  }),
+}));
+
+// A multi-line paragraph ("line one\nline two continues") so a click syncs to its FIRST source
+// line (2) while its data-end-line (3) differs — the case that actually exercises the fix.
+const DOC = "# Plan\n\nline one\nline two continues\n\nSecond paragraph.\n\n<!--inplan v1\n[]\n-->\n";
+const PNG = new File([new Uint8Array([1, 2, 3])], "shot.png", { type: "image/png" });
+
+function firePasteImage(el: Element, file: File) {
+  const ev = new ClipboardEvent("paste", { bubbles: true, cancelable: true });
+  Object.defineProperty(ev, "clipboardData", { value: { files: [file], getData: () => "" } });
+  el.dispatchEvent(ev);
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '<div id="root"></div>';
+  const session = createMemoryApi({ content: DOC });
+  (session.api as unknown as { saveAsset: unknown }).saveAsset = vi.fn(async () => ({ relPath: "plan.assets/x.png" }));
+  (window as unknown as { api: unknown }).api = session.api;
+});
+afterEach(cleanup);
+
+async function mountApp() {
+  const { App } = await import("../src/App");
+  render(<App />);
+  await waitFor(() => expect(document.body.textContent).toContain("Second paragraph."));
+}
+
+describe("preview pane image paste", () => {
+  it("with no active block yet, appends the image at the end of the document", async () => {
+    await mountApp();
+    const rendered = document.querySelector(".ap-rendered")!;
+
+    await act(async () => firePasteImage(rendered, PNG));
+    await waitFor(() => expect(document.querySelector(".ap-rendered")?.innerHTML).toContain("plan.assets/x.png"));
+
+    const html = document.querySelector(".ap-rendered")!.innerHTML;
+    expect(html.indexOf("Second paragraph.")).toBeLessThan(html.indexOf("plan.assets/x.png"));
+  });
+
+  it("inserts right after the WHOLE active paragraph (its data-end-line), not mid-paragraph", async () => {
+    await mountApp();
+    // Click the multi-line paragraph — syncs activePreviewLine to its FIRST line (2).
+    const para = screen.getByText(/line one/);
+    fireEvent.click(para.closest("[data-line]")!);
+
+    const rendered = document.querySelector(".ap-rendered")!;
+    await act(async () => firePasteImage(rendered, PNG));
+
+    await waitFor(() => expect(document.querySelector(".ap-rendered")?.innerHTML).toContain("plan.assets/x.png"));
+    // "line two continues" (the paragraph's LAST line) must precede the image in the source
+    // order; if the insert had used data-line (2) instead of data-end-line (3), the image
+    // would land between "line one" and "line two continues" instead.
+    const html = document.querySelector(".ap-rendered")!.innerHTML;
+    expect(html.indexOf("line two continues")).toBeLessThan(html.indexOf("plan.assets/x.png"));
+    expect(html.indexOf("plan.assets/x.png")).toBeLessThan(html.indexOf("Second paragraph."));
+  });
+
+  it("does nothing for a plain (non-image) paste", async () => {
+    const saveAsset = vi.fn();
+    await mountApp();
+    (window as unknown as { api: { saveAsset: unknown } }).api.saveAsset = saveAsset;
+    const rendered = document.querySelector(".ap-rendered")!;
+
+    const ev = new ClipboardEvent("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(ev, "clipboardData", { value: { files: [], getData: () => "plain text" } });
+    await act(async () => rendered.dispatchEvent(ev));
+
+    expect(saveAsset).not.toHaveBeenCalled();
+  });
+});

--- a/packages/renderer/test/App.previewPasteImage.test.tsx
+++ b/packages/renderer/test/App.previewPasteImage.test.tsx
@@ -143,6 +143,21 @@ describe("preview pane image paste", () => {
     expect(document.querySelector(".ap-rendered img")!.getAttribute("src")).toContain("Product%20Plan.assets/x.png");
   });
 
+  it("when the host write fails after preventDefault(), reports it instead of a silent unhandled rejection", async () => {
+    (window as unknown as { api: { saveAsset: unknown } }).api.saveAsset = vi.fn(async () => {
+      throw new Error("disk full");
+    });
+    await mountApp();
+    const rendered = document.querySelector(".ap-rendered")!;
+    const before = document.querySelector(".ap-rendered")!.innerHTML;
+
+    await act(async () => firePasteImage(rendered, PNG));
+    await waitFor(() => expect(document.body.textContent).toContain("couldn't paste image"));
+
+    // No image link was inserted — the doc is untouched.
+    expect(document.querySelector(".ap-rendered")!.innerHTML).toBe(before);
+  });
+
   it("does nothing for a plain (non-image) paste", async () => {
     const saveAsset = vi.fn();
     await mountApp();

--- a/packages/renderer/test/App.previewPasteImage.test.tsx
+++ b/packages/renderer/test/App.previewPasteImage.test.tsx
@@ -73,6 +73,31 @@ describe("preview pane image paste", () => {
     expect(html.indexOf("plan.assets/x.png")).toBeLessThan(html.indexOf("Second paragraph."));
   });
 
+  it("with a list item active, inserts after the ITEM (not the whole list) — a <ul> and its first <li> share a data-line, and the item is the more specific (last-DOM-order) match", async () => {
+    const { App } = await import("../src/App");
+    document.body.innerHTML = '<div id="root"></div>';
+    const listDoc = "# Plan\n\n- item one\n- item two\n\nNext paragraph.\n";
+    const session = createMemoryApi({ content: listDoc });
+    (session.api as unknown as { saveAsset: unknown }).saveAsset = vi.fn(async () => ({ relPath: "plan.assets/x.png" }));
+    (window as unknown as { api: unknown }).api = session.api;
+    render(<App />);
+    await waitFor(() => expect(document.body.textContent).toContain("Next paragraph."));
+
+    // Both the <ul> and its first <li> ("item one") report data-line="2" — click syncs to that line.
+    const itemOne = screen.getByText("item one");
+    fireEvent.click(itemOne.closest("[data-line]")!);
+
+    const rendered = document.querySelector(".ap-rendered")!;
+    await act(async () => firePasteImage(rendered, PNG));
+    await waitFor(() => expect(document.querySelector(".ap-rendered")?.innerHTML).toContain("plan.assets/x.png"));
+
+    // Must land right after "item one" (the <li>'s own end line), before "item two" — using the
+    // <ul>'s end line instead (the querySelector-first-match bug) would push it past "item two".
+    const html = document.querySelector(".ap-rendered")!.innerHTML;
+    expect(html.indexOf("item one")).toBeLessThan(html.indexOf("plan.assets/x.png"));
+    expect(html.indexOf("plan.assets/x.png")).toBeLessThan(html.indexOf("item two"));
+  });
+
   it("still renders as an actual <img> when relPath has a space (from a doc name like 'Product Plan.md') — a bare, unbracketed destination wouldn't parse as an image at all", async () => {
     (window as unknown as { api: { saveAsset: unknown } }).api.saveAsset = vi.fn(async () => ({ relPath: "Product Plan.assets/x.png" }));
     await mountApp();

--- a/packages/renderer/test/App.previewPasteImage.test.tsx
+++ b/packages/renderer/test/App.previewPasteImage.test.tsx
@@ -158,6 +158,32 @@ describe("preview pane image paste", () => {
     expect(document.querySelector(".ap-rendered")!.innerHTML).toBe(before);
   });
 
+  it("does not apply the image link to a doc the user navigated to WHILE the save was still in flight", async () => {
+    let resolveSave!: (v: { relPath: string }) => void;
+    const session = createMemoryApi({ content: DOC }) as unknown as {
+      api: typeof window.api & { onNavigated: (cb: (p: { path: string; content: string }) => void) => void };
+    };
+    session.api.saveAsset = vi.fn(() => new Promise((resolve) => { resolveSave = resolve; }));
+    let navigatedCb: ((p: { path: string; content: string }) => void) | undefined;
+    session.api.onNavigated = (cb) => void (navigatedCb = cb);
+    (window as unknown as { api: unknown }).api = session.api;
+    await mountApp();
+
+    const rendered = document.querySelector(".ap-rendered")!;
+    await act(async () => firePasteImage(rendered, PNG));
+
+    // The save is still pending — navigate to a different document before it resolves.
+    await act(async () => navigatedCb?.({ path: "docs/B.md", content: "# B\n\nDoc B body.\n\n<!--inplan v1\n[]\n-->\n" }));
+    await waitFor(() => expect(document.body.textContent).toContain("Doc B body."));
+
+    await act(async () => resolveSave({ relPath: "plan.assets/x.png" }));
+    // Give the paste handler's continuation a turn to run (and NOT apply to doc B).
+    await act(async () => await Promise.resolve());
+
+    expect(document.querySelector(".ap-rendered")!.innerHTML).not.toContain("plan.assets/x.png");
+    expect(document.body.textContent).toContain("Doc B body.");
+  });
+
   it("does nothing for a plain (non-image) paste", async () => {
     const saveAsset = vi.fn();
     await mountApp();

--- a/packages/renderer/test/App.previewPasteImage.test.tsx
+++ b/packages/renderer/test/App.previewPasteImage.test.tsx
@@ -73,6 +73,17 @@ describe("preview pane image paste", () => {
     expect(html.indexOf("plan.assets/x.png")).toBeLessThan(html.indexOf("Second paragraph."));
   });
 
+  it("still renders as an actual <img> when relPath has a space (from a doc name like 'Product Plan.md') — a bare, unbracketed destination wouldn't parse as an image at all", async () => {
+    (window as unknown as { api: { saveAsset: unknown } }).api.saveAsset = vi.fn(async () => ({ relPath: "Product Plan.assets/x.png" }));
+    await mountApp();
+    const rendered = document.querySelector(".ap-rendered")!;
+
+    await act(async () => firePasteImage(rendered, PNG));
+    await waitFor(() => expect(document.querySelector(".ap-rendered img")).toBeTruthy());
+
+    expect(document.querySelector(".ap-rendered img")!.getAttribute("src")).toContain("Product%20Plan.assets/x.png");
+  });
+
   it("does nothing for a plain (non-image) paste", async () => {
     const saveAsset = vi.fn();
     await mountApp();

--- a/packages/renderer/test/SourceEditor.pasteImage.test.tsx
+++ b/packages/renderer/test/SourceEditor.pasteImage.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment happy-dom
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Pasting an image (screenshot tool, browser "copy image", etc.) onto the source editor: the
+// editor hands the raw bytes + MIME type to the app's onPasteImage, then inserts a Markdown
+// image link at the cursor once it resolves. A clipboard with no image file falls through to
+// the existing (comment-aware) paste handling untouched.
+
+import { cleanup, render } from "@testing-library/react";
+import { createRef } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SourceEditor, type SourceEditorHandle } from "../src/SourceEditor";
+
+function mount(onPasteImage?: (bytes: ArrayBuffer, mime: string) => Promise<string | null>) {
+  const ref = createRef<SourceEditorHandle>();
+  const utils = render(<SourceEditor ref={ref} value="Hello world" editable onChange={() => {}} onPasteImage={onPasteImage} />);
+  const content = utils.container.querySelector(".cm-content") as HTMLElement;
+  const text = () => content.textContent;
+  return { ref, content, text };
+}
+
+/** A synthetic "image on the clipboard" paste — a plain object standing in for DataTransfer
+ *  (happy-dom's real DataTransfer doesn't wire `.items.add()` through to `.files`), which is
+ *  all the handler under test reads (`e.clipboardData.files`). */
+function firePasteImage(content: HTMLElement, file: File): ClipboardEvent {
+  const ev = new ClipboardEvent("paste", { bubbles: true, cancelable: true });
+  Object.defineProperty(ev, "clipboardData", { value: { files: [file], getData: () => "" } });
+  content.dispatchEvent(ev);
+  return ev;
+}
+
+const PNG = new File([new Uint8Array([1, 2, 3])], "shot.png", { type: "image/png" });
+
+afterEach(cleanup);
+
+describe("SourceEditor image paste", () => {
+  it("hands the image's bytes + MIME type to onPasteImage and inserts the returned link", async () => {
+    const onPasteImage = vi.fn(async () => "design.plan.assets/image-20260731.png");
+    const { ref, text } = mount(onPasteImage);
+    ref.current!.selectRange(0, 0);
+
+    await firePasteImage(document.querySelector(".cm-content")!, PNG);
+    await Promise.resolve(); // let the paste handler's async chain settle
+    await Promise.resolve();
+
+    expect(onPasteImage).toHaveBeenCalledTimes(1);
+    const [bytes, mime] = onPasteImage.mock.calls[0]!;
+    expect(mime).toBe("image/png");
+    expect(new Uint8Array(bytes)).toEqual(new Uint8Array([1, 2, 3]));
+    expect(text()).toBe("![](design.plan.assets/image-20260731.png)Hello world");
+  });
+
+  it("does nothing (no insert) when onPasteImage resolves null — e.g. the host couldn't write it", async () => {
+    const onPasteImage = vi.fn(async () => null);
+    const { ref, text } = mount(onPasteImage);
+    ref.current!.selectRange(0, 0);
+
+    await firePasteImage(document.querySelector(".cm-content")!, PNG);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(text()).toBe("Hello world");
+  });
+
+  it("without an onPasteImage prop, an image paste falls through untouched (no crash)", () => {
+    const { content, text } = mount(undefined);
+    firePasteImage(content, PNG);
+    expect(text()).toBe("Hello world");
+  });
+
+  it("a text-only paste is unaffected by the image-paste handler", () => {
+    const onPasteImage = vi.fn();
+    const { content, text } = mount(onPasteImage);
+    const ev = new ClipboardEvent("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(ev, "clipboardData", { value: { files: [], getData: () => "plain text" } });
+    content.dispatchEvent(ev);
+    expect(onPasteImage).not.toHaveBeenCalled();
+    expect(text()).toBe("plain textHello world"); // no inplan comment payload either → native paste happens
+  });
+});

--- a/packages/renderer/test/SourceEditor.pasteImage.test.tsx
+++ b/packages/renderer/test/SourceEditor.pasteImage.test.tsx
@@ -47,7 +47,19 @@ describe("SourceEditor image paste", () => {
     const [bytes, mime] = onPasteImage.mock.calls[0]!;
     expect(mime).toBe("image/png");
     expect(new Uint8Array(bytes)).toEqual(new Uint8Array([1, 2, 3]));
-    expect(text()).toBe("![](design.plan.assets/image-20260731.png)Hello world");
+    expect(text()).toBe("![](<design.plan.assets/image-20260731.png>)Hello world");
+  });
+
+  it("uses the angle-bracket destination form so a relPath with a space (from a doc name like 'Product Plan.md') still parses as an image", async () => {
+    const onPasteImage = vi.fn(async () => "Product Plan.assets/image-20260731.png");
+    const { ref, text } = mount(onPasteImage);
+    ref.current!.selectRange(0, 0);
+
+    await firePasteImage(document.querySelector(".cm-content")!, PNG);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(text()).toBe("![](<Product Plan.assets/image-20260731.png>)Hello world");
   });
 
   it("does nothing (no insert) when onPasteImage resolves null — e.g. the host couldn't write it", async () => {

--- a/packages/renderer/test/SourceEditor.pasteImage.test.tsx
+++ b/packages/renderer/test/SourceEditor.pasteImage.test.tsx
@@ -62,6 +62,24 @@ describe("SourceEditor image paste", () => {
     expect(text()).toBe("![](<Product Plan.assets/image-20260731.png>)Hello world");
   });
 
+  it("reads the cursor position at insert time, not at paste time — a save that finishes after the user has moved the cursor lands the image at the CURRENT position, not a stale one", async () => {
+    let resolveSave!: (relPath: string) => void;
+    const onPasteImage = vi.fn(() => new Promise<string | null>((resolve) => { resolveSave = resolve; }));
+    const { ref, text } = mount(onPasteImage);
+    ref.current!.selectRange(0, 0);
+
+    await firePasteImage(document.querySelector(".cm-content")!, PNG);
+    // The save is still in flight (onPasteImage hasn't resolved) — move the cursor to the end.
+    ref.current!.selectRange(11, 11); // "Hello world".length === 11
+    resolveSave("design.plan.assets/image-20260731.png");
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Capturing the position before the await (the stale-pos bug) would insert at the front
+    // instead, and could throw a RangeError entirely if the doc had shrunk below that position.
+    expect(text()).toBe("Hello world![](<design.plan.assets/image-20260731.png>)");
+  });
+
   it("does nothing (no insert) when onPasteImage resolves null — e.g. the host couldn't write it", async () => {
     const onPasteImage = vi.fn(async () => null);
     const { ref, text } = mount(onPasteImage);

--- a/packages/renderer/test/markdown.test.ts
+++ b/packages/renderer/test/markdown.test.ts
@@ -23,6 +23,16 @@ describe("renderMarkdown", () => {
     expect(lines.length).toBe(3);
     expect(new Set(lines).size).toBe(3); // distinct lines, not all the table's first line
   });
+
+  it("tags a single-line paragraph with matching data-line and data-end-line", () => {
+    const html = renderMarkdown("intro\n\nOne line.\n");
+    expect(html).toMatch(/data-line="2" data-end-line="2"/);
+  });
+
+  it("tags a multi-line paragraph's data-end-line as its LAST line, not its first (so an insert-after lands past the whole paragraph)", () => {
+    const html = renderMarkdown("line one\nline two\nline three\n");
+    expect(html).toMatch(/data-line="0" data-end-line="2"/);
+  });
 });
 
 describe("renderMarkdown image src resolution (pasted/picked images)", () => {


### PR DESCRIPTION
## Summary
- Builds on the Source toolbar's image-upload work (#64, merged) and reuses its asset-saving infrastructure (`asset:save` IPC, `saveAsset` bridge, `markdown.ts`'s `file://` image rendering, the CSP `img-src` fix) — this adds clipboard **paste** of an image on top of that.
- Works in two places: the Source pane (CodeMirror) and directly in the rendered preview.
- A paste into the preview inserts the link right after the active (click-synced) block's LAST source line — a `data-end-line` alongside the existing `data-line` block tagging in `markdown.ts` — so pasting into a multi-line paragraph doesn't split it. No active block yet ⇒ appended at the end of the document.
- Both paste paths use the angle-bracket image destination (`![](<relPath>)`), matching `imageEdit`'s fix from #64's review — a doc name with a space/paren (e.g. "Product Plan.md") would otherwise produce a path markdown-it's bare destination syntax can't parse as an image link at all.
- Local-only for now; cloud-doc image storage (Supabase Storage or similar) is a follow-up decision.

## Test plan
- [x] `SourceEditor.pasteImage.test.tsx`, `App.pasteImage.test.tsx`, `App.previewPasteImage.test.tsx` — including a case for a relPath with a space, asserting it still renders as a real `<img>`
- [x] Full renderer/app suite passing (589 tests), typecheck clean across all workspaces
- [x] Verified against the real Electron app via Playwright `_electron`: paste into the Source pane inserts at the cursor; paste into the preview (after clicking a paragraph) inserts right after that paragraph
- [x] Manually verified in the running app

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/65?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Paste images directly into the source editor or rendered preview.
  * Pasted images are saved automatically and inserted as Markdown image links.
  * Preview pasting places images after the active content block or appends them when none is selected.
  * HTTPS remote images are supported alongside local images.

* **Bug Fixes**
  * Improved image placement for multi-line content and asset paths containing spaces.
  * Added feedback when image saving fails.
  * Preview highlighting now remains accurate during navigation and nested content selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->