### PR TITLE
test(e2e): cover the Source toolbar + image insertion through the real app (#64)

### DIFF
--- a/e2e/sourceToolbar.spec.ts
+++ b/e2e/sourceToolbar.spec.ts
@@ -68,16 +68,22 @@ test("Checklist toggles a task marker on and back off", async () => {
 });
 
 test("the Image button saves a picked PNG and the preview renders it from a file:// URL", async () => {
-  // Drive the hidden <input type=file> the toolbar's Image button clicks — setInputFiles bypasses
-  // the OS-native picker while exercising the real onChange → asset:save → insert path.
-  await win.locator('input[type="file"]').setInputFiles({ name: "shot.png", mimeType: "image/png", buffer: PNG_1x1 });
+  // Click the REAL Image toolbar button (not the raw input) so a broken button→input handler is
+  // caught too; it opens the OS picker, which Playwright intercepts via the filechooser event —
+  // exercising the whole button → onChange → asset:save → insert path.
+  const chooserPromise = win.waitForEvent("filechooser");
+  await win.getByRole("button", { name: "Image", exact: true }).click();
+  const chooser = await chooserPromise;
+  await chooser.setFiles({ name: "shot.png", mimeType: "image/png", buffer: PNG_1x1 });
 
   // The insert uses the angle-bracket destination and points at the doc's sibling assets folder.
   await expect.poll(() => source(win), { timeout: 10_000 }).toMatch(/!\[\]\(<[^>]*\.assets\/image-[^>]*\.png>\)/);
 
   // The whole chain works only if the file was written, the CSP allows file:, markdown.ts rewrote
-  // the relative src to file://, and the browser loaded it — assert the rendered <img> has pixels.
+  // the relative src to a file:// URL, and the browser loaded it. Assert BOTH: the src is actually
+  // a file:// URL (proves markdown.ts resolved it, not just any decodable image) AND it has pixels.
   const img = win.locator(".ap-rendered img, .ap-preview img").first();
   await expect(img).toBeVisible({ timeout: 10_000 });
+  await expect.poll(() => img.getAttribute("src"), { timeout: 10_000 }).toMatch(/^file:\/\/.*\.assets\/image-.*\.png$/);
   await expect.poll(() => img.evaluate((el: HTMLImageElement) => el.naturalWidth), { timeout: 10_000 }).toBeGreaterThan(0);
 });

--- a/e2e/sourceToolbar.spec.ts
+++ b/e2e/sourceToolbar.spec.ts
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// e2e for the Source pane's formatting toolbar + image insertion (#64), through the REAL app —
+// the browser-only behaviours the happy-dom unit suite can't reach: the toolbar's imperative
+// commands driving a real CodeMirror, the heading dropdown, and (the high-value one) a picked
+// image travelling the WHOLE asset path end to end — `asset:save` writes it next to the doc,
+// the CSP allows `file:`, markdown.ts resolves the relative src to a `file://` URL, and the
+// preview `<img>` actually loads it (naturalWidth > 0). A regression in any of those links
+// fails this test, which the unit tests (pure logic + jsdom, no real image load) can't catch.
+
+import { expect, test, type ElectronApplication, type Page } from "@playwright/test";
+import { launch, quit, setPanes, type Ctx } from "./helpers";
+
+let ctx: Ctx;
+let app: ElectronApplication;
+let win: Page;
+
+// A valid 1×1 transparent PNG — enough for the browser to decode (naturalWidth becomes 1).
+const PNG_1x1 = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+  "base64",
+);
+
+/** Read the CodeMirror source text (the whole doc body as the editor sees it). */
+async function source(page: Page): Promise<string> {
+  return (await page.locator(".cm-content").textContent()) ?? "";
+}
+
+/** Focus the source editor, jump to the end, and type a fresh line — returns with the cursor at the
+ *  end of `word` on its own line (no trailing selection). */
+async function typeFreshLine(page: Page, word: string): Promise<void> {
+  const cm = page.locator(".cm-content");
+  await cm.click();
+  await page.keyboard.press("ControlOrMeta+End");
+  await page.keyboard.type(`\n${word}`);
+}
+
+test.beforeEach(async () => {
+  ctx = await launch();
+  app = ctx.app;
+  win = ctx.win;
+  await setPanes(win, 3); // the source pane (CodeMirror + toolbar) only mounts with the source visible
+  await expect(win.locator(".ap-src-toolbar")).toBeVisible({ timeout: 5_000 });
+});
+test.afterEach(() => quit(app));
+
+test("Bold wraps the selected word in the source", async () => {
+  await typeFreshLine(win, "BOLDME");
+  for (let i = 0; i < "BOLDME".length; i++) await win.keyboard.press("Shift+ArrowLeft"); // select BOLDME
+  await win.getByRole("button", { name: "Bold", exact: true }).click();
+  await expect.poll(() => source(win)).toContain("**BOLDME**");
+});
+
+test("Heading dropdown applies H2 to the cursor's line", async () => {
+  await typeFreshLine(win, "MyHeading");
+  await win.getByTitle("Heading", { exact: true }).click(); // open the level picker
+  await win.getByRole("menuitem", { name: "Heading 2", exact: true }).click();
+  await expect.poll(() => source(win)).toContain("## MyHeading");
+});
+
+test("Checklist toggles a task marker on and back off", async () => {
+  await typeFreshLine(win, "a task");
+  const checklist = win.getByRole("button", { name: "Checklist", exact: true });
+  await checklist.click();
+  await expect.poll(() => source(win)).toContain("- [ ] a task");
+  await checklist.click(); // re-toggle strips it (recognizes the "- [ ] " prefix)
+  await expect.poll(() => source(win)).not.toContain("- [ ] a task");
+});
+
+test("the Image button saves a picked PNG and the preview renders it from a file:// URL", async () => {
+  // Drive the hidden <input type=file> the toolbar's Image button clicks — setInputFiles bypasses
+  // the OS-native picker while exercising the real onChange → asset:save → insert path.
+  await win.locator('input[type="file"]').setInputFiles({ name: "shot.png", mimeType: "image/png", buffer: PNG_1x1 });
+
+  // The insert uses the angle-bracket destination and points at the doc's sibling assets folder.
+  await expect.poll(() => source(win), { timeout: 10_000 }).toMatch(/!\[\]\(<[^>]*\.assets\/image-[^>]*\.png>\)/);
+
+  // The whole chain works only if the file was written, the CSP allows file:, markdown.ts rewrote
+  // the relative src to file://, and the browser loaded it — assert the rendered <img> has pixels.
+  const img = win.locator(".ap-rendered img, .ap-preview img").first();
+  await expect(img).toBeVisible({ timeout: 10_000 });
+  await expect.poll(() => img.evaluate((el: HTMLImageElement) => el.naturalWidth), { timeout: 10_000 }).toBeGreaterThan(0);
+});


### PR DESCRIPTION
## Why
The #64 formatting toolbar + image button merged with **unit** coverage only (pure edit logic in `markdownEdits.test.ts` + jsdom component wiring). The "verified via Playwright `_electron`" in that PR was **manual** — nothing committed. This adds the committed e2e for the browser-only behaviour the happy-dom suite structurally can't reach.

## What
A standalone Electron spec (`e2e/sourceToolbar.spec.ts`, same pattern as `editing.spec.ts`), 4 tests:

1. **Bold** wraps a real CodeMirror selection (`**BOLDME**`).
2. **Heading dropdown** applies H2 to the cursor's line (`## MyHeading`).
3. **Checklist** toggles `- [ ] ` on and back off (guards the `prefixPattern` fix from #64's review).
4. **Image button → renders from `file://`** — the high-value one. Drives the hidden `<input type=file>` with a 1×1 PNG and asserts the whole asset path end to end: `asset:save` writes the file → CSP allows `file:` → `markdown.ts` resolves the relative src to a `file://` URL → the `<img>` actually loads (`naturalWidth > 0`). A regression in **any** of those links fails this test — exactly the integration the unit tests (no real image load) can't catch. Also asserts the angle-bracket destination (`![](<….assets/image-….png>)`).

## Validation
- `playwright test --list` compiles all 4 (I can't launch Electron in this environment — no display).
- Triggered the `e2e-nightly` workflow via `workflow_dispatch` on this branch to run them under Xvfb against the real app; result linked in a comment.

## Scope
Electron-only (the image button needs `saveAsset`, absent on web). Folding the format buttons into the cross-host `editorControls.shared.ts` (so they also run on web) is a sensible follow-up; kept out here to avoid touching the file the cloud imports.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/66?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for source toolbar formatting, including bold text, H2 headings, and checklist toggling.
  * Added image upload coverage, including file selection, asset saving, Markdown insertion, security policy handling, and rendered image loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->