### PR TITLE
fix(app): desktop plugin renderer entry was CORS-blocked on Electron 43

### DIFF
--- a/e2e/desktopPlugin.spec.ts
+++ b/e2e/desktopPlugin.spec.ts
@@ -53,6 +53,7 @@ let win: Page;
 // either was previously invisible (the page trace sees neither the main stderr nor, reliably, the
 // renderer console). Dumped in afterAll so the next regression is diagnosable from the CI log.
 const capturedLogs: string[] = [];
+let flushStderr: () => void = () => {};
 
 test.beforeAll(async () => {
   const dir = mkdtempSync(join(tmpdir(), "inplan-plugin-e2e-"));
@@ -87,14 +88,31 @@ test.beforeAll(async () => {
     executablePath: join(REPO, "node_modules/.bin/electron"),
     env: { ...process.env, INPLAN_HOME: home, INPLAN_SIDECAR_DIR: join(dir, "sidecars"), INPLAN_PLUGIN_PUBLIC_KEY: PUB_PEM },
   });
-  app.process().stderr?.on("data", (d: Buffer) => capturedLogs.push(d.toString().trimEnd()));
+  // Buffer stderr by line — a `data` chunk is arbitrary bytes, so a diagnostic line can split
+  // across chunks; accumulate and only push complete lines (the remainder flushes in afterAll).
+  let stderrBuf = "";
+  app.process().stderr?.on("data", (d: Buffer) => {
+    stderrBuf += d.toString();
+    const parts = stderrBuf.split("\n");
+    stderrBuf = parts.pop() ?? "";
+    for (const line of parts) capturedLogs.push(line);
+  });
+  flushStderr = () => {
+    if (stderrBuf) capturedLogs.push(stderrBuf);
+  };
+  // Register renderer console + pageerror listeners on EVERY window as it opens (via app.on("window"),
+  // before firstWindow resolves), so console output during initial document load and the first plugin
+  // import — which can happen before firstWindow returns — isn't missed.
+  app.on("window", (page) => {
+    page.on("console", (m) => capturedLogs.push(`[renderer.console.${m.type()}] ${m.text()}`));
+    page.on("pageerror", (e) => capturedLogs.push(`[renderer.pageerror] ${e.message}`));
+  });
   win = await app.firstWindow();
-  win.on("console", (m) => capturedLogs.push(`[renderer.console.${m.type()}] ${m.text()}`));
-  win.on("pageerror", (e) => capturedLogs.push(`[renderer.pageerror] ${e.message}`));
   await expect(win.locator("body")).toContainText("Plugin E2E", { timeout: 15_000 });
 });
 
 test.afterAll(async () => {
+  flushStderr(); // emit any trailing partial stderr line
   const relevant = capturedLogs.filter((l) => /\[inplan\]|\[renderer\.|plugin|CORS|Refused|Security|verif|lease|sha|scheme|import/i.test(l));
   if (relevant.length) console.log("=== plugin diagnostics (main stderr + renderer console) ===\n" + relevant.join("\n"));
   await app?.evaluate(({ app: a }) => a.exit(0)).catch(() => {});

--- a/e2e/desktopPlugin.spec.ts
+++ b/e2e/desktopPlugin.spec.ts
@@ -48,6 +48,11 @@ export function activate(session){globalThis.__E2E_PLUGIN={active:true,session};
 
 let app: ElectronApplication;
 let win: Page;
+// Capture the Electron MAIN-process stderr AND the RENDERER console/pageerror — the plugin trust
+// path spans both (main verifies + serves; the renderer imports + activates), and a failure in
+// either was previously invisible (the page trace sees neither the main stderr nor, reliably, the
+// renderer console). Dumped in afterAll so the next regression is diagnosable from the CI log.
+const capturedLogs: string[] = [];
 
 test.beforeAll(async () => {
   const dir = mkdtempSync(join(tmpdir(), "inplan-plugin-e2e-"));
@@ -82,11 +87,16 @@ test.beforeAll(async () => {
     executablePath: join(REPO, "node_modules/.bin/electron"),
     env: { ...process.env, INPLAN_HOME: home, INPLAN_SIDECAR_DIR: join(dir, "sidecars"), INPLAN_PLUGIN_PUBLIC_KEY: PUB_PEM },
   });
+  app.process().stderr?.on("data", (d: Buffer) => capturedLogs.push(d.toString().trimEnd()));
   win = await app.firstWindow();
+  win.on("console", (m) => capturedLogs.push(`[renderer.console.${m.type()}] ${m.text()}`));
+  win.on("pageerror", (e) => capturedLogs.push(`[renderer.pageerror] ${e.message}`));
   await expect(win.locator("body")).toContainText("Plugin E2E", { timeout: 15_000 });
 });
 
 test.afterAll(async () => {
+  const relevant = capturedLogs.filter((l) => /\[inplan\]|\[renderer\.|plugin|CORS|Refused|Security|verif|lease|sha|scheme|import/i.test(l));
+  if (relevant.length) console.log("=== plugin diagnostics (main stderr + renderer console) ===\n" + relevant.join("\n"));
   await app?.evaluate(({ app: a }) => a.exit(0)).catch(() => {});
   await app?.close().catch(() => {});
 });

--- a/packages/app/src/main/desktopPlugin.ts
+++ b/packages/app/src/main/desktopPlugin.ts
@@ -61,9 +61,14 @@ function setStatusSession(file: string, session: string | undefined): void {
   }
 }
 
-/** Register the privileged scheme. MUST run before app 'ready' (Electron requirement). */
+/** Register the privileged scheme. MUST run before app 'ready' (Electron requirement).
+ *  `corsEnabled` is required: the renderer document is `file://`, so its dynamic
+ *  `import("inplan-plugin://bundle/renderer.js")` is a CROSS-origin module fetch. Chromium (Electron
+ *  43+) blocks a cross-origin fetch to a custom scheme unless the scheme is CORS-enabled — without
+ *  this the import fails with "blocked by CORS policy … only supported for chrome/data/http/https",
+ *  and the plugin never activates (Instant mode / TOC / live-collab silently don't load). */
 export function registerPluginScheme(): void {
-  protocol.registerSchemesAsPrivileged([{ scheme: SCHEME, privileges: { standard: true, secure: true, supportFetchAPI: true } }]);
+  protocol.registerSchemesAsPrivileged([{ scheme: SCHEME, privileges: { standard: true, secure: true, supportFetchAPI: true, corsEnabled: true } }]);
 }
 
 /** Serve the *currently-verified* renderer-entry bytes over the scheme. Call once in whenReady. The
@@ -71,7 +76,12 @@ export function registerPluginScheme(): void {
 export function handlePluginScheme(): void {
   protocol.handle(SCHEME, () => {
     if (!state) return new Response("", { status: 404 });
-    return new Response(readFileSync(state.rendererPath), { headers: { "content-type": "text/javascript" } });
+    // Explicit ACAO alongside `corsEnabled`: the `file://` renderer imports this cross-origin, and
+    // the bytes are already Ed25519+sha384-verified before we ever serve them, so allowing our own
+    // renderer to import the verified entry is safe.
+    return new Response(readFileSync(state.rendererPath), {
+      headers: { "content-type": "text/javascript", "access-control-allow-origin": "*" },
+    });
   });
 }
 


### PR DESCRIPTION
## Impact
The **paid desktop plugin** (Instant mode, table-of-contents, live-collab) **silently failed to load on Electron 43** — the renderer fell back to the file-backed editor without the plugin. This first surfaced as the intermittent `desktopPlugin.spec.ts` nightly failure (issue-adjacent to #58), but it's a **real user-facing bug**, not just a flaky test.

## Root cause
The renderer document is `file://`. It loads the verified plugin renderer entry via a dynamic `import("inplan-plugin://bundle/renderer.js")` — a **cross-origin module fetch**. Electron 43's Chromium blocks a cross-origin fetch to a custom scheme unless the scheme is CORS-enabled. The scheme was registered `{ standard, secure, supportFetchAPI }` **without `corsEnabled`**, and the handler set no `Access-Control-Allow-Origin`, so the import failed:

```
Access to script at 'inplan-plugin://bundle/renderer.js' from origin 'file://' has been blocked by CORS policy:
Cross origin requests are only supported for protocol schemes: chrome, chrome-extension, chrome-untrusted, data, http, https.
→ TypeError: Failed to fetch dynamically imported module: inplan-plugin://bundle/renderer.js
```

Main verified + started the plugin fine (`[inplan] desktop plugin active`); the **renderer-side import** threw and was swallowed by the fail-soft catch (`plugin unavailable; using the file-backed editor`) — so the failure was invisible. It read as an intermittent e2e flake because a 30s poll can never recover a one-shot import that CORS-blocks.

## Fix
`packages/app/src/main/desktopPlugin.ts`:
- Register the scheme with **`corsEnabled: true`**.
- Set an explicit **`Access-Control-Allow-Origin`** on the served entry.

Safe: the bytes are already **Ed25519 + sha384 verified** before we serve them, so letting our own `file://` renderer import the verified entry cross-origin adds no exposure.

Also: the e2e now captures the **Electron main stderr + renderer console/pageerror** in `afterAll` (neither was visible in the page trace — this is what let me root-cause it), so the next plugin regression is diagnosable from the CI log.

## Validation
`e2e-nightly` `workflow_dispatch` on this branch → **green**. Both plugin tests, which were timing out at 30s×3 on `main`, now pass in **~42ms** (the import + activate succeeds immediately). Fixes the standing `desktopPlugin.spec.ts` nightly failure.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/67?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin resource access by enabling cross-origin requests for the privileged plugin scheme.
  * Preserved clear not-found responses when plugin state is unavailable.
  * Continued serving verified plugin content correctly as JavaScript.

* **Tests**
  * Enhanced end-to-end diagnostics with Electron process output, renderer console messages, and page errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->