### PR TITLE
release: 0.1.24 — desktop plugin CORS fix (Electron 43)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5335,7 +5335,7 @@
     },
     "packages/cli": {
       "name": "@inplan/cli",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@hocuspocus/provider": "^2.15.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inplan/cli",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "private": true,
   "description": "inplan CLI: open / wait / signal orchestration over the document core.",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
Version bump 0.1.23 → 0.1.24 to publish **#67**. On merge, tagging `v0.1.24` fires `release.yml` → publishes `inplan` to npm via OIDC.

## Ships
- **fix(app): desktop plugin renderer entry was CORS-blocked on Electron 43 (#67)** — the paid desktop plugin (Instant mode / table-of-contents / live-collab) silently failed to load on Electron 43: the renderer's cross-origin `import("inplan-plugin://…")` of the verified plugin entry was blocked because the scheme lacked `corsEnabled`. Fixed by registering the scheme CORS-enabled + serving an explicit `Access-Control-Allow-Origin`. **This restores the plugin for paid desktop users on the current Electron.**

(Also on main since 0.1.23: the Source formatting toolbar + image insert/paste #64/#65 — renderer features that reach desktop via this app build.)

## Diff
Two lines: `packages/cli/package.json` + `package-lock.json`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/68?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

