### PR TITLE
fix(skill): drop the Write(...) auto-approve rules (Edit already covers them)

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -962,7 +962,12 @@ function skillTargets(): { name: string; root: string; target: string }[] {
  *  editing plan files, and the ~/.inplan sidecars (control log / canonical / proposed /
  *  backups / status). The human reviews every change in the inplan app, so these never
  *  need a per-edit prompt. Deliberately narrow — NOT a global permission bypass. */
-const SKILL_ALLOW = ["Bash(inplan *)", "Edit(**/*.plan.md)", "Write(**/*.plan.md)", "Read(~/.inplan/**)", "Edit(~/.inplan/**)", "Write(~/.inplan/**)"];
+// NB: no `Write(...)` rules — an `Edit(<path>)` rule already covers ALL file-editing tools (Write
+// included), and Claude Code's permission system ignores `Write(<path>)` rules and warns about them.
+const SKILL_ALLOW = ["Bash(inplan *)", "Edit(**/*.plan.md)", "Read(~/.inplan/**)", "Edit(~/.inplan/**)"];
+// Rules earlier versions added that are now inert + warned-about — pruned on merge (below) so an
+// existing install stops surfacing the warning. Only ever the exact rules we added, never a user's.
+const SKILL_ALLOW_OBSOLETE = ["Write(**/*.plan.md)", "Write(~/.inplan/**)"];
 const SKILL_DIRS = ["~/.inplan/"]; // sidecars live outside the project cwd; grant file access there
 
 /** Merge {@link SKILL_ALLOW} / {@link SKILL_DIRS} into `~/.claude/settings.json`, preserving
@@ -984,9 +989,14 @@ function grantClaudePermissions(claudeRoot: string): boolean {
   // allow/additionalDirectories keys on JSON.stringify (and falsely report a grant).
   const rawPerms = settings.permissions;
   const perms = (rawPerms && typeof rawPerms === "object" && !Array.isArray(rawPerms) ? rawPerms : {}) as Record<string, unknown>;
-  const allow = Array.isArray(perms.allow) ? (perms.allow as string[]) : [];
+  let allow = Array.isArray(perms.allow) ? (perms.allow as string[]) : [];
   const dirs = Array.isArray(perms.additionalDirectories) ? (perms.additionalDirectories as string[]) : [];
   let changed = false;
+  // Prune the now-obsolete Write(...) rules a prior install added (Edit already covers Write, and
+  // these trip a Claude Code warning). Only these exact strings — never a user's own Write rules.
+  const beforePrune = allow.length;
+  allow = allow.filter((r) => !SKILL_ALLOW_OBSOLETE.includes(r));
+  if (allow.length !== beforePrune) changed = true;
   for (const r of SKILL_ALLOW) {
     if (!allow.includes(r)) {
       allow.push(r);

--- a/packages/cli/test/installSkill.test.ts
+++ b/packages/cli/test/installSkill.test.ts
@@ -39,8 +39,24 @@ describe("inplan install-skill — Claude Code auto-approval", () => {
   it("merges the scoped allow rules + sidecar dir into ~/.claude/settings.json", () => {
     install();
     const s = readSettings();
-    expect(s.permissions.allow).toEqual(expect.arrayContaining(["Bash(inplan *)", "Edit(**/*.plan.md)", "Write(**/*.plan.md)", "Read(~/.inplan/**)", "Edit(~/.inplan/**)", "Write(~/.inplan/**)"]));
+    expect(s.permissions.allow).toEqual(expect.arrayContaining(["Bash(inplan *)", "Edit(**/*.plan.md)", "Read(~/.inplan/**)", "Edit(~/.inplan/**)"]));
     expect(s.permissions.additionalDirectories).toContain("~/.inplan/");
+    // No Write(...) rules — Edit already covers Write, and Claude Code ignores + warns about Write rules.
+    expect(s.permissions.allow).not.toContain("Write(**/*.plan.md)");
+    expect(s.permissions.allow).not.toContain("Write(~/.inplan/**)");
+  });
+
+  it("prunes the obsolete Write(...) rules a prior version installed, keeping the user's own", () => {
+    writeFileSync(
+      join(home, ".claude", "settings.json"),
+      JSON.stringify({ permissions: { allow: ["Write(**/*.plan.md)", "Write(~/.inplan/**)", "Write(src/**)"] } }) + "\n",
+    );
+    install();
+    const s = readSettings();
+    expect(s.permissions.allow).not.toContain("Write(**/*.plan.md)"); // pruned
+    expect(s.permissions.allow).not.toContain("Write(~/.inplan/**)"); // pruned
+    expect(s.permissions.allow).toContain("Write(src/**)"); // the user's own — untouched
+    expect(s.permissions.allow).toContain("Edit(**/*.plan.md)"); // added
   });
 
   it("is idempotent — running twice doesn't duplicate rules", () => {

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -7,10 +7,8 @@ description: Use for ANY planning, design, PRD, or spec document — always plan
 allowed-tools:
   - Bash(inplan *)
   - Edit(**/*.plan.md)
-  - Write(**/*.plan.md)
   - Read(~/.inplan/**)
   - Edit(~/.inplan/**)
-  - Write(~/.inplan/**)
 ---
 
 # inplan


### PR DESCRIPTION
## Symptom
Launching Claude Code with the inplan skill installed prints:

```
Permission allow rule (.claude/settings.json): Write(**/*.plan.md) is not matched by file
permission checks — only Edit(path) rules are. Use Edit(**/*.plan.md) instead.
Permission allow rule (.claude/settings.json): Write(~/.inplan/**) is not matched …
```

Claude Code's permission system ignores `Write(<path>)` rules — an `Edit(<path>)` rule already covers **all** file-editing tools (Write included). The inplan skill emitted redundant `Write(...)` rules in two places, so both `Edit(...)` and `Write(...)` were granted; the `Write(...)` half is now inert and warned-about.

## Fix
- **`install-skill`** (`cli.ts` `SKILL_ALLOW`): drop `Write(**/*.plan.md)` + `Write(~/.inplan/**)`. Keep the `Edit(...)` rules (unchanged coverage). And **prune** the two obsolete Write rules from an existing `settings.json` on merge — only those exact strings, never a user's own Write rules — so an already-installed user stops seeing the warning after upgrading + re-running `install-skill` (the guarded `postinstall` does this).
- **`skill/SKILL.md`** `allowed-tools`: drop the same two Write rules.
- **Tests**: assert the Write rules are absent, and a new case covers the prune migration (obsolete rules removed, the user's own `Write(src/**)` kept).

No behavior change to what's auto-approved — Edit already covers writing plan files + sidecars.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/69?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified skill permissions by relying on edit access for file changes.
  * Removed obsolete write permissions during skill installation.
  * Preserved user-defined write permissions unrelated to the skill.
* **Documentation**
  * Updated the skill’s allowed-tool configuration to remove redundant write entries while retaining required read and edit access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->