### PR TITLE
release: 0.1.25 — skill drops the obsolete Write(...) permission rules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5335,7 +5335,7 @@
     },
     "packages/cli": {
       "name": "@inplan/cli",
-      "version": "0.1.24",
+      "version": "0.1.25",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@hocuspocus/provider": "^2.15.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inplan/cli",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "private": true,
   "description": "inplan CLI: open / wait / signal orchestration over the document core.",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
Version bump 0.1.24 → 0.1.25 to publish **#69**. On merge, tagging `v0.1.25` fires `release.yml` → publishes `inplan` to npm via OIDC.

## Ships
- **fix(skill): drop the `Write(...)` auto-approve rules (#69)** — Claude Code ignores `Write(<path>)` permission rules (an `Edit(<path>)` rule already covers all file-editing tools, Write included) and warns about them on launch. `inplan install-skill` no longer emits `Write(**/*.plan.md)` / `Write(~/.inplan/**)`, and now **prunes** those stale rules from an existing `settings.json` on re-run (only those exact strings — never a user's own Write rules). The `skill/SKILL.md` `allowed-tools` drop them too. No change to what's auto-approved.

Users clear the launch warning by upgrading (`npm i -g inplan@latest`) — the guarded `postinstall` re-runs `install-skill`, which prunes the obsolete rules.

## Diff
Two lines: `packages/cli/package.json` + `package-lock.json`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/70?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

