### PR TITLE
CLI remote-agent auth: auto-login, open→wait deprecation, session-race fix

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -555,7 +555,10 @@ async function persistCloudIdentity(): Promise<void> {
 export function canInteractiveLogin(args: string[]): boolean {
   if (hasFlag(args, "no-login")) return false;
   if (process.env.CI || process.env.INPLAN_NO_BROWSER) return false;
-  return Boolean(process.stdin.isTTY && process.stderr.isTTY);
+  // A human at a terminal has BOTH stdin and stdout as TTYs. Gate on stdout (not stderr): piping
+  // stdout — `inplan wait --remote DOC | tool` — is programmatic use and must never open a browser,
+  // yet stderr often stays a TTY there, so an stderr check would wrongly allow it.
+  return Boolean(process.stdin.isTTY && process.stdout.isTTY);
 }
 
 /**

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -27,7 +27,7 @@ import {
 } from "@inplan/core/node";
 import { agentAuthorFor } from "./agentAuthor";
 import { gitProvenance } from "./provenance";
-import { authedSession, clearAuth, currentUser, loadAuth, remoteBackend, saveAuth, type AuthFile } from "./cliAuth";
+import { authedSession, clearAuth, currentUser, liveRemoteBackend, loadAuth, remoteBackend, saveAuth, type AuthFile } from "./cliAuth";
 import { browserLogin } from "./cliLogin";
 import { resolveIdentity, setManualProfile, writeLocalProfile } from "./cliProfile";
 import { checkForUpdate, selfUpdate, UPDATE_PKG } from "./update";
@@ -647,12 +647,19 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
     return;
   }
 
+  // A `wait` can block for longer than the ~1h access-token lifetime (the human idles before taking
+  // their turn). Poll through a self-refreshing backend so the token is re-minted — via the
+  // lock-coordinated authedSession() path, never an off-lock auto-refresh — before it expires,
+  // instead of silently 401ing mid-wait. Short ops above (signal/message) used the one-shot `backend`.
+  const live = liveRemoteBackend(docId, "cli-agent");
+
   // Save-locally handoff (only when following a promoted local file): download the
   // live body to its original path, flip the status back to local, reopen the local
-  // editor, and report — the inverse of "Collaborate on Cloud".
+  // editor, and report — the inverse of "Collaborate on Cloud". Reads through `live` since the
+  // handoff can fire after a long wait (the initial token may have expired by then).
   const onSaveLocally = localFile
     ? async () => {
-        const body = await backend.store.loadDoc();
+        const body = await live.store.loadDoc();
         writeFileSync(localFile, body);
         writeStatus(docPaths(localFile).statusPath, { location: "local", originalPath: localFile, lastSyncedHash: hashBody(body) });
         const pid = spawnApp(localFile); // reopen the doc in the local editor
@@ -660,15 +667,17 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
       }
     : undefined;
 
-  // While we hold the turn on a cloud doc, announce the local agent in the doc's
-  // presence room so the web badge shows "agent · your machine"; clear it on exit.
+  // While we hold the turn on a cloud doc, announce the local agent in the doc's presence room so
+  // the web badge shows "agent · your machine"; clear it on exit. (Presence is a cosmetic websocket
+  // on the initial token; the correctness-critical DB polling rides `live` above and stays
+  // authenticated across the whole wait, even past the initial token's ~1h expiry.)
   const presence = announcePresence(docId, backend.token, model);
   try {
     await waitCycle(
       {
-        channel: backend.channel,
-        store: backend.store,
-        history: async () => (await backend.channel.readSince(0)).entries,
+        channel: live.channel,
+        store: live.store,
+        history: async () => (await live.channel.readSince(0)).entries,
         logExit: () => {}, // no local sidecar for a cloud doc
         ...(onSaveLocally ? { onSaveLocally } : {}),
       },

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -27,7 +27,7 @@ import {
 } from "@inplan/core/node";
 import { agentAuthorFor } from "./agentAuthor";
 import { gitProvenance } from "./provenance";
-import { authedSession, clearAuth, currentUser, remoteBackend, saveAuth } from "./cliAuth";
+import { authedSession, clearAuth, currentUser, loadAuth, remoteBackend, saveAuth, type AuthFile } from "./cliAuth";
 import { browserLogin } from "./cliLogin";
 import { resolveIdentity, setManualProfile, writeLocalProfile } from "./cliProfile";
 import { checkForUpdate, selfUpdate, UPDATE_PKG } from "./update";
@@ -525,7 +525,7 @@ async function doLogin(args: string[]): Promise<void> {
   // Interactive browser handoff. No partial-credential mode: anything short of the full
   // non-interactive set above falls through to the browser, which is the intended UX.
   try {
-    const auth = await browserLogin({ onUrl: (u) => process.stderr.write(`Opening your browser to sign in:\n  ${u}\nIf it didn't open, paste that URL into your browser.\n`) });
+    const auth = await defaultBrowserLogin();
     saveAuth(auth);
     await persistCloudIdentity();
     output({ status: "logged_in", url: auth.url, ...(auth.email ? { email: auth.email } : {}) });
@@ -547,6 +547,48 @@ async function persistCloudIdentity(): Promise<void> {
 }
 
 /**
+ * May we open a browser to sign in on the user's behalf? Auto-login is a foreground
+ * convenience for a human at a terminal — never for a background agent hook, a CI job,
+ * or a piped/headless invocation, where popping a browser would hang or surprise. Gate
+ * on a real TTY on both ends, honour `CI`/`INPLAN_NO_BROWSER`, and an explicit `--no-login`.
+ */
+export function canInteractiveLogin(args: string[]): boolean {
+  if (hasFlag(args, "no-login")) return false;
+  if (process.env.CI || process.env.INPLAN_NO_BROWSER) return false;
+  return Boolean(process.stdin.isTTY && process.stderr.isTTY);
+}
+
+/**
+ * Ensure a cloud session exists before a foreground cloud command runs. When there are
+ * no stored credentials *and* we're interactive, run the browser login inline (so the
+ * connect instruction is just `inplan wait --remote <doc>` — no separate `inplan login`).
+ * Returns false when we can't/shouldn't auto-login (headless, --no-login, or the handoff
+ * failed); the caller prints the actionable "run `inplan login`" guidance and exits.
+ *
+ * Scoped to the *missing credentials* case (loadAuth === null) on purpose: an expired
+ * session still falls through to the existing refresh path + its message, so we never
+ * pop a browser on every routine expiry. `login` is injectable for tests.
+ */
+export async function ensureLoggedIn(args: string[], login: () => Promise<AuthFile> = defaultBrowserLogin): Promise<boolean> {
+  if (loadAuth()) return true; // credentials present → remoteBackend refreshes (expiry handled there)
+  if (!canInteractiveLogin(args)) return false;
+  try {
+    process.stderr.write("inplan: not signed in — opening your browser to sign in…\n");
+    saveAuth(await login());
+    await persistCloudIdentity();
+    return true;
+  } catch (e) {
+    process.stderr.write(`inplan login: ${e instanceof Error ? e.message : String(e)}\n`);
+    return false;
+  }
+}
+
+/** The real browser handoff used by auto-login (mirrors `doLogin`'s interactive path). */
+function defaultBrowserLogin(): Promise<AuthFile> {
+  return browserLogin({ onUrl: (u) => process.stderr.write(`Opening your browser to sign in:\n  ${u}\nIf it didn't open, paste that URL into your browser.\n`) });
+}
+
+/**
  * Drive a *cloud* document as the logged-in agent. There is no local editor to
  * spawn (a cloud doc opens in the browser), so `open`/`wait` both attach + wait
  * over the Supabase backend, and `signal` appends the agent's protocol events.
@@ -556,6 +598,12 @@ async function persistCloudIdentity(): Promise<void> {
  * its original path on disk). The bare `--remote <docId>` case has no local file.
  */
 async function runRemote(cmd: string, docId: string, explicitCursor: number | null, confirmed: Set<string>, rest: string[], localFile?: string, model?: string): Promise<void> {
+  // Self-heal a fresh machine: with no stored credentials, sign in inline (interactive
+  // only) so `inplan wait --remote <doc>` works without a preceding `inplan login`.
+  if (!(await ensureLoggedIn(rest))) {
+    process.stderr.write("inplan: not logged in (or session expired) — run `inplan login`\n");
+    process.exit(1);
+  }
   const backend = await remoteBackend(docId, "cli-agent");
   if (!backend) {
     process.stderr.write("inplan: not logged in (or session expired) — run `inplan login`\n");
@@ -1439,7 +1487,9 @@ async function main(): Promise<void> {
 
   if (!cmd || !["open", "wait", "signal", "message", "comment", "relay", "status", "promote", "demote", "upload"].includes(cmd)) {
     process.stderr.write(
-      "usage: inplan <open|wait|signal> <file|--remote DOC_ID> [--model NAME] [--cursor N] [--confirmed-comment-deletion=a,b] [--done] [--reload]\n" +
+      "usage: inplan open  <file>   (create/open a local plan in the editor)\n" +
+        "       inplan wait   <file|--remote DOC_ID> [--model NAME] [--cursor N] [--confirmed-comment-deletion=a,b] [--done] [--reload]\n" +
+        "       inplan signal <file|--remote DOC_ID> [--done] [--reload]\n" +
         '       inplan message <file> "your message"   (relay a note to the editor status bar)\n' +
         "       inplan comment <file> (--parent-id <id>|--doc|--span \"text\") --text \"...\" [--model NAME] [--may-resolve] [--question <json>]\n" +
         "       inplan relay [--hook <kind> | --text <s> [--activity]]   (agent-hook → editor; resolves the active doc)\n" +
@@ -1465,7 +1515,14 @@ async function main(): Promise<void> {
   const remoteDocId = getFlag(args, "remote");
   if (remoteDocId) {
     rejectCommentOnCloud(cmd, false);
-    await runRemote(cmd, remoteDocId, explicitCursor, confirmed, args, undefined, model);
+    // `open` and `wait` are the same over the cloud backend — a cloud doc has no local
+    // editor to launch, which is the only thing `open` adds locally. So `open --remote`
+    // is deprecated: warn and behave exactly as `wait --remote`.
+    const remoteCmd = cmd === "open" ? "wait" : cmd;
+    if (cmd === "open") {
+      process.stderr.write("inplan: `open --remote` is deprecated (a cloud doc has no local editor to launch) — use `wait --remote`. Attaching as `wait`.\n");
+    }
+    await runRemote(remoteCmd, remoteDocId, explicitCursor, confirmed, args, undefined, model);
     return;
   }
 

--- a/packages/cli/src/cliAuth.ts
+++ b/packages/cli/src/cliAuth.ts
@@ -358,7 +358,10 @@ export function liveRemoteBackend(docId: string, consumerId = "cli-agent"): Live
           // we reuse rather than re-mint on every call, while still re-checking soon.
           expiresAt = loadAuth()?.expiresAt ?? now + 300;
         }
-        return b ?? inner; // transient refresh failure ⇒ keep the last-good client and retry next call
+        // Transient refresh failure ⇒ keep the last-good client and retry next call, but ONLY while it
+        // hasn't actually expired — past expiry it would poll with dead credentials, so surface null
+        // and let the session be treated as unavailable.
+        return b ?? (inner && expiresAt > Math.floor(Date.now() / 1000) ? inner : null);
       })
       .finally(() => {
         inflight = null;

--- a/packages/cli/src/cliAuth.ts
+++ b/packages/cli/src/cliAuth.ts
@@ -333,15 +333,28 @@ export interface LiveRemoteBackend {
 export function liveRemoteBackend(docId: string, consumerId = "cli-agent"): LiveRemoteBackend {
   let inner: RemoteBackend | null = null;
   let expiresAt = 0; // the cached inner's access-token expiry (unix seconds)
+  let inflight: Promise<RemoteBackend | null> | null = null; // the single in-progress re-mint, if any
   const fresh = async (): Promise<RemoteBackend | null> => {
     const now = Math.floor(Date.now() / 1000);
-    if (inner && expiresAt - now > ACCESS_SKEW_S) return inner; // still valid — reuse (no re-mint)
-    const b = await remoteBackend(docId, consumerId);
-    if (b) {
-      inner = b;
-      expiresAt = loadAuth()?.expiresAt ?? 0; // authedSession persisted the new expiry
-    }
-    return inner;
+    if (inner && expiresAt - now > ACCESS_SKEW_S) return inner; // cached token still valid — reuse
+    // Coalesce concurrent re-mints into ONE refresh: every channel/store call routes through here, so
+    // without this several could each acquire the lock and rotate the refresh token in series. A
+    // re-mint goes through remoteBackend()→authedSession(), which re-reads auth.json INSIDE the lock —
+    // so it always starts from the freshest persisted token even if another process just rotated it.
+    inflight ??= remoteBackend(docId, consumerId)
+      .then((b) => {
+        if (b) {
+          inner = b;
+          // Trust the persisted expiry; if a session somehow carried none, assume a short validity so
+          // we reuse rather than re-mint on every call, while still re-checking soon.
+          expiresAt = loadAuth()?.expiresAt ?? now + 300;
+        }
+        return b ?? inner; // transient refresh failure ⇒ keep the last-good client and retry next call
+      })
+      .finally(() => {
+        inflight = null;
+      });
+    return inflight;
   };
   const need = async (): Promise<RemoteBackend> => {
     const b = await fresh();

--- a/packages/cli/src/cliAuth.ts
+++ b/packages/cli/src/cliAuth.ts
@@ -100,10 +100,16 @@ export interface AuthedSession {
 // file with a token another already rotated away — which then gets revoked and kills the whole
 // session (observed: a `wait` loop + any concurrent command). Serializing the critical section,
 // and loading INSIDE the lock so each refresher starts from the freshest token, closes the race.
-const LOCK_WAIT_MS = 10_000; // give up waiting after this and proceed best-effort (never deadlock)
-// A lock older than this is assumed abandoned (crashed holder) and stolen. Set well above any
-// plausible refresh (a token refresh is ~1s) so a live refresh is never stolen out from under us.
+const LOCK_WAIT_MS = 10_000; // stop waiting after this and report non-acquisition (never deadlock)
+// A lock older than this is assumed abandoned (crashed holder) and reclaimed. Set well above any
+// plausible refresh (a token refresh is ~1s) so a live refresh is never reclaimed out from under us.
 const LOCK_STALE_MS = 60_000;
+
+/** Tunable timings — overridable in tests. */
+export interface AuthLockOpts {
+  waitMs?: number;
+  staleMs?: number;
+}
 
 function lockDir(): string {
   return join(process.env.INPLAN_HOME || join(homedir(), ".inplan"), "auth.lock");
@@ -112,43 +118,55 @@ function lockOwnerPath(): string {
   return join(lockDir(), "owner");
 }
 
-async function withAuthLock<T>(fn: () => Promise<T>): Promise<T> {
+/**
+ * Run `fn` while holding an exclusive cross-process lock over auth.json. Returns
+ * `{ acquired: true, value }` ONLY when this process held the lock for the whole of `fn`. If the
+ * lock can't be acquired within `waitMs`, returns `{ acquired: false }` WITHOUT running `fn` — the
+ * caller must NOT then refresh unlocked (concurrent refreshSession rotates the single-use token and
+ * logs the session out). Reclaiming an abandoned lock is atomic (rename-aside), so two racers can
+ * never both "steal" and proceed. Exported for the concurrency tests.
+ */
+export async function withAuthLock<T>(fn: () => Promise<T>, opts: AuthLockOpts = {}): Promise<{ acquired: true; value: T } | { acquired: false }> {
   const lock = lockDir();
   mkdirSync(process.env.INPLAN_HOME || join(homedir(), ".inplan"), { recursive: true });
-  // A per-acquisition token so cleanup only removes a lock THIS call still owns — if a slow refresh
-  // ever exceeds LOCK_STALE_MS and a successor steals + re-acquires, we must not delete theirs.
   const token = `${process.pid}-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
-  const deadline = Date.now() + LOCK_WAIT_MS;
+  const waitMs = opts.waitMs ?? LOCK_WAIT_MS;
+  const staleMs = opts.staleMs ?? LOCK_STALE_MS;
+  const deadline = Date.now() + waitMs;
   let held = false;
   while (Date.now() < deadline) {
     try {
-      mkdirSync(lock); // atomic create — fails if another holder exists
+      mkdirSync(lock); // atomic create — fails (EEXIST) if a holder exists
       writeFileSync(lockOwnerPath(), token);
       held = true;
       break;
     } catch (e) {
       if ((e as NodeJS.ErrnoException).code !== "EEXIST") throw e;
+      // Reclaim an abandoned lock ATOMICALLY: rename it aside — only one racer's rename can succeed,
+      // so we never delete a lock a peer just (re)acquired (a `stat`-then-`rm` had that race). A
+      // fresh lock isn't stale, so a live refresh is never reclaimed.
       try {
-        if (Date.now() - statSync(lock).mtimeMs > LOCK_STALE_MS) {
-          rmSync(lock, { recursive: true, force: true }); // steal an abandoned lock
-          continue;
+        if (Date.now() - statSync(lock).mtimeMs > staleMs) {
+          const aside = `${lock}.stale-${token}`;
+          renameSync(lock, aside); // atomic; throws if another racer already moved/removed it
+          rmSync(aside, { recursive: true, force: true });
+          continue; // retry mkdir immediately
         }
       } catch {
-        continue; // the lock vanished between stat and now — retry acquiring
+        continue; // lock vanished / we lost the reclaim race — just retry acquiring
       }
       await new Promise((r) => setTimeout(r, 40 + Math.floor(Math.random() * 40)));
     }
   }
+  if (!held) return { acquired: false }; // never run fn() unlocked — a racing refresh would corrupt the session
   try {
-    return await fn(); // proceed even if unacquired (best-effort) — a held lock is the common case
+    return { acquired: true, value: await fn() };
   } finally {
-    if (held) {
-      try {
-        // Only release a lock we still own (see `token`) — never delete a successor's.
-        if (readFileSync(lockOwnerPath(), "utf8") === token) rmSync(lock, { recursive: true, force: true });
-      } catch {
-        /* owner file gone / lock already stolen — leave it for its current owner */
-      }
+    try {
+      // Only release a lock we still own (see `token`) — never delete a successor's.
+      if (readFileSync(lockOwnerPath(), "utf8") === token) rmSync(lock, { recursive: true, force: true });
+    } catch {
+      /* owner file gone / lock already reclaimed — leave it for its current owner */
     }
   }
 }
@@ -194,9 +212,9 @@ export async function authedSession(): Promise<AuthedSession | null> {
   if (reused) return reused;
 
   // Slow path — the cached token is missing/expiring: refresh (which rotates the refresh token)
-  // under a cross-process lock, and cache the new access token so the next callers take the fast
+  // ONLY under the exclusive lock, and cache the new access token so later callers take the fast
   // path. Load again inside the lock in case a concurrent process just refreshed.
-  return withAuthLock(async () => {
+  const locked = await withAuthLock<AuthedSession | null>(async () => {
     const auth = loadAuth();
     if (!auth) return null;
     const fresh = await reuseCached(auth); // a peer may have refreshed while we waited for the lock
@@ -217,6 +235,12 @@ export async function authedSession(): Promise<AuthedSession | null> {
     });
     return { db, session: data.session };
   });
+  if (locked.acquired) return locked.value;
+
+  // Couldn't acquire the lock within the deadline (heavy contention). Do NOT refresh unlocked — the
+  // holder almost certainly just refreshed and cached a fresh token, so re-check the cache. If it's
+  // still not usable, return null (a retryable "not logged in") — never a racing refresh.
+  return reuseCached(loadAuth() ?? cached);
 }
 
 /** The signed-in user (id + email + display name), or null when not logged in / session invalid. */

--- a/packages/cli/src/cliAuth.ts
+++ b/packages/cli/src/cliAuth.ts
@@ -357,11 +357,18 @@ export function liveRemoteBackend(docId: string, consumerId = "cli-agent"): Live
           // Trust the persisted expiry; if a session somehow carried none, assume a short validity so
           // we reuse rather than re-mint on every call, while still re-checking soon.
           expiresAt = loadAuth()?.expiresAt ?? now + 300;
+          return b;
         }
-        // Transient refresh failure ⇒ keep the last-good client and retry next call, but ONLY while it
-        // hasn't actually expired — past expiry it would poll with dead credentials, so surface null
-        // and let the session be treated as unavailable.
-        return b ?? (inner && expiresAt > Math.floor(Date.now() / 1000) ? inner : null);
+        // Re-mint failed. Keep the last-good client ONLY for a genuinely transient failure — i.e. we're
+        // still logged in (creds present) AND its token hasn't expired — so a brief network blip
+        // doesn't drop a valid session. Otherwise (another process logged out ⇒ no creds, or the token
+        // expired) DISCARD it: clear inner/expiresAt so tokenNow()/subscribe(), which bypass need(),
+        // can't keep serving a stale/expired/revoked client, and callers get a clean "unavailable".
+        const stillLoggedIn = loadAuth() !== null;
+        if (stillLoggedIn && inner && expiresAt > Math.floor(Date.now() / 1000)) return inner;
+        inner = null;
+        expiresAt = 0;
+        return null;
       })
       .finally(() => {
         inflight = null;

--- a/packages/cli/src/cliAuth.ts
+++ b/packages/cli/src/cliAuth.ts
@@ -222,10 +222,12 @@ function newClient(auth: AuthFile): SupabaseClient {
 }
 
 /** Bind a client to a still-valid cached access token WITHOUT a network refresh (no rotation).
- *  Returns null if there's no usable cached token or it's within the expiry skew. */
-async function reuseCached(auth: AuthFile): Promise<AuthedSession | null> {
+ *  Returns null if there's no usable cached token or it's within `skewS` of expiry. `skewS` defaults
+ *  to the refresh skew (proactively re-mint before expiry); pass 0 to accept any not-yet-expired
+ *  token (the contention fallback, where the token is still usable while a peer refreshes). */
+async function reuseCached(auth: AuthFile, skewS = ACCESS_SKEW_S): Promise<AuthedSession | null> {
   if (!auth.accessToken || !auth.expiresAt) return null;
-  if (auth.expiresAt - Math.floor(Date.now() / 1000) <= ACCESS_SKEW_S) return null;
+  if (auth.expiresAt - Math.floor(Date.now() / 1000) <= skewS) return null;
   const db = newClient(auth);
   // setSession only decodes+stores when the access token is unexpired (no network call, no
   // rotation). We've already checked expiry, so this is purely local.
@@ -273,9 +275,12 @@ export async function authedSession(): Promise<AuthedSession | null> {
   if (locked.acquired) return locked.value;
 
   // Couldn't acquire the lock within the deadline (heavy contention). Do NOT refresh unlocked — the
-  // holder almost certainly just refreshed and cached a fresh token, so re-check the cache. If it's
-  // still not usable, return null (a retryable "not logged in") — never a racing refresh.
-  return reuseCached(loadAuth() ?? cached);
+  // holder is refreshing and about to persist. Re-check the cache with skew 0: accept the current
+  // token as long as it isn't actually expired (it stays valid for up to the skew window), so
+  // transient contention returns a usable session rather than a spurious null. Only a genuinely
+  // expired/absent session yields null here — the one case where callers SHOULD say "run inplan
+  // login". This keeps a long `wait` from aborting (and misreporting "logged out") on lock churn.
+  return reuseCached(loadAuth() ?? cached, 0);
 }
 
 /** The signed-in user (id + email + display name), or null when not logged in / session invalid. */
@@ -325,6 +330,10 @@ export async function remoteBackend(docId: string, consumerId = "cli-agent"): Pr
  *  first ensures a fresh inner backend; between re-mints (≈ once per token lifetime) the cached one
  *  is reused, so the hot poll path creates no per-tick clients. */
 export interface LiveRemoteBackend {
+  /** A control channel that re-mints its client before expiry. NOTE: `channel.subscribe` is
+   *  best-effort and unsupported before the first request lands (there's no inner client yet, so a
+   *  pre-mint subscription is dropped); this backend is built for the POLL-based wait, which never
+   *  subscribes. A future push-based consumer must not rely on subscribe here. */
   channel: ControlChannel;
   store: DocumentStore;
   /** The freshest access token (for presence/websocket re-auth), or null if the session is gone. */

--- a/packages/cli/src/cliAuth.ts
+++ b/packages/cli/src/cliAuth.ts
@@ -6,7 +6,7 @@
 // must belong to the document's org). The service-role key is NEVER used here:
 // the local CLI runs as the human, the same as the browser SPA.
 
-import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { createClient, type Session, type SupabaseClient } from "@supabase/supabase-js";
@@ -31,6 +31,11 @@ export interface AuthFile {
   anonKey: string;
   refreshToken: string;
   email?: string;
+  /** Cached short-lived access token (JWT) + its epoch-seconds expiry. Lets a CLI op reuse a
+   *  still-valid session WITHOUT a refresh (which rotates the refresh token) — so concurrent
+   *  processes don't race the single-use rotation. Absent right after login (first op refreshes). */
+  accessToken?: string;
+  expiresAt?: number;
 }
 
 /** `~/.inplan/auth.json` — `INPLAN_HOME` overrides the base dir (tests; avoids $HOME). */
@@ -46,7 +51,14 @@ export function loadAuth(): AuthFile | null {
   try {
     const raw = JSON.parse(readFileSync(path, "utf8")) as Partial<AuthFile>;
     if (typeof raw.url === "string" && typeof raw.anonKey === "string" && typeof raw.refreshToken === "string") {
-      return { url: raw.url, anonKey: raw.anonKey, refreshToken: raw.refreshToken, ...(raw.email ? { email: raw.email } : {}) };
+      return {
+        url: raw.url,
+        anonKey: raw.anonKey,
+        refreshToken: raw.refreshToken,
+        ...(raw.email ? { email: raw.email } : {}),
+        ...(typeof raw.accessToken === "string" ? { accessToken: raw.accessToken } : {}),
+        ...(typeof raw.expiresAt === "number" ? { expiresAt: raw.expiresAt } : {}),
+      };
     }
     return null;
   } catch {
@@ -78,31 +90,118 @@ export interface AuthedSession {
   session: Session;
 }
 
+// Cross-process mutex over auth.json. Supabase rotates refresh tokens (single-use, ~10s reuse
+// window), so an unsynchronized read→refresh→write lets concurrent `inplan` processes clobber the
+// file with a token another already rotated away — which then gets revoked and kills the whole
+// session (observed: a `wait` loop + any concurrent command). Serializing the critical section,
+// and loading INSIDE the lock so each refresher starts from the freshest token, closes the race.
+const LOCK_WAIT_MS = 10_000; // give up waiting after this and proceed best-effort (never deadlock)
+const LOCK_STALE_MS = 15_000; // a lock older than this is assumed abandoned (crashed holder) and stolen
+
+function lockDir(): string {
+  return join(process.env.INPLAN_HOME || join(homedir(), ".inplan"), "auth.lock");
+}
+
+async function withAuthLock<T>(fn: () => Promise<T>): Promise<T> {
+  const lock = lockDir();
+  mkdirSync(process.env.INPLAN_HOME || join(homedir(), ".inplan"), { recursive: true });
+  const deadline = Date.now() + LOCK_WAIT_MS;
+  let held = false;
+  while (Date.now() < deadline) {
+    try {
+      mkdirSync(lock); // atomic create — fails if another holder exists
+      held = true;
+      break;
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code !== "EEXIST") throw e;
+      try {
+        if (Date.now() - statSync(lock).mtimeMs > LOCK_STALE_MS) {
+          rmSync(lock, { recursive: true, force: true }); // steal an abandoned lock
+          continue;
+        }
+      } catch {
+        continue; // the lock vanished between stat and now — retry acquiring
+      }
+      await new Promise((r) => setTimeout(r, 40 + Math.floor(Math.random() * 40)));
+    }
+  }
+  try {
+    return await fn(); // proceed even if unacquired (best-effort) — a held lock is the common case
+  } finally {
+    if (held) {
+      try {
+        rmSync(lock, { recursive: true, force: true });
+      } catch {
+        /* already gone */
+      }
+    }
+  }
+}
+
 /**
  * Exchange the stored refresh token for an authenticated client. Persists the
  * rotated refresh token (and the session's email, for display) back to
  * `auth.json` so the next invocation starts fresh. Returns null when not logged
  * in or the session can't be refreshed (callers print "run `inplan login`").
  */
-export async function authedSession(): Promise<AuthedSession | null> {
-  const auth = loadAuth();
-  if (!auth) return null;
+/** Refresh a full minute before expiry so a reused token never lands on a just-expired boundary. */
+const ACCESS_SKEW_S = 120;
 
-  const db = createClient(auth.url, auth.anonKey, {
-    auth: { persistSession: false, autoRefreshToken: true, detectSessionInUrl: false },
+// A CLI client that never refreshes on its own: short-lived ops refresh explicitly (below), and
+// leaving auto-refresh on would silently rotate the refresh token in-memory during a long `wait`
+// without persisting it — invalidating auth.json.
+function newClient(auth: AuthFile): SupabaseClient {
+  return createClient(auth.url, auth.anonKey, {
+    auth: { persistSession: false, autoRefreshToken: false, detectSessionInUrl: false },
     realtime: realtimeTransport,
   });
-  const { data, error } = await db.auth.refreshSession({ refresh_token: auth.refreshToken });
-  if (error || !data.session) return null;
+}
 
-  // Refresh tokens rotate; persist the new one (+ the email label) so we never
-  // reuse a spent token and `whoami` has an identity without another round-trip.
-  const rotated = data.session.refresh_token || auth.refreshToken;
-  const email = data.session.user?.email ?? auth.email;
-  if (rotated !== auth.refreshToken || email !== auth.email) {
-    saveAuth({ ...auth, refreshToken: rotated, ...(email ? { email } : {}) });
-  }
-  return { db, session: data.session };
+/** Bind a client to a still-valid cached access token WITHOUT a network refresh (no rotation).
+ *  Returns null if there's no usable cached token or it's within the expiry skew. */
+async function reuseCached(auth: AuthFile): Promise<AuthedSession | null> {
+  if (!auth.accessToken || !auth.expiresAt) return null;
+  if (auth.expiresAt - Math.floor(Date.now() / 1000) <= ACCESS_SKEW_S) return null;
+  const db = newClient(auth);
+  // setSession only decodes+stores when the access token is unexpired (no network call, no
+  // rotation). We've already checked expiry, so this is purely local.
+  const { data, error } = await db.auth.setSession({ access_token: auth.accessToken, refresh_token: auth.refreshToken });
+  return error || !data.session ? null : { db, session: data.session };
+}
+
+export async function authedSession(): Promise<AuthedSession | null> {
+  const cached = loadAuth();
+  if (!cached) return null;
+
+  // Fast path — reuse a still-valid access token: no refresh, no rotation, no lock. This is what
+  // makes concurrent `inplan` processes safe (they never touch the single-use refresh token).
+  const reused = await reuseCached(cached);
+  if (reused) return reused;
+
+  // Slow path — the cached token is missing/expiring: refresh (which rotates the refresh token)
+  // under a cross-process lock, and cache the new access token so the next callers take the fast
+  // path. Load again inside the lock in case a concurrent process just refreshed.
+  return withAuthLock(async () => {
+    const auth = loadAuth();
+    if (!auth) return null;
+    const fresh = await reuseCached(auth); // a peer may have refreshed while we waited for the lock
+    if (fresh) return fresh;
+
+    const db = newClient(auth);
+    const { data, error } = await db.auth.refreshSession({ refresh_token: auth.refreshToken });
+    if (error || !data.session) return null;
+
+    // Persist the rotated refresh token + the new access token (& expiry) so the fast path can
+    // reuse it, and `whoami` has an identity without another round-trip.
+    saveAuth({
+      ...auth,
+      refreshToken: data.session.refresh_token || auth.refreshToken,
+      accessToken: data.session.access_token,
+      ...(data.session.expires_at ? { expiresAt: data.session.expires_at } : {}),
+      ...(data.session.user?.email ? { email: data.session.user.email } : {}),
+    });
+    return { db, session: data.session };
+  });
 }
 
 /** The signed-in user (id + email + display name), or null when not logged in / session invalid. */

--- a/packages/cli/src/cliAuth.ts
+++ b/packages/cli/src/cliAuth.ts
@@ -6,7 +6,7 @@
 // must belong to the document's org). The service-role key is NEVER used here:
 // the local CLI runs as the human, the same as the browser SPA.
 
-import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { createClient, type Session, type SupabaseClient } from "@supabase/supabase-js";
@@ -70,12 +70,17 @@ export function loadAuth(): AuthFile | null {
 export function saveAuth(auth: AuthFile): void {
   const path = authPath();
   mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, `${JSON.stringify(auth, null, 2)}\n`, { mode: 0o600 });
+  // Atomic replace: write a 0600 temp file in the same dir, then rename over auth.json, so a
+  // concurrent (lockless fast-path) loadAuth can never observe a half-written file. rename is
+  // atomic within a filesystem; the temp name is pid-scoped to avoid two writers colliding.
+  const tmp = `${path}.${process.pid}.tmp`;
+  writeFileSync(tmp, `${JSON.stringify(auth, null, 2)}\n`, { mode: 0o600 });
   try {
-    chmodSync(path, 0o600);
+    chmodSync(tmp, 0o600);
   } catch {
     /* best-effort on platforms without POSIX modes */
   }
+  renameSync(tmp, path);
 }
 
 /** Forget the stored credentials (sign out). No-op if not logged in. */
@@ -96,20 +101,29 @@ export interface AuthedSession {
 // session (observed: a `wait` loop + any concurrent command). Serializing the critical section,
 // and loading INSIDE the lock so each refresher starts from the freshest token, closes the race.
 const LOCK_WAIT_MS = 10_000; // give up waiting after this and proceed best-effort (never deadlock)
-const LOCK_STALE_MS = 15_000; // a lock older than this is assumed abandoned (crashed holder) and stolen
+// A lock older than this is assumed abandoned (crashed holder) and stolen. Set well above any
+// plausible refresh (a token refresh is ~1s) so a live refresh is never stolen out from under us.
+const LOCK_STALE_MS = 60_000;
 
 function lockDir(): string {
   return join(process.env.INPLAN_HOME || join(homedir(), ".inplan"), "auth.lock");
+}
+function lockOwnerPath(): string {
+  return join(lockDir(), "owner");
 }
 
 async function withAuthLock<T>(fn: () => Promise<T>): Promise<T> {
   const lock = lockDir();
   mkdirSync(process.env.INPLAN_HOME || join(homedir(), ".inplan"), { recursive: true });
+  // A per-acquisition token so cleanup only removes a lock THIS call still owns — if a slow refresh
+  // ever exceeds LOCK_STALE_MS and a successor steals + re-acquires, we must not delete theirs.
+  const token = `${process.pid}-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
   const deadline = Date.now() + LOCK_WAIT_MS;
   let held = false;
   while (Date.now() < deadline) {
     try {
       mkdirSync(lock); // atomic create — fails if another holder exists
+      writeFileSync(lockOwnerPath(), token);
       held = true;
       break;
     } catch (e) {
@@ -130,9 +144,10 @@ async function withAuthLock<T>(fn: () => Promise<T>): Promise<T> {
   } finally {
     if (held) {
       try {
-        rmSync(lock, { recursive: true, force: true });
+        // Only release a lock we still own (see `token`) — never delete a successor's.
+        if (readFileSync(lockOwnerPath(), "utf8") === token) rmSync(lock, { recursive: true, force: true });
       } catch {
-        /* already gone */
+        /* owner file gone / lock already stolen — leave it for its current owner */
       }
     }
   }

--- a/packages/cli/src/cliAuth.ts
+++ b/packages/cli/src/cliAuth.ts
@@ -6,7 +6,7 @@
 // must belong to the document's org). The service-role key is NEVER used here:
 // the local CLI runs as the human, the same as the browser SPA.
 
-import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { createClient, type Session, type SupabaseClient } from "@supabase/supabase-js";
@@ -159,9 +159,22 @@ export async function withAuthLock<T>(fn: () => Promise<T>, opts: AuthLockOpts =
     }
   }
   if (!held) return { acquired: false }; // never run fn() unlocked — a racing refresh would corrupt the session
+  // Heartbeat: keep renewing the lock's mtime while we hold it, so a LIVE holder is never reclaimed
+  // on age alone even if `fn` runs longer than staleMs (a slow/hung network refresh). Only a CRASHED
+  // holder stops the heartbeat → the lock actually goes stale and a waiter can reclaim it. The timer
+  // fires on the event loop during `fn`'s awaits; unref so it never keeps the process alive.
+  const beat = setInterval(() => {
+    try {
+      utimesSync(lock, new Date(), new Date());
+    } catch {
+      /* released/removed — nothing to renew */
+    }
+  }, Math.max(1, Math.floor(staleMs / 3)));
+  if (typeof beat.unref === "function") beat.unref();
   try {
     return { acquired: true, value: await fn() };
   } finally {
+    clearInterval(beat);
     try {
       // Only release a lock we still own (see `token`) — never delete a successor's.
       if (readFileSync(lockOwnerPath(), "utf8") === token) rmSync(lock, { recursive: true, force: true });

--- a/packages/cli/src/cliAuth.ts
+++ b/packages/cli/src/cliAuth.ts
@@ -126,7 +126,10 @@ function lockOwnerPath(): string {
  * logs the session out). Reclaiming an abandoned lock is atomic (rename-aside), so two racers can
  * never both "steal" and proceed. Exported for the concurrency tests.
  */
-export async function withAuthLock<T>(fn: () => Promise<T>, opts: AuthLockOpts = {}): Promise<{ acquired: true; value: T } | { acquired: false }> {
+export async function withAuthLock<T>(
+  fn: (fence: { stillMine: () => boolean }) => Promise<T>,
+  opts: AuthLockOpts = {},
+): Promise<{ acquired: true; value: T } | { acquired: false }> {
   const lock = lockDir();
   mkdirSync(process.env.INPLAN_HOME || join(homedir(), ".inplan"), { recursive: true });
   const token = `${process.pid}-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
@@ -159,20 +162,35 @@ export async function withAuthLock<T>(fn: () => Promise<T>, opts: AuthLockOpts =
     }
   }
   if (!held) return { acquired: false }; // never run fn() unlocked — a racing refresh would corrupt the session
+  // Ownership fence: the owner marker still carries OUR token. If this process was paused (SIGSTOP,
+  // laptop sleep, a blocked event loop) past staleMs, a waiter can reclaim the lock and write its own
+  // token; when we resume we're no longer the owner. Callers MUST re-check `stillMine()` immediately
+  // before any single-use side effect (the refresh-token rotation) so a stolen holder aborts instead
+  // of rotating alongside the new owner. Narrows the window to the check→act gap (a few ms), vs. the
+  // whole of `fn`.
+  const stillMine = (): boolean => {
+    try {
+      return readFileSync(lockOwnerPath(), "utf8") === token;
+    } catch {
+      return false; // owner file gone / lock reclaimed ⇒ not ours
+    }
+  };
   // Heartbeat: keep renewing the lock's mtime while we hold it, so a LIVE holder is never reclaimed
   // on age alone even if `fn` runs longer than staleMs (a slow/hung network refresh). Only a CRASHED
-  // holder stops the heartbeat → the lock actually goes stale and a waiter can reclaim it. The timer
-  // fires on the event loop during `fn`'s awaits; unref so it never keeps the process alive.
+  // (or paused) holder stops the heartbeat → the lock actually goes stale and a waiter can reclaim it.
+  // Guard on `stillMine()` so a resumed-after-reclaim holder never renews a SUCCESSOR's lock (which
+  // would wrongly keep the new owner's lock fresh / fight its heartbeat). The timer fires on the event
+  // loop during `fn`'s awaits; unref so it never keeps the process alive.
   const beat = setInterval(() => {
     try {
-      utimesSync(lock, new Date(), new Date());
+      if (stillMine()) utimesSync(lock, new Date(), new Date());
     } catch {
       /* released/removed — nothing to renew */
     }
   }, Math.max(1, Math.floor(staleMs / 3)));
   if (typeof beat.unref === "function") beat.unref();
   try {
-    return { acquired: true, value: await fn() };
+    return { acquired: true, value: await fn({ stillMine }) };
   } finally {
     clearInterval(beat);
     try {
@@ -190,7 +208,7 @@ export async function withAuthLock<T>(fn: () => Promise<T>, opts: AuthLockOpts =
  * `auth.json` so the next invocation starts fresh. Returns null when not logged
  * in or the session can't be refreshed (callers print "run `inplan login`").
  */
-/** Refresh a full minute before expiry so a reused token never lands on a just-expired boundary. */
+/** Refresh two minutes before expiry so a reused token never lands on a just-expired boundary. */
 const ACCESS_SKEW_S = 120;
 
 // A CLI client that never refreshes on its own: short-lived ops refresh explicitly (below), and
@@ -227,12 +245,16 @@ export async function authedSession(): Promise<AuthedSession | null> {
   // Slow path — the cached token is missing/expiring: refresh (which rotates the refresh token)
   // ONLY under the exclusive lock, and cache the new access token so later callers take the fast
   // path. Load again inside the lock in case a concurrent process just refreshed.
-  const locked = await withAuthLock<AuthedSession | null>(async () => {
+  const locked = await withAuthLock<AuthedSession | null>(async ({ stillMine }) => {
     const auth = loadAuth();
     if (!auth) return null;
     const fresh = await reuseCached(auth); // a peer may have refreshed while we waited for the lock
     if (fresh) return fresh;
 
+    // Fence the single-use rotation: if we were paused past staleMs and reclaimed, bail rather than
+    // refresh alongside the new owner (that double-rotate revokes the token → logs the session out).
+    // The caller re-checks the cache on non-acquisition, so returning null here is safely retryable.
+    if (!stillMine()) return null;
     const db = newClient(auth);
     const { data, error } = await db.auth.refreshSession({ refresh_token: auth.refreshToken });
     if (error || !data.session) return null;
@@ -292,4 +314,61 @@ export async function remoteBackend(docId: string, consumerId = "cli-agent"): Pr
     store: new SupabaseDocumentStore(s.db, docId),
     token: s.session.access_token,
   };
+}
+
+/** A doc backend that transparently re-mints its authenticated client before the access token
+ *  expires. A long `wait --remote` (the human idles past the ~1h JWT lifetime) otherwise keeps
+ *  polling a fixed client whose token has expired — its reads 401 and the wait silently stalls,
+ *  never seeing the user's turn. Re-minting runs through {@link remoteBackend}→{@link authedSession}
+ *  (the lock-coordinated, refresh-token-persisting path), so it NEVER rotates the single-use token
+ *  off-lock — which is exactly the race `autoRefreshToken:false` closes. Every channel/store call
+ *  first ensures a fresh inner backend; between re-mints (≈ once per token lifetime) the cached one
+ *  is reused, so the hot poll path creates no per-tick clients. */
+export interface LiveRemoteBackend {
+  channel: ControlChannel;
+  store: DocumentStore;
+  /** The freshest access token (for presence/websocket re-auth), or null if the session is gone. */
+  tokenNow(): string | null;
+}
+export function liveRemoteBackend(docId: string, consumerId = "cli-agent"): LiveRemoteBackend {
+  let inner: RemoteBackend | null = null;
+  let expiresAt = 0; // the cached inner's access-token expiry (unix seconds)
+  const fresh = async (): Promise<RemoteBackend | null> => {
+    const now = Math.floor(Date.now() / 1000);
+    if (inner && expiresAt - now > ACCESS_SKEW_S) return inner; // still valid — reuse (no re-mint)
+    const b = await remoteBackend(docId, consumerId);
+    if (b) {
+      inner = b;
+      expiresAt = loadAuth()?.expiresAt ?? 0; // authedSession persisted the new expiry
+    }
+    return inner;
+  };
+  const need = async (): Promise<RemoteBackend> => {
+    const b = await fresh();
+    if (!b) throw new Error("inplan: not logged in (or session expired) — run `inplan login`");
+    return b;
+  };
+  const channel: ControlChannel = {
+    append: async (e, o) => (await need()).channel.append(e, o),
+    readSince: async (c) => (await need()).channel.readSince(c),
+    // The poll-based wait never subscribes; delegate best-effort to the current inner (a re-mint
+    // doesn't migrate an active subscription — not needed on this path).
+    subscribe: (cb) => inner?.channel.subscribe(cb) ?? (() => {}),
+    getCursor: async () => (await need()).channel.getCursor(),
+    setCursor: async (s) => (await need()).channel.setCursor(s),
+    claimLock: async (t) => (await need()).channel.claimLock(t),
+    isSuperseded: async (t) => (await need()).channel.isSuperseded(t),
+    presence: async () => (await need()).channel.presence(),
+  };
+  const store: DocumentStore = {
+    loadDoc: async () => (await need()).store.loadDoc(),
+    saveDoc: async (c) => (await need()).store.saveDoc(c),
+    getCanonical: async () => (await need()).store.getCanonical(),
+    setCanonical: async (c) => (await need()).store.setCanonical(c),
+    getProposed: async () => (await need()).store.getProposed(),
+    setProposed: async (c) => (await need()).store.setProposed(c),
+    clearProposed: async () => (await need()).store.clearProposed(),
+    backup: async (c, m) => (await need()).store.backup(c, m),
+  };
+  return { channel, store, tokenNow: () => inner?.token ?? null };
 }

--- a/packages/cli/test/cliAuthSession.test.ts
+++ b/packages/cli/test/cliAuthSession.test.ts
@@ -25,6 +25,7 @@ vi.mock("@inplan/backend-supabase", () => ({
   SupabaseControlChannel: class {
     constructor(public db: { auth?: { token?: string } }, public docId: string, public consumer: string) {}
     async getCursor() { return 0; }
+    async readSince(cursor: number) { return { entries: [], cursor }; }
   },
   SupabaseDocumentStore: class { constructor(public db: unknown, public docId: string) {} },
 }));
@@ -151,6 +152,16 @@ describe("liveRemoteBackend", () => {
     expect(refreshSession).toHaveBeenCalledTimes(1); // freshly minted token is valid ⇒ reused, not re-refreshed
     expect(live.tokenNow()).toBe("jwt-123");
   });
+
+  it("coalesces concurrent re-mints into a single refresh (no rotation storm)", async () => {
+    saveAuth({ url: "https://x.supabase.co", anonKey: "anon", refreshToken: "rt-old", email: "e@x.io", accessToken: "old", expiresAt: now() + 60 }); // stale ⇒ needs a re-mint
+    refreshResult = { data: { session: session({ access_token: "jwt-123", expires_at: now() + 3600 }) }, error: null };
+    const live = liveRemoteBackend("doc-1");
+    // Fire several channel calls before the first re-mint resolves: they must share ONE refresh, not
+    // each acquire the lock and rotate the single-use token in series.
+    await Promise.all([live.channel.getCursor(), live.channel.readSince(0), live.channel.getCursor()]);
+    expect(refreshSession).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("withAuthLock", () => {
@@ -198,24 +209,25 @@ describe("withAuthLock", () => {
   it("retains ownership across a callback longer than staleMs (heartbeat) — the 2nd fn waits for the 1st", async () => {
     const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
     const order: string[] = [];
-    // First holder runs WELL past staleMs (150ms ≫ 30ms). Without the heartbeat the second would
-    // reclaim the "stale" lock at ~30ms and interleave; with it, the first's lock stays fresh.
+    // First holder runs WELL past staleMs (600ms ≫ 200ms). Without the heartbeat the second would
+    // reclaim the "stale" lock at ~200ms and interleave; with it, the first's lock stays fresh. Wide
+    // margins (600/200/50) keep this robust against event-loop stalls on a loaded CI runner.
     const first = withAuthLock(
       async () => {
         order.push("A:start");
-        await sleep(150);
+        await sleep(600);
         order.push("A:end");
         return "A";
       },
-      { staleMs: 30, waitMs: 3000 },
+      { staleMs: 200, waitMs: 5000 },
     );
-    await sleep(15); // let the first acquire before the second contends
+    await sleep(50); // let the first acquire before the second contends
     const second = withAuthLock(
       async () => {
         order.push("B");
         return "B";
       },
-      { staleMs: 30, waitMs: 3000 },
+      { staleMs: 200, waitMs: 5000 },
     );
     const [ra, rb] = await Promise.all([first, second]);
     expect(ra).toEqual({ acquired: true, value: "A" });

--- a/packages/cli/test/cliAuthSession.test.ts
+++ b/packages/cli/test/cliAuthSession.test.ts
@@ -3,7 +3,7 @@
 // Covers the authenticated-session paths of cliAuth (refresh, rotation persist,
 // remoteBackend wiring) with a mocked supabase-js — no network, no real creds.
 
-import { mkdtempSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { mkdtempSync, readFileSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -171,6 +171,21 @@ describe("liveRemoteBackend", () => {
     await live.channel.getCursor(); // inner is set, but its cached expiry is already in the past
     refreshResult = { data: { session: null }, error: { message: "network" } }; // the next re-mint fails
     await expect(live.channel.getCursor()).rejects.toThrow(/inplan login/); // expired inner ⇒ surfaced, not reused
+    expect(live.tokenNow()).toBeNull(); // …and the expired client is DISCARDED, not left exposed via tokenNow()/subscribe()
+  });
+
+  it("discards the cached client when another process logs out, even if the token hasn't expired", async () => {
+    // Token is valid but within the skew, so each call re-mints. First call mints; then auth.json is
+    // removed (a logout elsewhere). The next re-mint must clear the cached client rather than keep
+    // serving a still-unexpired-but-revoked session.
+    saveAuth({ url: "https://x.supabase.co", anonKey: "anon", refreshToken: "rt", email: "e@x.io", accessToken: "valid", expiresAt: now() + 60 });
+    refreshResult = { data: { session: session({ access_token: "valid", expires_at: now() + 60 }) }, error: null };
+    const live = liveRemoteBackend("doc-1");
+    await live.channel.getCursor();
+    expect(live.tokenNow()).not.toBeNull(); // authenticated so far
+    rmSync(authPath()); // another process logged out ⇒ loadAuth() is now null
+    await expect(live.channel.getCursor()).rejects.toThrow(/inplan login/);
+    expect(live.tokenNow()).toBeNull(); // cached client dropped despite the token not being expired
   });
 });
 

--- a/packages/cli/test/cliAuthSession.test.ts
+++ b/packages/cli/test/cliAuthSession.test.ts
@@ -10,9 +10,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 let refreshResult: { data: { session: unknown }; error: unknown } = { data: { session: null }, error: null };
 const refreshSession = vi.fn(async () => refreshResult);
+// setSession is the local (no-network) reuse of a still-valid access token: echo it back as a session.
+const setSession = vi.fn(async ({ access_token, refresh_token }: { access_token: string; refresh_token: string }) => ({
+  data: { session: { access_token, refresh_token, user: { id: "user-1", email: "cached@x.io" } } },
+  error: null,
+}));
 
 vi.mock("@supabase/supabase-js", () => ({
-  createClient: vi.fn(() => ({ auth: { refreshSession } })),
+  createClient: vi.fn(() => ({ auth: { refreshSession, setSession } })),
 }));
 vi.mock("@inplan/backend-supabase", () => ({
   SupabaseControlChannel: class { constructor(public db: unknown, public docId: string, public consumer: string) {} },
@@ -26,6 +31,7 @@ beforeEach(() => {
   home = mkdtempSync(join(tmpdir(), "inplan-auth-"));
   process.env.INPLAN_HOME = home;
   refreshSession.mockClear();
+  setSession.mockClear();
 });
 afterEach(() => {
   delete process.env.INPLAN_HOME;
@@ -36,6 +42,7 @@ const seed = () => saveAuth({ url: "https://x.supabase.co", anonKey: "anon", ref
 const session = (over: Record<string, unknown> = {}) => ({
   refresh_token: "rt-new",
   access_token: "jwt-123",
+  expires_at: Math.floor(Date.now() / 1000) + 3600,
   user: { id: "user-1", email: "new@x.io" },
   ...over,
 });
@@ -51,7 +58,7 @@ describe("authedSession", () => {
     expect(await authedSession()).toBeNull();
   });
 
-  it("refreshes, persisting the rotated token + email", async () => {
+  it("refreshes, persisting the rotated refresh token + cached access token + email", async () => {
     seed();
     refreshResult = { data: { session: session() }, error: null };
     const s = await authedSession();
@@ -59,14 +66,37 @@ describe("authedSession", () => {
     const stored = JSON.parse(readFileSync(authPath(), "utf8"));
     expect(stored.refreshToken).toBe("rt-new");
     expect(stored.email).toBe("new@x.io");
+    expect(stored.accessToken).toBe("jwt-123"); // cached so the next call can reuse without a refresh
+    expect(typeof stored.expiresAt).toBe("number");
   });
 
-  it("does not rewrite when the token + email are unchanged", async () => {
-    saveAuth({ url: "https://x.supabase.co", anonKey: "anon", refreshToken: "rt-same", email: "same@x.io" });
-    refreshResult = { data: { session: session({ refresh_token: "rt-same", user: { id: "u", email: "same@x.io" } }) }, error: null };
+  it("reuses a valid cached access token without refreshing or rewriting (concurrency-safe fast path)", async () => {
+    saveAuth({
+      url: "https://x.supabase.co",
+      anonKey: "anon",
+      refreshToken: "rt",
+      email: "e@x.io",
+      accessToken: "cached-jwt",
+      expiresAt: Math.floor(Date.now() / 1000) + 3600,
+    });
     const before = readFileSync(authPath(), "utf8");
+    const s = await authedSession();
+    expect(s?.session.access_token).toBe("cached-jwt"); // used the cached token…
+    expect(refreshSession).not.toHaveBeenCalled(); // …with NO refresh ⇒ no refresh-token rotation…
+    expect(readFileSync(authPath(), "utf8")).toBe(before); // …and no rewrite of auth.json
+  });
+
+  it("falls through to refresh when the cached access token is expired", async () => {
+    saveAuth({
+      url: "https://x.supabase.co",
+      anonKey: "anon",
+      refreshToken: "rt",
+      accessToken: "old-jwt",
+      expiresAt: Math.floor(Date.now() / 1000) - 10, // already expired
+    });
+    refreshResult = { data: { session: session() }, error: null };
     await authedSession();
-    expect(readFileSync(authPath(), "utf8")).toBe(before);
+    expect(refreshSession).toHaveBeenCalled();
   });
 });
 

--- a/packages/cli/test/cliAuthSession.test.ts
+++ b/packages/cli/test/cliAuthSession.test.ts
@@ -146,4 +146,32 @@ describe("withAuthLock", () => {
     expect(r).toEqual({ acquired: false });
     expect(fn).not.toHaveBeenCalled();
   });
+
+  it("retains ownership across a callback longer than staleMs (heartbeat) — the 2nd fn waits for the 1st", async () => {
+    const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+    const order: string[] = [];
+    // First holder runs WELL past staleMs (150ms ≫ 30ms). Without the heartbeat the second would
+    // reclaim the "stale" lock at ~30ms and interleave; with it, the first's lock stays fresh.
+    const first = withAuthLock(
+      async () => {
+        order.push("A:start");
+        await sleep(150);
+        order.push("A:end");
+        return "A";
+      },
+      { staleMs: 30, waitMs: 3000 },
+    );
+    await sleep(15); // let the first acquire before the second contends
+    const second = withAuthLock(
+      async () => {
+        order.push("B");
+        return "B";
+      },
+      { staleMs: 30, waitMs: 3000 },
+    );
+    const [ra, rb] = await Promise.all([first, second]);
+    expect(ra).toEqual({ acquired: true, value: "A" });
+    expect(rb).toEqual({ acquired: true, value: "B" });
+    expect(order).toEqual(["A:start", "A:end", "B"]); // B ran only after A completed
+  });
 });

--- a/packages/cli/test/cliAuthSession.test.ts
+++ b/packages/cli/test/cliAuthSession.test.ts
@@ -20,11 +20,16 @@ vi.mock("@supabase/supabase-js", () => ({
   createClient: vi.fn(() => ({ auth: { refreshSession, setSession } })),
 }));
 vi.mock("@inplan/backend-supabase", () => ({
-  SupabaseControlChannel: class { constructor(public db: unknown, public docId: string, public consumer: string) {} },
+  // getCursor echoes the client's access token so a test can prove which minted client a
+  // self-refreshing call delegated to (i.e. whether it re-minted).
+  SupabaseControlChannel: class {
+    constructor(public db: { auth?: { token?: string } }, public docId: string, public consumer: string) {}
+    async getCursor() { return 0; }
+  },
   SupabaseDocumentStore: class { constructor(public db: unknown, public docId: string) {} },
 }));
 
-import { authedSession, currentUser, remoteBackend, saveAuth, authPath, withAuthLock } from "../src/cliAuth";
+import { authedSession, currentUser, liveRemoteBackend, remoteBackend, saveAuth, authPath, withAuthLock } from "../src/cliAuth";
 
 let home: string;
 beforeEach(() => {
@@ -123,6 +128,31 @@ describe("remoteBackend", () => {
   });
 });
 
+describe("liveRemoteBackend", () => {
+  const now = () => Math.floor(Date.now() / 1000);
+
+  it("mints once then reuses the client while the token stays valid (no re-refresh)", async () => {
+    saveAuth({ url: "https://x.supabase.co", anonKey: "anon", refreshToken: "rt", email: "e@x.io", accessToken: "cached-jwt", expiresAt: now() + 3600 });
+    const live = liveRemoteBackend("doc-1");
+    await live.channel.getCursor(); // first call mints (fast path: setSession, no refresh)
+    await live.channel.getCursor(); // token still valid ⇒ reuse the cached inner, no new mint
+    expect(refreshSession).not.toHaveBeenCalled(); // never rotates the single-use token
+    expect(setSession).toHaveBeenCalledTimes(1); // minted exactly once
+    expect(live.tokenNow()).toBe("cached-jwt");
+  });
+
+  it("re-mints through the locked refresh path when the cached token is within the expiry skew", async () => {
+    saveAuth({ url: "https://x.supabase.co", anonKey: "anon", refreshToken: "rt-old", email: "e@x.io", accessToken: "old", expiresAt: now() + 60 }); // < ACCESS_SKEW_S ⇒ stale
+    refreshResult = { data: { session: session({ access_token: "jwt-123", expires_at: now() + 3600 }) }, error: null };
+    const live = liveRemoteBackend("doc-1");
+    await live.channel.getCursor();
+    expect(refreshSession).toHaveBeenCalledTimes(1); // expiring ⇒ coordinated refresh
+    await live.channel.getCursor();
+    expect(refreshSession).toHaveBeenCalledTimes(1); // freshly minted token is valid ⇒ reused, not re-refreshed
+    expect(live.tokenNow()).toBe("jwt-123");
+  });
+});
+
 describe("withAuthLock", () => {
   it("acquires a free lock and runs fn", async () => {
     const fn = vi.fn(async () => "ran");
@@ -145,6 +175,24 @@ describe("withAuthLock", () => {
     const r = await withAuthLock(fn, { staleMs: 999_999, waitMs: 150 });
     expect(r).toEqual({ acquired: false });
     expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("fences a reclaimed holder: stillMine() flips false once the owner marker changes (paused-then-stolen)", async () => {
+    // Simulate this process being paused past staleMs and a successor stealing the lock: the owner
+    // marker no longer carries our token, so stillMine() must report false — the signal the refresh
+    // path uses to abort rather than rotate the single-use token alongside the new owner.
+    const seen: boolean[] = [];
+    const r = await withAuthLock(
+      async ({ stillMine }) => {
+        seen.push(stillMine()); // true — we still own it
+        writeFileSync(join(home, "auth.lock", "owner"), "successor-token"); // a reclaimer took over
+        seen.push(stillMine()); // false — no longer ours
+        return "done";
+      },
+      { waitMs: 2000 },
+    );
+    expect(r).toEqual({ acquired: true, value: "done" });
+    expect(seen).toEqual([true, false]);
   });
 
   it("retains ownership across a callback longer than staleMs (heartbeat) — the 2nd fn waits for the 1st", async () => {

--- a/packages/cli/test/cliAuthSession.test.ts
+++ b/packages/cli/test/cliAuthSession.test.ts
@@ -36,6 +36,7 @@ let home: string;
 beforeEach(() => {
   home = mkdtempSync(join(tmpdir(), "inplan-auth-"));
   process.env.INPLAN_HOME = home;
+  refreshResult = { data: { session: null }, error: null }; // reset so tests don't inherit a prior one's value
   refreshSession.mockClear();
   setSession.mockClear();
 });
@@ -161,6 +162,15 @@ describe("liveRemoteBackend", () => {
     // each acquire the lock and rotate the single-use token in series.
     await Promise.all([live.channel.getCursor(), live.channel.readSince(0), live.channel.getCursor()]);
     expect(refreshSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops the last-good client once it has expired and a re-mint fails (no polling dead creds)", async () => {
+    saveAuth({ url: "https://x.supabase.co", anonKey: "anon", refreshToken: "rt", email: "e@x.io", accessToken: "old", expiresAt: now() - 1 });
+    refreshResult = { data: { session: session({ access_token: "t1", expires_at: now() - 1 }) }, error: null }; // mint yields an already-expired token
+    const live = liveRemoteBackend("doc-1");
+    await live.channel.getCursor(); // inner is set, but its cached expiry is already in the past
+    refreshResult = { data: { session: null }, error: { message: "network" } }; // the next re-mint fails
+    await expect(live.channel.getCursor()).rejects.toThrow(/inplan login/); // expired inner ⇒ surfaced, not reused
   });
 });
 

--- a/packages/cli/test/cliAuthSession.test.ts
+++ b/packages/cli/test/cliAuthSession.test.ts
@@ -20,10 +20,10 @@ vi.mock("@supabase/supabase-js", () => ({
   createClient: vi.fn(() => ({ auth: { refreshSession, setSession } })),
 }));
 vi.mock("@inplan/backend-supabase", () => ({
-  // getCursor echoes the client's access token so a test can prove which minted client a
-  // self-refreshing call delegated to (i.e. whether it re-minted).
+  // A minimal channel: getCursor/readSince are stubbed so a delegating call has something to hit.
+  // Tests assert delegation by side effect (refresh/setSession call counts), not the return values.
   SupabaseControlChannel: class {
-    constructor(public db: { auth?: { token?: string } }, public docId: string, public consumer: string) {}
+    constructor(public db: unknown, public docId: string, public consumer: string) {}
     async getCursor() { return 0; }
     async readSince(cursor: number) { return { entries: [], cursor }; }
   },

--- a/packages/cli/test/cliAuthSession.test.ts
+++ b/packages/cli/test/cliAuthSession.test.ts
@@ -24,7 +24,7 @@ vi.mock("@inplan/backend-supabase", () => ({
   SupabaseDocumentStore: class { constructor(public db: unknown, public docId: string) {} },
 }));
 
-import { authedSession, currentUser, remoteBackend, saveAuth, authPath } from "../src/cliAuth";
+import { authedSession, currentUser, remoteBackend, saveAuth, authPath, withAuthLock } from "../src/cliAuth";
 
 let home: string;
 beforeEach(() => {
@@ -120,5 +120,30 @@ describe("remoteBackend", () => {
     expect(b?.token).toBe("jwt-123");
     expect((b?.channel as unknown as { docId: string }).docId).toBe("doc-1");
     expect((b?.store as unknown as { docId: string }).docId).toBe("doc-1");
+  });
+});
+
+describe("withAuthLock", () => {
+  it("acquires a free lock and runs fn", async () => {
+    const fn = vi.fn(async () => "ran");
+    const r = await withAuthLock(fn, { waitMs: 2000 });
+    expect(r).toEqual({ acquired: true, value: "ran" });
+    expect(fn).toHaveBeenCalledOnce();
+  });
+
+  it("reclaims a STALE lock (atomically) and runs fn", async () => {
+    mkdirSync(join(home, "auth.lock")); // a leftover lock from a crashed holder
+    const fn = vi.fn(async () => "ran");
+    const r = await withAuthLock(fn, { staleMs: -1, waitMs: 2000 }); // staleMs:-1 ⇒ treat any lock as stale
+    expect(r).toEqual({ acquired: true, value: "ran" });
+    expect(fn).toHaveBeenCalledOnce();
+  });
+
+  it("does NOT run fn when a fresh lock is held and can't be acquired (no unlocked refresh)", async () => {
+    mkdirSync(join(home, "auth.lock")); // held by a live holder; fresh ⇒ never reclaimed
+    const fn = vi.fn(async () => "ran");
+    const r = await withAuthLock(fn, { staleMs: 999_999, waitMs: 150 });
+    expect(r).toEqual({ acquired: false });
+    expect(fn).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/test/ensureLogin.test.ts
+++ b/packages/cli/test/ensureLogin.test.ts
@@ -47,7 +47,11 @@ afterEach(() => {
   delete process.env.INPLAN_HOME;
   rmSync(home, { recursive: true, force: true });
   for (const stream of ["stdin", "stderr"] as const) {
-    if (ttyDescriptors[stream]) Object.defineProperty(process[stream], "isTTY", ttyDescriptors[stream]!);
+    if (ttyDescriptors[stream]) {
+      Object.defineProperty(process[stream], "isTTY", ttyDescriptors[stream]!);
+    } else {
+      delete (process[stream] as { isTTY?: boolean }).isTTY; // no original descriptor → drop the injected own-prop
+    }
     ttyDescriptors[stream] = undefined;
   }
 });

--- a/packages/cli/test/ensureLogin.test.ts
+++ b/packages/cli/test/ensureLogin.test.ts
@@ -24,9 +24,9 @@ import { loadAuth, saveAuth, type AuthFile } from "../src/cliAuth";
 let home: string;
 const ttyDescriptors: Record<string, PropertyDescriptor | undefined> = {};
 
-/** Force stdin/stderr's isTTY (a getter on the streams) so "interactive" is deterministic. */
+/** Force stdin/stdout's isTTY (a getter on the streams) so "interactive" is deterministic. */
 function setTTY(value: boolean): void {
-  for (const stream of ["stdin", "stderr"] as const) {
+  for (const stream of ["stdin", "stdout"] as const) {
     ttyDescriptors[stream] ??= Object.getOwnPropertyDescriptor(process[stream], "isTTY");
     Object.defineProperty(process[stream], "isTTY", { value, configurable: true });
   }
@@ -46,7 +46,7 @@ beforeEach(() => {
 afterEach(() => {
   delete process.env.INPLAN_HOME;
   rmSync(home, { recursive: true, force: true });
-  for (const stream of ["stdin", "stderr"] as const) {
+  for (const stream of ["stdin", "stdout"] as const) {
     if (ttyDescriptors[stream]) {
       Object.defineProperty(process[stream], "isTTY", ttyDescriptors[stream]!);
     } else {
@@ -71,6 +71,22 @@ describe("canInteractiveLogin", () => {
   it("is false without a TTY even when nothing else opts out", () => {
     setTTY(false);
     expect(canInteractiveLogin([])).toBe(false);
+  });
+
+  it("is false when stdout is piped even though stdin/stderr are TTYs (`… | tool` ⇒ no browser)", () => {
+    // The reported case: `inplan wait --remote DOC | tool` — stdout is piped for programmatic use,
+    // but stdin and stderr stay TTYs. Must NOT be eligible for a browser login.
+    const origStderr = Object.getOwnPropertyDescriptor(process.stderr, "isTTY");
+    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+    Object.defineProperty(process.stderr, "isTTY", { value: true, configurable: true });
+    Object.defineProperty(process.stdout, "isTTY", { value: false, configurable: true }); // piped
+    try {
+      expect(canInteractiveLogin([])).toBe(false);
+    } finally {
+      // afterEach restores stdin/stdout; stderr isn't managed there, so reset it here.
+      if (origStderr) Object.defineProperty(process.stderr, "isTTY", origStderr);
+      else delete (process.stderr as { isTTY?: boolean }).isTTY;
+    }
   });
 });
 

--- a/packages/cli/test/ensureLogin.test.ts
+++ b/packages/cli/test/ensureLogin.test.ts
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Auto-login (#3a): `inplan wait --remote <doc>` self-heals a fresh machine by running the
+// browser handoff inline — but ONLY for an interactive human. These tests pin the decision
+// logic: credentials present → no browser; headless / --no-login / CI → no browser (caller
+// errors); interactive + no creds → login runs and the credentials are persisted.
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Stub only the post-login identity refresh (currentUser → network) so ensureLoggedIn's
+// best-effort `persistCloudIdentity` never touches the network in these unit tests. loadAuth /
+// saveAuth (and everything else) stay real so credential persistence is genuinely exercised.
+vi.mock("../src/cliAuth", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/cliAuth")>()),
+  currentUser: vi.fn(async () => null),
+}));
+
+import { canInteractiveLogin, ensureLoggedIn } from "../src/cli";
+import { loadAuth, saveAuth, type AuthFile } from "../src/cliAuth";
+
+let home: string;
+const ttyDescriptors: Record<string, PropertyDescriptor | undefined> = {};
+
+/** Force stdin/stderr's isTTY (a getter on the streams) so "interactive" is deterministic. */
+function setTTY(value: boolean): void {
+  for (const stream of ["stdin", "stderr"] as const) {
+    ttyDescriptors[stream] ??= Object.getOwnPropertyDescriptor(process[stream], "isTTY");
+    Object.defineProperty(process[stream], "isTTY", { value, configurable: true });
+  }
+}
+
+// A credential whose URL refuses connections instantly, so the best-effort identity refresh
+// after login fails fast (and swallows) rather than hitting the network in a unit test.
+const FAST_FAIL_AUTH: AuthFile = { url: "http://127.0.0.1:1", anonKey: "anon", refreshToken: "r" };
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "inplan-ensure-"));
+  process.env.INPLAN_HOME = home;
+  delete process.env.CI;
+  delete process.env.INPLAN_NO_BROWSER;
+});
+
+afterEach(() => {
+  delete process.env.INPLAN_HOME;
+  rmSync(home, { recursive: true, force: true });
+  for (const stream of ["stdin", "stderr"] as const) {
+    if (ttyDescriptors[stream]) Object.defineProperty(process[stream], "isTTY", ttyDescriptors[stream]!);
+    ttyDescriptors[stream] = undefined;
+  }
+});
+
+describe("canInteractiveLogin", () => {
+  it("is true only with a TTY on both ends and no CI / --no-login / opt-out", () => {
+    setTTY(true);
+    expect(canInteractiveLogin([])).toBe(true);
+    expect(canInteractiveLogin(["--no-login"])).toBe(false);
+    process.env.CI = "true";
+    expect(canInteractiveLogin([])).toBe(false);
+    delete process.env.CI;
+    process.env.INPLAN_NO_BROWSER = "1";
+    expect(canInteractiveLogin([])).toBe(false);
+  });
+
+  it("is false without a TTY even when nothing else opts out", () => {
+    setTTY(false);
+    expect(canInteractiveLogin([])).toBe(false);
+  });
+});
+
+describe("ensureLoggedIn", () => {
+  it("short-circuits (no browser) when credentials already exist", async () => {
+    saveAuth({ url: "https://x.supabase.co", anonKey: "a", refreshToken: "r" });
+    setTTY(true);
+    const login = vi.fn();
+    expect(await ensureLoggedIn([], login)).toBe(true);
+    expect(login).not.toHaveBeenCalled();
+  });
+
+  it("does NOT open a browser when headless (no TTY) — the caller errors instead", async () => {
+    setTTY(false);
+    const login = vi.fn();
+    expect(await ensureLoggedIn([], login)).toBe(false);
+    expect(login).not.toHaveBeenCalled();
+    expect(loadAuth()).toBeNull();
+  });
+
+  it("does NOT open a browser under --no-login even when interactive", async () => {
+    setTTY(true);
+    const login = vi.fn();
+    expect(await ensureLoggedIn(["--no-login"], login)).toBe(false);
+    expect(login).not.toHaveBeenCalled();
+  });
+
+  it("does NOT open a browser under CI even when interactive", async () => {
+    setTTY(true);
+    process.env.CI = "true";
+    const login = vi.fn();
+    expect(await ensureLoggedIn([], login)).toBe(false);
+    expect(login).not.toHaveBeenCalled();
+  });
+
+  it("runs the login handoff and persists credentials when interactive with none stored", async () => {
+    setTTY(true);
+    const login = vi.fn(async () => FAST_FAIL_AUTH);
+    expect(await ensureLoggedIn([], login)).toBe(true);
+    expect(login).toHaveBeenCalledOnce();
+    expect(loadAuth()).toEqual(FAST_FAIL_AUTH); // stored so the very next remoteBackend() call is authenticated
+  });
+
+  it("returns false (and stores nothing) when the login handoff fails", async () => {
+    setTTY(true);
+    const login = vi.fn(async () => {
+      throw new Error("login timed out — no response from the browser");
+    });
+    expect(await ensureLoggedIn([], login)).toBe(false);
+    expect(loadAuth()).toBeNull();
+  });
+});

--- a/packages/cli/test/open.test.ts
+++ b/packages/cli/test/open.test.ts
@@ -63,4 +63,16 @@ describe("inplan open", () => {
     expect(r.stderr).toMatch(/file not found/i);
     expect(existsSync(file)).toBe(false); // wait never creates the file
   });
+
+  it("deprecates `open --remote` and runs it as `wait --remote`", () => {
+    // A cloud doc has no local editor to launch — the only thing `open` adds locally — so
+    // `open --remote` is a deprecated alias for `wait --remote`. With no stored credentials in
+    // this non-interactive spawn it falls straight through to the wait path's auth guard (never
+    // opening a browser), which proves the forward happened.
+    const r = spawnSync(process.execPath, [CLI, "open", "--remote", "doc-abc"], { env, encoding: "utf8" });
+    expect(r.stderr).toMatch(/`open --remote` is deprecated/i);
+    expect(r.stderr).toMatch(/use `wait --remote`/i);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toMatch(/not logged in/i);
+  });
 });

--- a/packages/renderer/src/i18n.tsx
+++ b/packages/renderer/src/i18n.tsx
@@ -196,7 +196,7 @@ export const EN: Catalog = {
   "agent.atLimit": "Usage limit reached — turns are paused until your plan resets or you upgrade",
   "agent.connection": "Agent connection",
   "agent.localCmdHint": "Paste this to your coding agent:",
-  "agent.localCmdBody": "Collaborate with me on my inplan plan. Check the CLI with `inplan --version` (if missing, install it: `npm i -g inplan`), then run `{cmd}` and work with me through the comments (it signs you in automatically the first time).",
+  "agent.localCmdBody": "Collaborate with me on my inplan plan. Check the CLI with `inplan --version` (if missing, install it: `npm i -g inplan`), then run `{cmd}` and work with me through the comments (you may be prompted to sign in the first time).",
   "agent.copy": "Copy",
   "agent.copied": "Copied",
   // comment rail

--- a/packages/renderer/src/i18n.tsx
+++ b/packages/renderer/src/i18n.tsx
@@ -196,7 +196,7 @@ export const EN: Catalog = {
   "agent.atLimit": "Usage limit reached — turns are paused until your plan resets or you upgrade",
   "agent.connection": "Agent connection",
   "agent.localCmdHint": "Paste this to your coding agent:",
-  "agent.localCmdBody": "Collaborate with me on my inplan plan. Check the CLI with `inplan --version` (if missing, install it: `npm i -g inplan`), then run `{cmd}` and work with me through the comments (you may be prompted to sign in the first time).",
+  "agent.localCmdBody": "Collaborate with me on my inplan plan. Check the CLI with `inplan --version` (if missing, install it: `npm i -g inplan`), sign in with `inplan login` if you haven't yet, then run `{cmd}` and work with me through the comments.",
   "agent.copy": "Copy",
   "agent.copied": "Copied",
   // comment rail

--- a/packages/renderer/src/i18n.tsx
+++ b/packages/renderer/src/i18n.tsx
@@ -196,7 +196,7 @@ export const EN: Catalog = {
   "agent.atLimit": "Usage limit reached — turns are paused until your plan resets or you upgrade",
   "agent.connection": "Agent connection",
   "agent.localCmdHint": "Paste this to your coding agent:",
-  "agent.localCmdBody": "Collaborate with me on my inplan plan. Check the CLI with `inplan --version` (if missing, install it: `npm i -g inplan`), sign in with `inplan login`, then run `{cmd}` and work with me through the comments.",
+  "agent.localCmdBody": "Collaborate with me on my inplan plan. Check the CLI with `inplan --version` (if missing, install it: `npm i -g inplan`), then run `{cmd}` and work with me through the comments (it signs you in automatically the first time).",
   "agent.copy": "Copy",
   "agent.copied": "Copied",
   // comment rail

--- a/packages/renderer/test/AgentIndicator.test.tsx
+++ b/packages/renderer/test/AgentIndicator.test.tsx
@@ -116,7 +116,7 @@ describe("AgentIndicator", () => {
     const copied = writeText.mock.calls[0][0] as string;
     expect(copied).toContain(cmd); // the connect command, in full
     expect(copied).toContain("npm i -g inplan"); // how to install if missing
-    expect(copied).not.toContain("inplan login"); // sign-in is now automatic on first `wait` — no separate step
+    expect(copied).toContain("inplan login"); // explicit sign-in step so headless (non-TTY) agents aren't relying on interactive-only auto-login
   });
 
   it("omits the local-agent command when the host supplies none (desktop)", () => {

--- a/packages/renderer/test/AgentIndicator.test.tsx
+++ b/packages/renderer/test/AgentIndicator.test.tsx
@@ -112,11 +112,11 @@ describe("AgentIndicator", () => {
     expect(document.body.textContent).toMatch(/coding agent/i); // framed as an agent hand-off, not a human command
     expect(document.body.textContent).toContain("…"); // long instruction shown middle-elided in the box
     fireEvent.click(screen.getByRole("button", { name: /^copy$/i }));
-    // Copies the FULL bootstrap instruction (install check + install + login + the connect command).
+    // Copies the FULL bootstrap instruction (install check + install + the connect command).
     const copied = writeText.mock.calls[0][0] as string;
     expect(copied).toContain(cmd); // the connect command, in full
     expect(copied).toContain("npm i -g inplan"); // how to install if missing
-    expect(copied).toContain("inplan login"); // how to sign in
+    expect(copied).not.toContain("inplan login"); // sign-in is now automatic on first `wait` — no separate step
   });
 
   it("omits the local-agent command when the host supplies none (desktop)", () => {


### PR DESCRIPTION
Makes `inplan wait --remote <docId>` work for a remote coding agent without a separate login, and fixes a session-invalidation bug found while testing.

## Changes
- **Auto-login (#3a):** `runRemote` signs in inline when there are no credentials **and** the session is interactive (TTY). Headless/CI/`--no-login` still error with guidance — background hooks never open a browser.
- **Deprecate `open --remote`:** a cloud doc has no local editor to launch, so it warns and behaves as `wait --remote`. Local `open` (create doc + launch editor) is unchanged.
- **Connect message:** drops "sign in with `inplan login`" (the first `wait` signs in automatically).
- **Auth-race fix:** `authedSession()` now reuses a cached access token while valid instead of refreshing (rotating Supabase's single-use refresh token) on every call. Concurrent CLI processes (a `wait` loop + any other command) were racing the rotation and persisting a revoked token → dead session. Refresh now happens only when missing/near-expiry, under a cross-process lock, with `autoRefreshToken` off.

## Tests
- New: `ensureLogin.test.ts` (TTY/CI/`--no-login` gating, persistence), `open --remote` deprecation.
- Updated: `cliAuthSession.test.ts` (cached-token reuse contract), `AgentIndicator` message.
- Full suite: 835 passing. Auth-race fix reproduced (concurrent `whoami` died before, survives 80 concurrent ops after).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/71?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote commands can sign in interactively when credentials are unavailable.
  * Valid cached credentials are reused automatically, with refreshed details saved reliably.
  * Long-running remote operations stay authenticated automatically.
  * Local-agent setup now defers sign-in until it is needed.
  * CLI usage guidance distinguishes `open`, `wait`, and `signal`.

* **Bug Fixes**
  * Improved authentication refresh handling across concurrent CLI processes.
  * Prevented browser sign-in in CI, headless, piped, or opt-out environments.

* **Deprecations**
  * `open --remote` displays guidance and behaves like `wait --remote`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

