### PR TITLE
Remote-agent live collab (Stage B/C): hub gate for cloud docs

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -36,7 +36,7 @@ import { applyGatedEdit } from "./applyEdit";
 import { evaluateAgentEdit } from "./gate";
 import { addComment, AddCommentError } from "./commentAdd";
 import { docPaths, sidecarRoot, type DocPaths } from "./paths";
-import { loadPluginGate, type PluginGate } from "./pluginGate";
+import { loadPluginGate, DEFAULT_HUB_URL, type PluginGate } from "./pluginGate";
 import { announcePresence } from "./presence";
 import { wakePredicate, waitForActions } from "./wait";
 import { versionFromModule } from "./version";
@@ -673,32 +673,48 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
   const presence = announcePresence(docId, backend.token, model);
   try {
     // Live collaboration (paid perk): if the user is entitled, load the signature-verified collab
-    // plugin and drive the agent's edits through the Yjs hub — a CRDT, so it's multi-user-safe,
-    // unlike a blind store overwrite. The agent's working surface is a local `.md` materialized from
-    // the hub's canonical on first attach (kept across turns so its edits survive); edits sync back
-    // via the gate. Not entitled / unverified / no plugin ⇒ null ⇒ the turn-based store path below.
-    const hubUrl = process.env.INPLAN_PLUGIN_URL || "wss://inplan-collab.fly.dev";
+    // plugin and drive the agent's edits through the Yjs hub instead of a blind store overwrite. The
+    // agent's working surface is a local `.md` materialized from the hub's canonical on first attach
+    // (kept across turns so its edits survive); edits sync back via the gate. Not entitled /
+    // unverified / no plugin ⇒ null ⇒ the turn-based store path below.
+    // NB (known gap, tracked): a turn applies the WHOLE working file against the current hub
+    // canonical, and the file is seeded only once — so a human edit made in the hub between turns can
+    // be reverted by the next agent apply. Concurrent LIVE typing is CRDT-merged, but this
+    // between-turns case is not yet fully multi-user-safe.
+    const hubUrl = process.env.INPLAN_PLUGIN_URL || DEFAULT_HUB_URL;
     const hubSession = JSON.stringify({ url: hubUrl, docName: docId, token: backend.token });
     const gate = await loadPluginGate(hubSession, { token: backend.token });
     if (gate) {
       const workFile = join(sidecarRoot(), "remote", `${docId}.plan.md`);
       mkdirSync(dirname(workFile), { recursive: true });
-      if (!existsSync(workFile)) writeFileSync(workFile, await gate.readCanonical()); // seed once; keep edits across turns
-      process.stderr.write(`inplan: live-collab — plan at ${workFile}; read/edit it there, then re-run to sync\n`);
-      await waitCycle(
-        {
-          channel: live.channel, // turns/comments still ride the cloud control log (self-refreshing)…
-          store: fsBackend(workFile).store, // …while the agent reads/edits a local working copy…
-          history: async () => (await live.channel.readSince(0)).entries,
-          logExit: () => {},
-          ...(onSaveLocally ? { onSaveLocally } : {}),
-        },
-        explicitCursor,
-        confirmed,
-        model,
-        gate, // …and accepted edits apply through the hub (CRDT), not the store.
-      );
-      return;
+      // Seed the local working copy once. If the hub is unreachable on first attach, don't abort the
+      // whole wait — fall through to the turn-based store path below (the documented fallback).
+      let onGate = true;
+      if (!existsSync(workFile)) {
+        try {
+          writeFileSync(workFile, await gate.readCanonical());
+        } catch (e) {
+          process.stderr.write(`inplan: live-collab hub unreachable (${String(e)}); using turn-based sync\n`);
+          onGate = false;
+        }
+      }
+      if (onGate) {
+        process.stderr.write(`inplan: live-collab — plan at ${workFile}; read/edit it there, then re-run to sync\n`);
+        await waitCycle(
+          {
+            channel: live.channel, // turns/comments still ride the cloud control log (self-refreshing)…
+            store: fsBackend(workFile).store, // …while the agent reads/edits a local working copy…
+            history: async () => (await live.channel.readSince(0)).entries,
+            logExit: () => {},
+            ...(onSaveLocally ? { onSaveLocally } : {}),
+          },
+          explicitCursor,
+          confirmed,
+          model,
+          gate, // …and accepted edits apply through the hub, not the store.
+        );
+        return;
+      }
     }
 
     await waitCycle(

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -37,7 +37,7 @@ import { evaluateAgentEdit } from "./gate";
 import { addComment, AddCommentError } from "./commentAdd";
 import { docPaths, sidecarRoot, type DocPaths } from "./paths";
 import { loadPluginGate, resolveHubUrl, type PluginGate } from "./pluginGate";
-import { shouldHydrateWorkFile } from "./liveSync";
+import { shouldHydrateWorkFile, pendingRequiresReplay } from "./liveSync";
 import { announcePresence } from "./presence";
 import { wakePredicate, waitForActions } from "./wait";
 import { versionFromModule } from "./version";
@@ -749,18 +749,22 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
             }
           : undefined;
 
-        // Guard BOTH hub directions so any drop degrades gracefully instead of crashing the turn:
+        // Guard BOTH hub directions so any drop degrades gracefully instead of crashing the turn,
+        // tracking read and write failures SEPARATELY (they mean different things afterward):
         //  - read failure ⇒ re-throw so waitCycle takes its existing local-store fallback;
         //  - write failure ⇒ persist the edit to the local working copy (so it's not lost) and don't
         //    re-throw, so the turn still emits a status instead of exiting 1 from main().catch.
-        // Either way `hubFailed` is set, so we mark the edit pending and skip the end-of-turn re-sync.
-        let hubFailed = false;
+        // Any failure skips the end-of-turn re-sync; only a WRITE failure marks `.pending` (a local
+        // revision to replay) — a read-only failure must not, or the next healthy run would skip
+        // hydration and risk reverting newer hub edits.
+        let hubReadFailed = false;
+        let hubWriteFailed = false;
         const trackedGate: PluginGate = {
           readCanonical: async () => {
             try {
               return await gate.readCanonical();
             } catch (e) {
-              hubFailed = true;
+              hubReadFailed = true;
               throw e;
             }
           },
@@ -768,7 +772,7 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
             try {
               await gate.applyRevision(md);
             } catch (e) {
-              hubFailed = true;
+              hubWriteFailed = true;
               process.stderr.write(`inplan: live-collab hub write failed (${String(e)}); kept the edit locally to retry\n`);
               await localStore.setCanonical(md);
               await localStore.saveDoc(md);
@@ -790,11 +794,15 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
           trackedGate, // …and accepted edits apply through the hub, not the store.
         );
 
-        if (hubFailed) {
-          // The hub dropped mid-turn; the accepted edit lives only in the working copy. Mark it
-          // pending (so the next run preserves it and pushes it) and DO NOT re-sync — re-syncing would
-          // overwrite that edit with stale hub canonical.
-          writeFileSync(pendingPath, "1");
+        if (hubReadFailed || hubWriteFailed) {
+          // The hub dropped mid-turn; DO NOT re-sync (that would overwrite a local edit with stale hub
+          // canonical). Mark `.pending` ONLY when a WRITE failed — that's the case with a local
+          // revision persisted off-hub that must be replayed. A read-only failure leaves the working
+          // copy either unchanged (clean) or hash-diverged (agent edited); both are handled by the
+          // start-of-turn hydration check, and a spurious `.pending` would wrongly skip it next run.
+          if (pendingRequiresReplay({ readFailed: hubReadFailed, writeFailed: hubWriteFailed })) {
+            writeFileSync(pendingPath, "1");
+          }
           process.stderr.write("inplan: hub was unavailable this turn — keeping local edits (will sync next turn)\n");
         } else {
           // Turn applied to the hub. The working copy is now consistent with the hub for the agent's

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -667,12 +667,40 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
       }
     : undefined;
 
-  // While we hold the turn on a cloud doc, announce the local agent in the doc's presence room so
-  // the web badge shows "agent · your machine"; clear it on exit. (Presence is a cosmetic websocket
-  // on the initial token; the correctness-critical DB polling rides `live` above and stays
-  // authenticated across the whole wait, even past the initial token's ~1h expiry.)
+  // the web badge shows "agent · your machine"; clear it on exit (wraps both wait paths below).
+  // (Presence is a cosmetic websocket on the initial token; the correctness-critical DB polling
+  // rides `live` above and stays authenticated across the whole wait, even past the ~1h expiry.)
   const presence = announcePresence(docId, backend.token, model);
   try {
+    // Live collaboration (paid perk): if the user is entitled, load the signature-verified collab
+    // plugin and drive the agent's edits through the Yjs hub — a CRDT, so it's multi-user-safe,
+    // unlike a blind store overwrite. The agent's working surface is a local `.md` materialized from
+    // the hub's canonical on first attach (kept across turns so its edits survive); edits sync back
+    // via the gate. Not entitled / unverified / no plugin ⇒ null ⇒ the turn-based store path below.
+    const hubUrl = process.env.INPLAN_PLUGIN_URL || "wss://inplan-collab.fly.dev";
+    const hubSession = JSON.stringify({ url: hubUrl, docName: docId, token: backend.token });
+    const gate = await loadPluginGate(hubSession, { token: backend.token });
+    if (gate) {
+      const workFile = join(sidecarRoot(), "remote", `${docId}.plan.md`);
+      mkdirSync(dirname(workFile), { recursive: true });
+      if (!existsSync(workFile)) writeFileSync(workFile, await gate.readCanonical()); // seed once; keep edits across turns
+      process.stderr.write(`inplan: live-collab — plan at ${workFile}; read/edit it there, then re-run to sync\n`);
+      await waitCycle(
+        {
+          channel: live.channel, // turns/comments still ride the cloud control log (self-refreshing)…
+          store: fsBackend(workFile).store, // …while the agent reads/edits a local working copy…
+          history: async () => (await live.channel.readSince(0)).entries,
+          logExit: () => {},
+          ...(onSaveLocally ? { onSaveLocally } : {}),
+        },
+        explicitCursor,
+        confirmed,
+        model,
+        gate, // …and accepted edits apply through the hub (CRDT), not the store.
+      );
+      return;
+    }
+
     await waitCycle(
       {
         channel: live.channel,

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -677,10 +677,6 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
     // agent's working surface is a local `.md` materialized from the hub's canonical on first attach
     // (kept across turns so its edits survive); edits sync back via the gate. Not entitled /
     // unverified / no plugin ⇒ null ⇒ the turn-based store path below.
-    // NB (known gap, tracked): a turn applies the WHOLE working file against the current hub
-    // canonical, and the file is seeded only once — so a human edit made in the hub between turns can
-    // be reverted by the next agent apply. Concurrent LIVE typing is CRDT-merged, but this
-    // between-turns case is not yet fully multi-user-safe.
     const hubUrl = process.env.INPLAN_PLUGIN_URL || DEFAULT_HUB_URL;
     const hubSession = JSON.stringify({ url: hubUrl, docName: docId, token: backend.token });
     const gate = await loadPluginGate(hubSession, { token: backend.token });
@@ -699,11 +695,25 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
         }
       }
       if (onGate) {
+        // Working doc stays on the local file, but Review-mode PROPOSALS persist to the CLOUD doc's
+        // proposal store (via live.store) — otherwise a parked proposal would sit in this machine's
+        // sidecar, invisible to the human in the web editor who's meant to accept/reject it.
+        const localStore = fsBackend(workFile).store;
+        const gateStore: DocumentStore = {
+          loadDoc: () => localStore.loadDoc(),
+          saveDoc: (c) => localStore.saveDoc(c),
+          getCanonical: () => localStore.getCanonical(),
+          setCanonical: (c) => localStore.setCanonical(c),
+          backup: (c, m) => localStore.backup(c, m),
+          getProposed: () => live.store.getProposed(),
+          setProposed: (c) => live.store.setProposed(c),
+          clearProposed: () => live.store.clearProposed(),
+        };
         process.stderr.write(`inplan: live-collab — plan at ${workFile}; read/edit it there, then re-run to sync\n`);
         await waitCycle(
           {
             channel: live.channel, // turns/comments still ride the cloud control log (self-refreshing)…
-            store: fsBackend(workFile).store, // …while the agent reads/edits a local working copy…
+            store: gateStore, // …the agent reads/edits a local working copy; proposals go to the cloud…
             history: async () => (await live.channel.readSince(0)).entries,
             logExit: () => {},
             ...(onSaveLocally ? { onSaveLocally } : {}),
@@ -713,6 +723,16 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
           model,
           gate, // …and accepted edits apply through the hub, not the store.
         );
+        // Re-sync the working copy from the hub canonical AFTER the turn — the human has just taken
+        // their turn, so the hub now holds their edits plus the agent's applied ones. Refreshing here
+        // (rather than never) means the agent's NEXT turn edits on top of the human's changes, so the
+        // next whole-file apply can't revert them. Done at turn-end (not start) so it never clobbers
+        // the edits the agent made before re-running. Best-effort: a hub blip just leaves last state.
+        try {
+          writeFileSync(workFile, await gate.readCanonical());
+        } catch {
+          /* hub momentarily unreachable — keep the current working copy; next turn re-syncs */
+        }
         return;
       }
     }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -36,7 +36,7 @@ import { applyGatedEdit } from "./applyEdit";
 import { evaluateAgentEdit } from "./gate";
 import { addComment, AddCommentError } from "./commentAdd";
 import { docPaths, sidecarRoot, type DocPaths } from "./paths";
-import { loadPluginGate, DEFAULT_HUB_URL, type PluginGate } from "./pluginGate";
+import { loadPluginGate, resolveHubUrl, type PluginGate } from "./pluginGate";
 import { announcePresence } from "./presence";
 import { wakePredicate, waitForActions } from "./wait";
 import { versionFromModule } from "./version";
@@ -434,16 +434,19 @@ async function waitCycle(backend: WaitBackend, explicitCursor: number | null, co
     return;
   }
 
-  await channel.setCursor(result.cursor); // advance the persisted cursor so the next call continues here
-
   // Cloud→local handoff: a human on the web asked us to bring the doc back to disk.
   // The backend's handler downloads + relocates + flips status and emits its own
-  // result, so we hand off instead of printing the normal turn status.
+  // result, so we hand off instead of printing the normal turn status. Do this BEFORE advancing the
+  // cursor: if the handler throws (e.g. the gate path's hub read fails), the SaveLocallyRequested
+  // event stays unconsumed so the next run retries — otherwise the handoff would be lost. On success
+  // the doc becomes local, so the cloud cursor is moot.
   if (backend.onSaveLocally && result.entries.some((e) => e.type === LogEventType.SaveLocallyRequested)) {
     backend.logExit("save_locally");
     await backend.onSaveLocally();
     return;
   }
+
+  await channel.setCursor(result.cursor); // advance the persisted cursor so the next call continues here
 
   // In-window navigation: the editor followed a link to a sibling doc and parked a
   // `navigated_to {path}`. Step down here and report the new path so the agent loop
@@ -677,7 +680,7 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
     // agent's working surface is a local `.md` materialized from the hub's canonical on first attach
     // (kept across turns so its edits survive); edits sync back via the gate. Not entitled /
     // unverified / no plugin ⇒ null ⇒ the turn-based store path below.
-    const hubUrl = process.env.INPLAN_PLUGIN_URL || DEFAULT_HUB_URL;
+    const hubUrl = resolveHubUrl();
     const hubSession = JSON.stringify({ url: hubUrl, docName: docId, token: backend.token });
     const gate = await loadPluginGate(hubSession, { token: backend.token });
     if (gate) {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -37,7 +37,7 @@ import { evaluateAgentEdit } from "./gate";
 import { addComment, AddCommentError } from "./commentAdd";
 import { docPaths, sidecarRoot, type DocPaths } from "./paths";
 import { loadPluginGate, resolveHubUrl, type PluginGate } from "./pluginGate";
-import { shouldHydrateWorkFile, pendingRequiresReplay } from "./liveSync";
+import { shouldHydrateWorkFile, pendingRequiresReplay, trackGateDegradations } from "./liveSync";
 import { announcePresence } from "./presence";
 import { wakePredicate, waitForActions } from "./wait";
 import { versionFromModule } from "./version";
@@ -750,35 +750,14 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
           : undefined;
 
         // Guard BOTH hub directions so any drop degrades gracefully instead of crashing the turn,
-        // tracking read and write failures SEPARATELY (they mean different things afterward):
-        //  - read failure ⇒ re-throw so waitCycle takes its existing local-store fallback;
-        //  - write failure ⇒ persist the edit to the local working copy (so it's not lost) and don't
-        //    re-throw, so the turn still emits a status instead of exiting 1 from main().catch.
-        // Any failure skips the end-of-turn re-sync; only a WRITE failure marks `.pending` (a local
-        // revision to replay) — a read-only failure must not, or the next healthy run would skip
-        // hydration and risk reverting newer hub edits.
-        let hubReadFailed = false;
-        let hubWriteFailed = false;
-        const trackedGate: PluginGate = {
-          readCanonical: async () => {
-            try {
-              return await gate.readCanonical();
-            } catch (e) {
-              hubReadFailed = true;
-              throw e;
-            }
-          },
-          applyRevision: async (md) => {
-            try {
-              await gate.applyRevision(md);
-            } catch (e) {
-              hubWriteFailed = true;
-              process.stderr.write(`inplan: live-collab hub write failed (${String(e)}); kept the edit locally to retry\n`);
-              await localStore.setCanonical(md);
-              await localStore.saveDoc(md);
-            }
-          },
-        };
+        // tracking read and write failures separately (see trackGateDegradations): a read failure
+        // re-throws (waitCycle falls back to the local store); a write failure persists the edit
+        // locally and doesn't re-throw (the turn still emits a status). Any failure skips the
+        // end-of-turn re-sync; only a WRITE marks `.pending` — a read-only failure must not, or the
+        // next healthy run would skip hydration and risk reverting newer hub edits.
+        const tracked = trackGateDegradations(gate, localStore, (m) =>
+          process.stderr.write(`inplan: live-collab hub write failed (${m}); kept the edit locally to retry\n`),
+        );
         process.stderr.write(`inplan: live-collab — plan at ${workFile}; read/edit it there, then re-run to sync\n`);
         await waitCycle(
           {
@@ -791,16 +770,16 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
           explicitCursor,
           confirmed,
           model,
-          trackedGate, // …and accepted edits apply through the hub, not the store.
+          tracked.gate, // …and accepted edits apply through the hub, not the store.
         );
 
-        if (hubReadFailed || hubWriteFailed) {
+        if (tracked.readFailed() || tracked.writeFailed()) {
           // The hub dropped mid-turn; DO NOT re-sync (that would overwrite a local edit with stale hub
           // canonical). Mark `.pending` ONLY when a WRITE failed — that's the case with a local
           // revision persisted off-hub that must be replayed. A read-only failure leaves the working
           // copy either unchanged (clean) or hash-diverged (agent edited); both are handled by the
           // start-of-turn hydration check, and a spurious `.pending` would wrongly skip it next run.
-          if (pendingRequiresReplay({ readFailed: hubReadFailed, writeFailed: hubWriteFailed })) {
+          if (pendingRequiresReplay({ readFailed: tracked.readFailed(), writeFailed: tracked.writeFailed() })) {
             writeFileSync(pendingPath, "1");
           }
           process.stderr.write("inplan: hub was unavailable this turn — keeping local edits (will sync next turn)\n");

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -4,7 +4,7 @@
 import { execFileSync, spawn, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { createRequire } from "node:module";
-import { appendFileSync, copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, renameSync, statSync, writeFileSync } from "node:fs";
+import { appendFileSync, copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -37,6 +37,7 @@ import { evaluateAgentEdit } from "./gate";
 import { addComment, AddCommentError } from "./commentAdd";
 import { docPaths, sidecarRoot, type DocPaths } from "./paths";
 import { loadPluginGate, resolveHubUrl, type PluginGate } from "./pluginGate";
+import { shouldHydrateWorkFile } from "./liveSync";
 import { announcePresence } from "./presence";
 import { wakePredicate, waitForActions } from "./wait";
 import { versionFromModule } from "./version";
@@ -685,20 +686,42 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
     const gate = await loadPluginGate(hubSession, { token: backend.token });
     if (gate) {
       const workFile = join(sidecarRoot(), "remote", `${docId}.plan.md`);
+      const pendingPath = `${workFile}.pending`; // marker: a local fallback edit awaits a hub push
+      const hashPath = `${workFile}.synced`; // hash of the working copy at our last write/sync
       mkdirSync(dirname(workFile), { recursive: true });
-      // Probe the hub on EVERY run (not just first attach): if it's unreachable now, fall through to
-      // the turn-based `live.store` path below (the documented fallback) rather than silently staying
-      // on the local-only gateStore and stranding cloud edits in the working copy. Seed the working
-      // copy the first time; on later runs keep it (it may hold the agent's not-yet-applied edits).
+      const readIf = (p: string): string | null => (existsSync(p) ? readFileSync(p, "utf8") : null);
+      const recordSynced = (content: string) => writeFileSync(hashPath, hashBody(content));
+
+      // Probe the hub on EVERY run: if unreachable now, fall through to the turn-based `live.store`
+      // path (the documented fallback) rather than staying on the local-only gateStore and stranding
+      // cloud edits in the working copy.
       let onGate = true;
+      let canonical = "";
       try {
-        const canonical = await gate.readCanonical();
-        if (!existsSync(workFile)) writeFileSync(workFile, canonical);
+        canonical = await gate.readCanonical();
       } catch (e) {
         process.stderr.write(`inplan: live-collab hub unreachable (${String(e)}); using turn-based sync\n`);
         onGate = false;
       }
       if (onGate) {
+        // Decide whether to (re)hydrate the working copy from the freshly probed canonical. Seed if
+        // absent; keep it if a local fallback edit is pending (must push first); otherwise refresh it
+        // ONLY when the agent hasn't touched it since our last sync (hash match) — so we pull the
+        // human's edits without clobbering unsynced agent edits. This is also what lets a FAILED
+        // end-of-turn re-sync self-heal on the next run.
+        const exists = existsSync(workFile);
+        if (
+          shouldHydrateWorkFile({
+            exists,
+            pending: existsSync(pendingPath),
+            currentHash: exists ? hashBody(readFileSync(workFile, "utf8")) : null,
+            syncedHash: readIf(hashPath),
+          })
+        ) {
+          writeFileSync(workFile, canonical);
+          recordSynced(canonical);
+        }
+
         // Working doc stays on the local file, but Review-mode PROPOSALS persist to the CLOUD doc's
         // proposal store (via live.store) — otherwise a parked proposal would sit in this machine's
         // sidecar, invisible to the human in the web editor who's meant to accept/reject it.
@@ -725,21 +748,32 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
               output({ status: "moved_local", path: localFile, reopened: pid !== null });
             }
           : undefined;
-        // Track a mid-turn hub read failure: if the hub drops during the turn, waitCycle falls back
-        // to the local store and applies the agent's edit there — so we must NOT re-sync afterward
-        // (that would overwrite the local-only edit with stale hub canonical). The next turn pushes
-        // the preserved local edit to the hub once it's reachable again.
-        let hubReadFailed = false;
+
+        // Guard BOTH hub directions so any drop degrades gracefully instead of crashing the turn:
+        //  - read failure ⇒ re-throw so waitCycle takes its existing local-store fallback;
+        //  - write failure ⇒ persist the edit to the local working copy (so it's not lost) and don't
+        //    re-throw, so the turn still emits a status instead of exiting 1 from main().catch.
+        // Either way `hubFailed` is set, so we mark the edit pending and skip the end-of-turn re-sync.
+        let hubFailed = false;
         const trackedGate: PluginGate = {
           readCanonical: async () => {
             try {
               return await gate.readCanonical();
             } catch (e) {
-              hubReadFailed = true;
+              hubFailed = true;
               throw e;
             }
           },
-          applyRevision: (md) => gate.applyRevision(md),
+          applyRevision: async (md) => {
+            try {
+              await gate.applyRevision(md);
+            } catch (e) {
+              hubFailed = true;
+              process.stderr.write(`inplan: live-collab hub write failed (${String(e)}); kept the edit locally to retry\n`);
+              await localStore.setCanonical(md);
+              await localStore.saveDoc(md);
+            }
+          },
         };
         process.stderr.write(`inplan: live-collab — plan at ${workFile}; read/edit it there, then re-run to sync\n`);
         await waitCycle(
@@ -755,21 +789,27 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
           model,
           trackedGate, // …and accepted edits apply through the hub, not the store.
         );
-        // Re-sync the working copy from the hub canonical AFTER the turn — the human has just taken
-        // their turn, so the hub now holds their edits plus the agent's applied ones. Refreshing here
-        // (rather than never) means the agent's NEXT turn edits on top of the human's changes, so the
-        // next whole-file apply can't revert them. Done at turn-end (not start) so it never clobbers
-        // the edits the agent made before re-running. SKIP when the turn degraded to the local store
-        // (hub dropped mid-turn): the accepted edit lives only in the working copy, so re-syncing
-        // would discard it — keep it and let the next turn push it. Best-effort otherwise.
-        if (!hubReadFailed) {
-          try {
-            writeFileSync(workFile, await gate.readCanonical());
-          } catch {
-            /* hub momentarily unreachable — keep the current working copy; next turn re-syncs */
-          }
+
+        if (hubFailed) {
+          // The hub dropped mid-turn; the accepted edit lives only in the working copy. Mark it
+          // pending (so the next run preserves it and pushes it) and DO NOT re-sync — re-syncing would
+          // overwrite that edit with stale hub canonical.
+          writeFileSync(pendingPath, "1");
+          process.stderr.write("inplan: hub was unavailable this turn — keeping local edits (will sync next turn)\n");
         } else {
-          process.stderr.write("inplan: hub was unreachable this turn — keeping local edits (will sync next turn)\n");
+          // Turn applied to the hub. The working copy is now consistent with the hub for the agent's
+          // part, so record its hash (this makes a FAILED re-sync below self-heal: next run sees a
+          // matching hash and safely hydrates). Then re-sync the copy to the latest canonical (folding
+          // in the human's just-taken turn) so the agent's NEXT turn builds on it, and clear pending.
+          if (existsSync(pendingPath)) rmSync(pendingPath);
+          recordSynced(readFileSync(workFile, "utf8"));
+          try {
+            const fresh = await gate.readCanonical();
+            writeFileSync(workFile, fresh);
+            recordSynced(fresh);
+          } catch {
+            /* transient: leave the copy (its hash still matches) so the next run hydrates it */
+          }
         }
         return;
       }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -683,16 +683,17 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
     if (gate) {
       const workFile = join(sidecarRoot(), "remote", `${docId}.plan.md`);
       mkdirSync(dirname(workFile), { recursive: true });
-      // Seed the local working copy once. If the hub is unreachable on first attach, don't abort the
-      // whole wait — fall through to the turn-based store path below (the documented fallback).
+      // Probe the hub on EVERY run (not just first attach): if it's unreachable now, fall through to
+      // the turn-based `live.store` path below (the documented fallback) rather than silently staying
+      // on the local-only gateStore and stranding cloud edits in the working copy. Seed the working
+      // copy the first time; on later runs keep it (it may hold the agent's not-yet-applied edits).
       let onGate = true;
-      if (!existsSync(workFile)) {
-        try {
-          writeFileSync(workFile, await gate.readCanonical());
-        } catch (e) {
-          process.stderr.write(`inplan: live-collab hub unreachable (${String(e)}); using turn-based sync\n`);
-          onGate = false;
-        }
+      try {
+        const canonical = await gate.readCanonical();
+        if (!existsSync(workFile)) writeFileSync(workFile, canonical);
+      } catch (e) {
+        process.stderr.write(`inplan: live-collab hub unreachable (${String(e)}); using turn-based sync\n`);
+        onGate = false;
       }
       if (onGate) {
         // Working doc stays on the local file, but Review-mode PROPOSALS persist to the CLOUD doc's
@@ -709,6 +710,18 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
           setProposed: (c) => live.store.setProposed(c),
           clearProposed: () => live.store.clearProposed(),
         };
+        // Save-local handoff on the gate path reads the HUB canonical (the source of truth here);
+        // live.store isn't updated by gate.applyRevision, so reading it would write a stale doc. If
+        // the hub read fails we throw BEFORE writing status, so the doc isn't switched to local.
+        const onSaveLocallyGate = localFile
+          ? async () => {
+              const body = await gate.readCanonical();
+              writeFileSync(localFile, body);
+              writeStatus(docPaths(localFile).statusPath, { location: "local", originalPath: localFile, lastSyncedHash: hashBody(body) });
+              const pid = spawnApp(localFile);
+              output({ status: "moved_local", path: localFile, reopened: pid !== null });
+            }
+          : undefined;
         process.stderr.write(`inplan: live-collab — plan at ${workFile}; read/edit it there, then re-run to sync\n`);
         await waitCycle(
           {
@@ -716,7 +729,7 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
             store: gateStore, // …the agent reads/edits a local working copy; proposals go to the cloud…
             history: async () => (await live.channel.readSince(0)).entries,
             logExit: () => {},
-            ...(onSaveLocally ? { onSaveLocally } : {}),
+            ...(onSaveLocallyGate ? { onSaveLocally: onSaveLocallyGate } : {}),
           },
           explicitCursor,
           confirmed,

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -725,6 +725,22 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
               output({ status: "moved_local", path: localFile, reopened: pid !== null });
             }
           : undefined;
+        // Track a mid-turn hub read failure: if the hub drops during the turn, waitCycle falls back
+        // to the local store and applies the agent's edit there — so we must NOT re-sync afterward
+        // (that would overwrite the local-only edit with stale hub canonical). The next turn pushes
+        // the preserved local edit to the hub once it's reachable again.
+        let hubReadFailed = false;
+        const trackedGate: PluginGate = {
+          readCanonical: async () => {
+            try {
+              return await gate.readCanonical();
+            } catch (e) {
+              hubReadFailed = true;
+              throw e;
+            }
+          },
+          applyRevision: (md) => gate.applyRevision(md),
+        };
         process.stderr.write(`inplan: live-collab — plan at ${workFile}; read/edit it there, then re-run to sync\n`);
         await waitCycle(
           {
@@ -737,17 +753,23 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
           explicitCursor,
           confirmed,
           model,
-          gate, // …and accepted edits apply through the hub, not the store.
+          trackedGate, // …and accepted edits apply through the hub, not the store.
         );
         // Re-sync the working copy from the hub canonical AFTER the turn — the human has just taken
         // their turn, so the hub now holds their edits plus the agent's applied ones. Refreshing here
         // (rather than never) means the agent's NEXT turn edits on top of the human's changes, so the
         // next whole-file apply can't revert them. Done at turn-end (not start) so it never clobbers
-        // the edits the agent made before re-running. Best-effort: a hub blip just leaves last state.
-        try {
-          writeFileSync(workFile, await gate.readCanonical());
-        } catch {
-          /* hub momentarily unreachable — keep the current working copy; next turn re-syncs */
+        // the edits the agent made before re-running. SKIP when the turn degraded to the local store
+        // (hub dropped mid-turn): the accepted edit lives only in the working copy, so re-syncing
+        // would discard it — keep it and let the next turn push it. Best-effort otherwise.
+        if (!hubReadFailed) {
+          try {
+            writeFileSync(workFile, await gate.readCanonical());
+          } catch {
+            /* hub momentarily unreachable — keep the current working copy; next turn re-syncs */
+          }
+        } else {
+          process.stderr.write("inplan: hub was unreachable this turn — keeping local edits (will sync next turn)\n");
         }
         return;
       }

--- a/packages/cli/src/liveSync.ts
+++ b/packages/cli/src/liveSync.ts
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //
-// Pure decision helpers for the live-collab working-copy sync. The tricky question — "when is it
-// safe to overwrite the agent's local working copy with a freshly probed hub canonical?" — is kept
-// side-effect-free here so it can be unit-tested without a live hub, then driven from `runRemote`.
+// Helpers for the live-collab working-copy sync. The tricky decisions — "when is it safe to
+// overwrite the agent's local working copy?" and "how does a hub failure degrade?" — live here so
+// they can be unit-tested without a live hub, then driven from `runRemote`.
+
+import type { DocumentStore } from "@inplan/core/node";
+import type { PluginGate } from "./pluginGate";
 
 export interface HydrateInput {
   /** Does the working copy already exist on disk? */
@@ -43,4 +46,54 @@ export function shouldHydrateWorkFile(o: HydrateInput): boolean {
  */
 export function pendingRequiresReplay(o: { readFailed: boolean; writeFailed: boolean }): boolean {
   return o.writeFailed;
+}
+
+export interface TrackedGate {
+  /** The gate to hand to `waitCycle` — wraps the real one with graceful hub-failure handling. */
+  gate: PluginGate;
+  readFailed: () => boolean;
+  writeFailed: () => boolean;
+}
+
+/**
+ * Wrap a hub gate so failures during a turn are observable and degrade gracefully:
+ *  - `readCanonical()` re-throws on failure (so `waitCycle` takes its existing local-store fallback),
+ *    recording `readFailed`;
+ *  - `applyRevision()` on failure persists the edit to the local store (preserve-and-retry) and does
+ *    NOT re-throw — so the turn still completes and emits a status instead of crashing to
+ *    `main().catch`/exit 1 — recording `writeFailed`.
+ * The caller uses the flags to skip the end-of-turn re-sync and, per {@link pendingRequiresReplay},
+ * mark the working copy `.pending` only when a local revision actually needs replaying (a write).
+ */
+export function trackGateDegradations(
+  gate: PluginGate,
+  localStore: Pick<DocumentStore, "setCanonical" | "saveDoc">,
+  onWriteError?: (message: string) => void,
+): TrackedGate {
+  let readFailed = false;
+  let writeFailed = false;
+  return {
+    readFailed: () => readFailed,
+    writeFailed: () => writeFailed,
+    gate: {
+      readCanonical: async () => {
+        try {
+          return await gate.readCanonical();
+        } catch (e) {
+          readFailed = true;
+          throw e;
+        }
+      },
+      applyRevision: async (md) => {
+        try {
+          await gate.applyRevision(md);
+        } catch (e) {
+          writeFailed = true;
+          onWriteError?.(String(e));
+          await localStore.setCanonical(md);
+          await localStore.saveDoc(md);
+        }
+      },
+    },
+  };
 }

--- a/packages/cli/src/liveSync.ts
+++ b/packages/cli/src/liveSync.ts
@@ -32,3 +32,15 @@ export function shouldHydrateWorkFile(o: HydrateInput): boolean {
   if (o.pending) return false;
   return o.currentHash != null && o.currentHash === o.syncedHash;
 }
+
+/**
+ * Whether a hub failure during the turn left a local revision that must be replayed to the hub later
+ * — i.e. whether to mark the working copy `.pending`. ONLY a WRITE failure qualifies: the accepted
+ * edit was persisted locally and hasn't reached the hub. A READ failure alone must NOT: the agent may
+ * have made no edit, and a spurious `.pending` would skip hydration on the next healthy run and risk
+ * applying a stale copy back over newer hub edits. (The synced-hash check preserves any genuine local
+ * edit on the read path anyway, since an edited copy no longer matches the recorded hash.)
+ */
+export function pendingRequiresReplay(o: { readFailed: boolean; writeFailed: boolean }): boolean {
+  return o.writeFailed;
+}

--- a/packages/cli/src/liveSync.ts
+++ b/packages/cli/src/liveSync.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Pure decision helpers for the live-collab working-copy sync. The tricky question — "when is it
+// safe to overwrite the agent's local working copy with a freshly probed hub canonical?" — is kept
+// side-effect-free here so it can be unit-tested without a live hub, then driven from `runRemote`.
+
+export interface HydrateInput {
+  /** Does the working copy already exist on disk? */
+  exists: boolean;
+  /** Is a local fallback edit pending — i.e. a prior turn applied an edit locally because the hub
+   *  was unreachable, and it hasn't been pushed yet? */
+  pending: boolean;
+  /** Hash of the working copy's current content (null if it doesn't exist). */
+  currentHash: string | null;
+  /** Hash recorded the last time WE wrote/synced the working copy (null if never). */
+  syncedHash: string | null;
+}
+
+/**
+ * Decide whether to (re)hydrate the working copy from a freshly probed hub canonical at turn START.
+ *  - No file yet ⇒ seed it (true).
+ *  - A pending local fallback edit ⇒ keep it, never overwrite (false) — it must be pushed first.
+ *  - Otherwise overwrite ONLY when the agent hasn't touched the copy since our last write/sync (its
+ *    hash still matches the recorded synced hash). A mismatch means unsynced agent edits to preserve.
+ *
+ * This is what lets a FAILED end-of-turn re-sync self-heal: on that path the working copy is left
+ * equal to what was applied to the hub (so its hash still matches the synced hash), and the next
+ * run safely hydrates it — pulling in the human's edits instead of reverting them.
+ */
+export function shouldHydrateWorkFile(o: HydrateInput): boolean {
+  if (!o.exists) return true;
+  if (o.pending) return false;
+  return o.currentHash != null && o.currentHash === o.syncedHash;
+}

--- a/packages/cli/src/pluginGate.ts
+++ b/packages/cli/src/pluginGate.ts
@@ -13,8 +13,11 @@ import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { resolveDesktopPlugin } from "@inplan/core/node";
 
+/** Default collab hub websocket URL. Exported so the CLI's session wiring and this HTTP-base
+ *  derivation share ONE literal (both keyed off `INPLAN_PLUGIN_URL`) and can't drift apart. */
+export const DEFAULT_HUB_URL = "wss://inplan-collab.fly.dev";
 /** Plugin server HTTP base (ws→http), shared with the desktop app's entitlement check. */
-const PLUGIN_HTTP = (process.env.INPLAN_PLUGIN_URL || "wss://inplan-collab.fly.dev").replace(/^ws/, "http");
+const PLUGIN_HTTP = (process.env.INPLAN_PLUGIN_URL || DEFAULT_HUB_URL).replace(/^ws/, "http");
 /** The same cache root the app uses, so a bundle fetched by either side is reused (and re-verified). */
 const defaultCacheDir = (): string => join(process.env.INPLAN_HOME || join(homedir(), ".inplan"), "plugin-cache");
 

--- a/packages/cli/src/pluginGate.ts
+++ b/packages/cli/src/pluginGate.ts
@@ -13,11 +13,14 @@ import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { resolveDesktopPlugin } from "@inplan/core/node";
 
-/** Default collab hub websocket URL. Exported so the CLI's session wiring and this HTTP-base
- *  derivation share ONE literal (both keyed off `INPLAN_PLUGIN_URL`) and can't drift apart. */
+/** Default collab hub websocket URL. */
 export const DEFAULT_HUB_URL = "wss://inplan-collab.fly.dev";
+/** THE single hub-URL resolution order, shared by the gate/edits (cli.ts), presence (presence.ts),
+ *  and this HTTP-base derivation — so the badge, the edits, and the entitlement probe can never
+ *  target different hubs. `INPLAN_PLUGIN_URL` wins, then legacy `INPLAN_COLLAB_URL`, then the default. */
+export const resolveHubUrl = (): string => process.env.INPLAN_PLUGIN_URL || process.env.INPLAN_COLLAB_URL || DEFAULT_HUB_URL;
 /** Plugin server HTTP base (ws→http), shared with the desktop app's entitlement check. */
-const PLUGIN_HTTP = (process.env.INPLAN_PLUGIN_URL || DEFAULT_HUB_URL).replace(/^ws/, "http");
+const PLUGIN_HTTP = resolveHubUrl().replace(/^ws/, "http");
 /** The same cache root the app uses, so a bundle fetched by either side is reused (and re-verified). */
 const defaultCacheDir = (): string => join(process.env.INPLAN_HOME || join(homedir(), ".inplan"), "plugin-cache");
 

--- a/packages/cli/src/presence.ts
+++ b/packages/cli/src/presence.ts
@@ -3,8 +3,12 @@
 import { HocuspocusProvider, HocuspocusProviderWebsocket } from "@hocuspocus/provider";
 import * as Y from "yjs";
 import WebSocket from "ws";
+import { DEFAULT_HUB_URL } from "./pluginGate";
 
-const COLLAB_URL = process.env.INPLAN_COLLAB_URL || "wss://inplan-collab.fly.dev";
+// Presence must connect to the SAME collab hub the agent's edits target, so prefer INPLAN_PLUGIN_URL
+// (what the gate/edits use); fall back to the legacy INPLAN_COLLAB_URL, then the shared default. If
+// these diverged, the badge would probe a different hub than where edits actually land.
+const COLLAB_URL = process.env.INPLAN_PLUGIN_URL || process.env.INPLAN_COLLAB_URL || DEFAULT_HUB_URL;
 
 export interface PresenceHandle {
   /** Tear down the awareness connection (call when the wait ends / the process exits). */

--- a/packages/cli/src/presence.ts
+++ b/packages/cli/src/presence.ts
@@ -3,12 +3,11 @@
 import { HocuspocusProvider, HocuspocusProviderWebsocket } from "@hocuspocus/provider";
 import * as Y from "yjs";
 import WebSocket from "ws";
-import { DEFAULT_HUB_URL } from "./pluginGate";
+import { resolveHubUrl } from "./pluginGate";
 
-// Presence must connect to the SAME collab hub the agent's edits target, so prefer INPLAN_PLUGIN_URL
-// (what the gate/edits use); fall back to the legacy INPLAN_COLLAB_URL, then the shared default. If
-// these diverged, the badge would probe a different hub than where edits actually land.
-const COLLAB_URL = process.env.INPLAN_PLUGIN_URL || process.env.INPLAN_COLLAB_URL || DEFAULT_HUB_URL;
+// Presence must connect to the SAME collab hub the agent's edits target — use the shared resolver so
+// the badge can't probe a different hub than where edits land.
+const COLLAB_URL = resolveHubUrl();
 
 export interface PresenceHandle {
   /** Tear down the awareness connection (call when the wait ends / the process exits). */

--- a/packages/cli/test/liveSync.test.ts
+++ b/packages/cli/test/liveSync.test.ts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { describe, expect, it } from "vitest";
+import { shouldHydrateWorkFile } from "../src/liveSync";
+
+describe("shouldHydrateWorkFile", () => {
+  it("seeds when the working copy doesn't exist yet", () => {
+    expect(shouldHydrateWorkFile({ exists: false, pending: false, currentHash: null, syncedHash: null })).toBe(true);
+  });
+
+  it("never overwrites while a local fallback edit is pending (must be pushed first)", () => {
+    // Even if the hashes match, a pending un-pushed edit must be preserved.
+    expect(shouldHydrateWorkFile({ exists: true, pending: true, currentHash: "a", syncedHash: "a" })).toBe(false);
+  });
+
+  it("hydrates when the agent hasn't touched the copy since our last sync (hashes match)", () => {
+    // This is the failed-re-sync self-heal: the copy still equals what was applied, so it's safe to
+    // refresh from the hub (pulling the human's edits) instead of reverting them.
+    expect(shouldHydrateWorkFile({ exists: true, pending: false, currentHash: "h", syncedHash: "h" })).toBe(true);
+  });
+
+  it("keeps the copy when the agent has edited it since our last sync (hashes differ)", () => {
+    expect(shouldHydrateWorkFile({ exists: true, pending: false, currentHash: "new", syncedHash: "old" })).toBe(false);
+  });
+
+  it("keeps the copy when there's no recorded synced hash to trust", () => {
+    expect(shouldHydrateWorkFile({ exists: true, pending: false, currentHash: "h", syncedHash: null })).toBe(false);
+  });
+});

--- a/packages/cli/test/liveSync.test.ts
+++ b/packages/cli/test/liveSync.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, expect, it } from "vitest";
-import { shouldHydrateWorkFile, pendingRequiresReplay } from "../src/liveSync";
+import { shouldHydrateWorkFile, pendingRequiresReplay, trackGateDegradations } from "../src/liveSync";
 
 describe("shouldHydrateWorkFile", () => {
   it("seeds when the working copy doesn't exist yet", () => {
@@ -41,5 +41,56 @@ describe("pendingRequiresReplay", () => {
 
   it("marks pending if a write failed even when a read also failed", () => {
     expect(pendingRequiresReplay({ readFailed: true, writeFailed: true })).toBe(true);
+  });
+});
+
+describe("trackGateDegradations", () => {
+  const makeStore = () => {
+    const calls = { setCanonical: [] as string[], saveDoc: [] as string[] };
+    return {
+      store: {
+        setCanonical: async (c: string) => void calls.setCanonical.push(c),
+        saveDoc: async (c: string) => void calls.saveDoc.push(c),
+      },
+      calls,
+    };
+  };
+
+  it("read failure: re-throws and flags readFailed, without touching the local store", async () => {
+    const { store, calls } = makeStore();
+    const t = trackGateDegradations({ readCanonical: async () => { throw new Error("hub down"); }, applyRevision: async () => {} }, store);
+    await expect(t.gate.readCanonical()).rejects.toThrow("hub down"); // re-throws ⇒ waitCycle takes its local fallback
+    expect(t.readFailed()).toBe(true);
+    expect(t.writeFailed()).toBe(false);
+    expect(calls.setCanonical).toEqual([]); // the wrapper itself persists nothing on a read failure…
+    expect(calls.saveDoc).toEqual([]); // …so no spurious local revision ⇒ no .pending
+  });
+
+  it("write failure: persists the edit locally, flags writeFailed, does NOT re-throw", async () => {
+    const { store, calls } = makeStore();
+    let logged = "";
+    const t = trackGateDegradations(
+      { readCanonical: async () => "CANON", applyRevision: async () => { throw new Error("post failed"); } },
+      store,
+      (m) => { logged = m; },
+    );
+    await expect(t.gate.applyRevision("EDIT")).resolves.toBeUndefined(); // swallowed ⇒ the turn still completes
+    expect(t.writeFailed()).toBe(true);
+    expect(t.readFailed()).toBe(false);
+    expect(calls.setCanonical).toEqual(["EDIT"]); // preserve-and-retry: the edit is kept locally…
+    expect(calls.saveDoc).toEqual(["EDIT"]);
+    expect(logged).toContain("post failed");
+  });
+
+  it("success: delegates to the real gate and flags nothing", async () => {
+    const { store, calls } = makeStore();
+    const applied: string[] = [];
+    const t = trackGateDegradations({ readCanonical: async () => "CANON", applyRevision: async (md) => void applied.push(md) }, store);
+    expect(await t.gate.readCanonical()).toBe("CANON");
+    await t.gate.applyRevision("X");
+    expect(applied).toEqual(["X"]);
+    expect(t.readFailed()).toBe(false);
+    expect(t.writeFailed()).toBe(false);
+    expect(calls.setCanonical).toEqual([]); // no local persistence on the happy path
   });
 });

--- a/packages/cli/test/liveSync.test.ts
+++ b/packages/cli/test/liveSync.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, expect, it } from "vitest";
-import { shouldHydrateWorkFile } from "../src/liveSync";
+import { shouldHydrateWorkFile, pendingRequiresReplay } from "../src/liveSync";
 
 describe("shouldHydrateWorkFile", () => {
   it("seeds when the working copy doesn't exist yet", () => {
@@ -25,5 +25,21 @@ describe("shouldHydrateWorkFile", () => {
 
   it("keeps the copy when there's no recorded synced hash to trust", () => {
     expect(shouldHydrateWorkFile({ exists: true, pending: false, currentHash: "h", syncedHash: null })).toBe(false);
+  });
+});
+
+describe("pendingRequiresReplay", () => {
+  it("marks pending on a hub WRITE failure (a local revision needs replay)", () => {
+    expect(pendingRequiresReplay({ readFailed: false, writeFailed: true })).toBe(true);
+  });
+
+  it("does NOT mark pending on a read-only failure (no local revision to replay)", () => {
+    // The regression: a transient read failure with a clean working copy must not create .pending,
+    // or the next healthy run would skip hydration and could apply the stale copy over newer hub edits.
+    expect(pendingRequiresReplay({ readFailed: true, writeFailed: false })).toBe(false);
+  });
+
+  it("marks pending if a write failed even when a read also failed", () => {
+    expect(pendingRequiresReplay({ readFailed: true, writeFailed: true })).toBe(true);
   });
 });


### PR DESCRIPTION
Stacked on #73. Lets a remote CLI agent read/edit a **cloud** doc through the Yjs collab hub (CRDT, multi-user-safe), Pro+-entitlement-gated + signature-verified — validated end-to-end against a deployed DEV collab server.

- `runRemote`: when entitled, `loadPluginGate` (verified-bundle fetch) → hub gate; materialize the doc to a local working `.md` from the hub canonical (seeded once) + drive edits back via the gate. Not entitled/unverified ⇒ unchanged store path.
- Reuses the existing `PluginGate`/`waitCycle` seam + `/api/v1/desktop-plugin`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added remote live collaboration through the collaboration hub.
  * Working documents now stay synchronized during collaborative sessions.
  * Collaboration connections can use configured or default hub settings.
  * Proposals and revisions are synchronized with the collaboration service.

* **Bug Fixes**
  * Added cloud synchronization fallback when collaboration services are unavailable.
  * Preserved local edits when synchronization or handoff fails for safe retrying.
  * Improved recovery and resynchronization after interrupted collaborative sessions.
  * Updated local status correctly when saving changes during collaboration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->