### PR TITLE
release: 0.1.26 — remote-agent auth hardening + live-collab gate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5335,7 +5335,7 @@
     },
     "packages/cli": {
       "name": "@inplan/cli",
-      "version": "0.1.25",
+      "version": "0.1.26",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@hocuspocus/provider": "^2.15.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inplan/cli",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "private": true,
   "description": "inplan CLI: open / wait / signal orchestration over the document core.",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
Release **0.1.26** — bumps `@inplan/cli` 0.1.25 → 0.1.26 (version-only; the code is already on `main`).

Ships the two features merged since 0.1.25:
- **#73 — remote-agent auth:** auto-login for `wait --remote`, `open`→`wait` deprecation, and the session/refresh-token rotation race fixes (cached-access fast path, exclusive auth lock with ownership fencing + heartbeat, long-wait client re-mint, contention-vs-logout handling).
- **#74 — live-collab gate:** `wait --remote` can drive a Pro-entitled cloud doc through the signature-verified Yjs hub, with a fail-closed + graceful fallback to the turn-based store path.

**Validation:** full unit/integration suite green; the live-collab gate passes the DEV live-hub smoke end-to-end (signed bundle verify + Pro entitlement lease + hub read + working-copy materialize). The signing public key is baked by `release.yml`, so this build is collab-capable (activation is fail-closed + graceful — no separate flag).

After merge: publish by creating a GitHub Release with tag `v0.1.26` (triggers `release.yml` → `npm publish`).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/75?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CLI package version to 0.1.26.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->