### PR TITLE
Gate the local agent on cloud docs; stop the agent badge reading disconnected while it works

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -30,13 +30,13 @@ import { gitProvenance } from "./provenance";
 import { authedSession, clearAuth, currentUser, liveRemoteBackend, loadAuth, remoteBackend, saveAuth, type AuthFile } from "./cliAuth";
 import { browserLogin } from "./cliLogin";
 import { resolveIdentity, setManualProfile, writeLocalProfile } from "./cliProfile";
-import { checkForUpdate, selfUpdate, UPDATE_PKG } from "./update";
+import { checkForUpdate, selfUpdate, UPDATE_PKG, warnIfOutdated } from "./update";
 import { runningEditorPid } from "./editorProcess";
 import { applyGatedEdit } from "./applyEdit";
 import { evaluateAgentEdit } from "./gate";
 import { addComment, AddCommentError } from "./commentAdd";
 import { docPaths, sidecarRoot, type DocPaths } from "./paths";
-import { loadPluginGate, resolveHubUrl, type PluginGate } from "./pluginGate";
+import { loadPluginGate, loadPluginGateOutcome, resolveHubUrl, type PluginAbsenceReason, type PluginGate } from "./pluginGate";
 import { shouldHydrateWorkFile, pendingRequiresReplay, trackGateDegradations } from "./liveSync";
 import { announcePresence } from "./presence";
 import { wakePredicate, waitForActions } from "./wait";
@@ -595,6 +595,50 @@ function defaultBrowserLogin(): Promise<AuthFile> {
   return browserLogin({ onUrl: (u) => process.stderr.write(`Opening your browser to sign in:\n  ${u}\nIf it didn't open, paste that URL into your browser.\n`) });
 }
 
+/** Where the staleness check parks its verdict, so it costs one registry hit per TTL, not per turn. */
+function stalenessCache(): { readCache: () => string | null; writeCache: (v: string) => void } {
+  const path = join(sidecarRoot(), ".update-check.json");
+  return {
+    readCache: () => (existsSync(path) ? readFileSync(path, "utf8") : null),
+    writeCache: (v) => {
+      mkdirSync(dirname(path), { recursive: true });
+      writeFileSync(path, v);
+    },
+  };
+}
+
+/** `wait --remote` on a plan that doesn't include the local agent. Distinct from the generic 1 so a
+ *  wrapper can tell "buy something" from "retry later" without scraping stderr. */
+export const EXIT_UPGRADE_REQUIRED = 4;
+/** `wait --remote` when we couldn't get a verified answer (offline / server error / bad bundle). */
+export const EXIT_PLUGIN_UNAVAILABLE = 5;
+
+/**
+ * Explain, to a human and to the coding agent reading our JSON, why we can't serve this cloud doc.
+ *
+ * The two reasons need different words: `unentitled` is a plan limit the human can act on, while
+ * `unavailable` is a transient failure they should just retry. Telling a paying customer to upgrade
+ * because a server hiccuped is the worst outcome here, which is why the reason is only ever
+ * `unentitled` on an explicit server denial (see {@link resolvePluginOutcome}).
+ */
+export function explainNoGate(reason: PluginAbsenceReason, localFile?: string): void {
+  if (reason === "unentitled") {
+    process.stderr.write(
+      "inplan: this plan doesn't include the local agent on cloud documents.\n" +
+        "  Open the document in your browser and click the agent indicator to upgrade.\n" +
+        (localFile ? `  Or keep working offline for free: \`inplan demote ${localFile}\` brings it back to disk.\n` : ""),
+    );
+    output({ status: "upgrade_required", reason, ...(localFile ? { localFile } : {}) });
+    return;
+  }
+  process.stderr.write(
+    "inplan: couldn't verify your plan for this cloud document (offline, or the service is down).\n" +
+      "  This is not a plan limit — retry in a moment.\n" +
+      (localFile ? `  To work offline meanwhile: \`inplan demote ${localFile}\`.\n` : ""),
+  );
+  output({ status: "plugin_unavailable", reason, ...(localFile ? { localFile } : {}) });
+}
+
 /**
  * Drive a *cloud* document as the logged-in agent. There is no local editor to
  * spawn (a cloud doc opens in the browser), so `open`/`wait` both attach + wait
@@ -616,6 +660,10 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
     process.stderr.write("inplan: not logged in (or session expired) — run `inplan login`\n");
     process.exit(1);
   }
+
+  // Cloud docs are the one place an out-of-date CLI fails *silently* — it attaches and looks fine
+  // while missing the code path the document needs. Warn early, cached, and never block the turn.
+  await warnIfOutdated(UPDATE_PKG, VERSION, stalenessCache());
 
   if (cmd === "signal") {
     if (hasFlag(rest, "done")) {
@@ -679,12 +727,21 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
     // Live collaboration (paid perk): if the user is entitled, load the signature-verified collab
     // plugin and drive the agent's edits through the Yjs hub instead of a blind store overwrite. The
     // agent's working surface is a local `.md` materialized from the hub's canonical on first attach
-    // (kept across turns so its edits survive); edits sync back via the gate. Not entitled /
-    // unverified / no plugin ⇒ null ⇒ the turn-based store path below.
+    // (kept across turns so its edits survive); edits sync back via the gate.
     const hubUrl = resolveHubUrl();
     const hubSession = JSON.stringify({ url: hubUrl, docName: docId, token: backend.token });
-    const gate = await loadPluginGate(hubSession, { token: backend.token });
-    if (gate) {
+    const { gate, reason } = await loadPluginGateOutcome(hubSession, { token: backend.token });
+    // No gate ⇒ STOP. The turn-based `live.store` path below exists for the managed cloud agent,
+    // which holds the body in memory; an out-of-process local agent needs a file, and the gate is
+    // what materializes one. Falling through would attach, consume the human's turns, and silently
+    // never be able to read or edit the document — so say why and exit non-zero instead.
+    if (!gate) {
+      explainNoGate(reason, localFile);
+      process.exit(reason === "unentitled" ? EXIT_UPGRADE_REQUIRED : EXIT_PLUGIN_UNAVAILABLE);
+    }
+    // Scope block for the gate path's locals. It falls through to the turn-based `waitCycle` below
+    // only when the hub turns out to be unreachable mid-run (`onGate === false`).
+    {
       const workFile = join(sidecarRoot(), "remote", `${docId}.plan.md`);
       const pendingPath = `${workFile}.pending`; // marker: a local fallback edit awaits a hub push
       const hashPath = `${workFile}.synced`; // hash of the working copy at our last write/sync

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -37,7 +37,7 @@ import { evaluateAgentEdit } from "./gate";
 import { addComment, AddCommentError } from "./commentAdd";
 import { docPaths, sidecarRoot, type DocPaths } from "./paths";
 import { loadPluginGate, loadPluginGateOutcome, resolveHubUrl, type PluginAbsenceReason, type PluginGate } from "./pluginGate";
-import { shouldHydrateWorkFile, pendingRequiresReplay, trackGateDegradations } from "./liveSync";
+import { shouldHydrateWorkFile, pendingRequiresReplay, postTurnAction, trackGateDegradations, type WaitOutcome } from "./liveSync";
 import { announcePresence } from "./presence";
 import { wakePredicate, waitForActions } from "./wait";
 import { versionFromModule } from "./version";
@@ -362,11 +362,6 @@ function logWaitExit(p: DocPaths, reason: string): void {
  * cursor, else "start from now" (current max). It is persisted on return so the
  * agent never hand-manages it and turns can't be skipped.
  */
-/** What a wait cycle did. `exiting` means it SCHEDULED a fail-fast exit (confirm_required /
- *  integrity_error) that will fire from an async stdout flush — callers must stop immediately rather
- *  than run their post-cycle work in the race window. */
-type WaitOutcome = "ok" | "exiting";
-
 async function waitCycle(backend: WaitBackend, explicitCursor: number | null, confirmed: Set<string>, model?: string, gate: PluginGate | null = null): Promise<WaitOutcome> {
   const { channel, store } = backend;
   const history = await backend.history();
@@ -846,15 +841,10 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
       tracked.gate, // …and accepted edits apply through the hub, not the store.
     );
 
-    // A fail-fast turn (confirm_required / integrity_error) has SCHEDULED its exit, which fires from
-    // an async stdout flush rather than immediately. Stop here: the re-sync below rewrites the
-    // working copy from the hub canonical, and running it for a turn that just reported failure would
-    // race the exit and nondeterministically discard the very edit the agent was told to fix.
-    // (A bare `process.exit` used to make this unreachable; making the exit flush-safe made it
-    // reachable, so the stop has to be explicit.)
-    if (outcome === "exiting") return;
+    const action = postTurnAction(outcome, { readFailed: tracked.readFailed(), writeFailed: tracked.writeFailed() });
+    if (action === "stop") return; // a fail-fast exit is pending — never touch the working copy
 
-    if (tracked.readFailed() || tracked.writeFailed()) {
+    if (action === "keep-local") {
       // The hub dropped mid-turn; DO NOT re-sync (that would overwrite a local edit with stale hub
       // canonical). Mark `.pending` ONLY when a WRITE failed — that's the case with a local
       // revision persisted off-hub that must be replayed. A read-only failure leaves the working

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -661,9 +661,6 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
     process.exit(1);
   }
 
-  // Cloud docs are the one place an out-of-date CLI fails *silently* — it attaches and looks fine
-  // while missing the code path the document needs. Warn early, cached, and never block the turn.
-  await warnIfOutdated(UPDATE_PKG, VERSION, stalenessCache());
 
   if (cmd === "signal") {
     if (hasFlag(rest, "done")) {
@@ -698,6 +695,13 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
     output({ status: "messaged" });
     return;
   }
+
+  // Cloud docs are the one place an out-of-date CLI fails *silently* — it attaches and looks fine
+  // while missing the code path the document needs. Deliberately BELOW the `signal`/`message` early
+  // returns: those run once per turn and must stay snappy, and a registry lookup only writes its
+  // cache on success — so on a degraded network every short op would re-pay the full timeout. Only
+  // the attaching path, which is the one that can silently misbehave, is worth the check.
+  await warnIfOutdated(UPDATE_PKG, VERSION, stalenessCache());
 
   // A `wait` can block for longer than the ~1h access-token lifetime (the human idles before taking
   // their turn). Poll through a self-refreshing backend so the token is re-minted — via the

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -705,172 +705,145 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
   // instead of silently 401ing mid-wait. Short ops above (signal/message) used the one-shot `backend`.
   const live = liveRemoteBackend(docId, "cli-agent");
 
-  // Save-locally handoff (only when following a promoted local file): download the
-  // live body to its original path, flip the status back to local, reopen the local
-  // editor, and report — the inverse of "Collaborate on Cloud". Reads through `live` since the
-  // handoff can fire after a long wait (the initial token may have expired by then).
-  const onSaveLocally = localFile
-    ? async () => {
-        const body = await live.store.loadDoc();
-        writeFileSync(localFile, body);
-        writeStatus(docPaths(localFile).statusPath, { location: "local", originalPath: localFile, lastSyncedHash: hashBody(body) });
-        const pid = spawnApp(localFile); // reopen the doc in the local editor
-        output({ status: "moved_local", path: localFile, reopened: pid !== null });
-      }
-    : undefined;
+  // Live collaboration (paid perk): if the user is entitled, load the signature-verified collab
+  // plugin and drive the agent's edits through the Yjs hub instead of a blind store overwrite. The
+  // agent's working surface is a local `.md` materialized from the hub's canonical on first attach
+  // (kept across turns so its edits survive); edits sync back via the gate.
+  //
+  // Resolved BEFORE announcing presence: an agent that is about to exit must never light up the
+  // web's "agent · your machine" badge, and `process.exit` below would skip any `finally` teardown.
+  const hubUrl = resolveHubUrl();
+  const hubSession = JSON.stringify({ url: hubUrl, docName: docId, token: backend.token });
+  const { gate, reason } = await loadPluginGateOutcome(hubSession, { token: backend.token });
+  // No gate ⇒ STOP. The turn-based `live.store` path exists for the managed cloud agent, which holds
+  // the body in memory; an out-of-process local agent needs a file, and the gate is what materializes
+  // one. Falling through would attach, consume the human's turns, and silently never be able to read
+  // or edit the document — so say why and exit non-zero instead.
+  if (!gate) {
+    explainNoGate(reason, localFile);
+    process.exit(reason === "unentitled" ? EXIT_UPGRADE_REQUIRED : EXIT_PLUGIN_UNAVAILABLE);
+  }
 
-  // the web badge shows "agent · your machine"; clear it on exit (wraps both wait paths below).
+  // the web badge shows "agent · your machine"; clear it on exit.
   // (Presence is a cosmetic websocket on the initial token; the correctness-critical DB polling
   // rides `live` above and stays authenticated across the whole wait, even past the ~1h expiry.)
   const presence = announcePresence(docId, backend.token, model);
   try {
-    // Live collaboration (paid perk): if the user is entitled, load the signature-verified collab
-    // plugin and drive the agent's edits through the Yjs hub instead of a blind store overwrite. The
-    // agent's working surface is a local `.md` materialized from the hub's canonical on first attach
-    // (kept across turns so its edits survive); edits sync back via the gate.
-    const hubUrl = resolveHubUrl();
-    const hubSession = JSON.stringify({ url: hubUrl, docName: docId, token: backend.token });
-    const { gate, reason } = await loadPluginGateOutcome(hubSession, { token: backend.token });
-    // No gate ⇒ STOP. The turn-based `live.store` path below exists for the managed cloud agent,
-    // which holds the body in memory; an out-of-process local agent needs a file, and the gate is
-    // what materializes one. Falling through would attach, consume the human's turns, and silently
-    // never be able to read or edit the document — so say why and exit non-zero instead.
-    if (!gate) {
-      explainNoGate(reason, localFile);
-      process.exit(reason === "unentitled" ? EXIT_UPGRADE_REQUIRED : EXIT_PLUGIN_UNAVAILABLE);
+    const workFile = join(sidecarRoot(), "remote", `${docId}.plan.md`);
+    const pendingPath = `${workFile}.pending`; // marker: a local fallback edit awaits a hub push
+    const hashPath = `${workFile}.synced`; // hash of the working copy at our last write/sync
+    mkdirSync(dirname(workFile), { recursive: true });
+    const readIf = (p: string): string | null => (existsSync(p) ? readFileSync(p, "utf8") : null);
+    const recordSynced = (content: string) => writeFileSync(hashPath, hashBody(content));
+
+    // Probe the hub on EVERY run. A failure here means we cannot materialize the working copy, so
+    // there is nothing for an out-of-process agent to read or edit — the same dead end the
+    // missing-gate branch above rejects, reached one step later. Falling back to the turn-based
+    // `live.store` path would just reinstate it silently, so stop and say so instead.
+    let canonical = "";
+    try {
+      canonical = await gate.readCanonical();
+    } catch (e) {
+      process.stderr.write(`inplan: live-collab hub unreachable (${String(e)})\n`);
+      presence.destroy(); // `process.exit` skips the `finally` below
+      explainNoGate("unavailable", localFile);
+      process.exit(EXIT_PLUGIN_UNAVAILABLE);
     }
-    // Scope block for the gate path's locals. It falls through to the turn-based `waitCycle` below
-    // only when the hub turns out to be unreachable mid-run (`onGate === false`).
-    {
-      const workFile = join(sidecarRoot(), "remote", `${docId}.plan.md`);
-      const pendingPath = `${workFile}.pending`; // marker: a local fallback edit awaits a hub push
-      const hashPath = `${workFile}.synced`; // hash of the working copy at our last write/sync
-      mkdirSync(dirname(workFile), { recursive: true });
-      const readIf = (p: string): string | null => (existsSync(p) ? readFileSync(p, "utf8") : null);
-      const recordSynced = (content: string) => writeFileSync(hashPath, hashBody(content));
-
-      // Probe the hub on EVERY run: if unreachable now, fall through to the turn-based `live.store`
-      // path (the documented fallback) rather than staying on the local-only gateStore and stranding
-      // cloud edits in the working copy.
-      let onGate = true;
-      let canonical = "";
-      try {
-        canonical = await gate.readCanonical();
-      } catch (e) {
-        process.stderr.write(`inplan: live-collab hub unreachable (${String(e)}); using turn-based sync\n`);
-        onGate = false;
-      }
-      if (onGate) {
-        // Decide whether to (re)hydrate the working copy from the freshly probed canonical. Seed if
-        // absent; keep it if a local fallback edit is pending (must push first); otherwise refresh it
-        // ONLY when the agent hasn't touched it since our last sync (hash match) — so we pull the
-        // human's edits without clobbering unsynced agent edits. This is also what lets a FAILED
-        // end-of-turn re-sync self-heal on the next run.
-        const exists = existsSync(workFile);
-        if (
-          shouldHydrateWorkFile({
-            exists,
-            pending: existsSync(pendingPath),
-            currentHash: exists ? hashBody(readFileSync(workFile, "utf8")) : null,
-            syncedHash: readIf(hashPath),
-          })
-        ) {
-          writeFileSync(workFile, canonical);
-          recordSynced(canonical);
-        }
-
-        // Working doc stays on the local file, but Review-mode PROPOSALS persist to the CLOUD doc's
-        // proposal store (via live.store) — otherwise a parked proposal would sit in this machine's
-        // sidecar, invisible to the human in the web editor who's meant to accept/reject it.
-        const localStore = fsBackend(workFile).store;
-        const gateStore: DocumentStore = {
-          loadDoc: () => localStore.loadDoc(),
-          saveDoc: (c) => localStore.saveDoc(c),
-          getCanonical: () => localStore.getCanonical(),
-          setCanonical: (c) => localStore.setCanonical(c),
-          backup: (c, m) => localStore.backup(c, m),
-          getProposed: () => live.store.getProposed(),
-          setProposed: (c) => live.store.setProposed(c),
-          clearProposed: () => live.store.clearProposed(),
-        };
-        // Save-local handoff on the gate path reads the HUB canonical (the source of truth here);
-        // live.store isn't updated by gate.applyRevision, so reading it would write a stale doc. If
-        // the hub read fails we throw BEFORE writing status, so the doc isn't switched to local.
-        const onSaveLocallyGate = localFile
-          ? async () => {
-              const body = await gate.readCanonical();
-              writeFileSync(localFile, body);
-              writeStatus(docPaths(localFile).statusPath, { location: "local", originalPath: localFile, lastSyncedHash: hashBody(body) });
-              const pid = spawnApp(localFile);
-              output({ status: "moved_local", path: localFile, reopened: pid !== null });
-            }
-          : undefined;
-
-        // Guard BOTH hub directions so any drop degrades gracefully instead of crashing the turn,
-        // tracking read and write failures separately (see trackGateDegradations): a read failure
-        // re-throws (waitCycle falls back to the local store); a write failure persists the edit
-        // locally and doesn't re-throw (the turn still emits a status). Any failure skips the
-        // end-of-turn re-sync; only a WRITE marks `.pending` — a read-only failure must not, or the
-        // next healthy run would skip hydration and risk reverting newer hub edits.
-        const tracked = trackGateDegradations(gate, localStore, (m) =>
-          process.stderr.write(`inplan: live-collab hub write failed (${m}); kept the edit locally to retry\n`),
-        );
-        process.stderr.write(`inplan: live-collab — plan at ${workFile}; read/edit it there, then re-run to sync\n`);
-        await waitCycle(
-          {
-            channel: live.channel, // turns/comments still ride the cloud control log (self-refreshing)…
-            store: gateStore, // …the agent reads/edits a local working copy; proposals go to the cloud…
-            history: async () => (await live.channel.readSince(0)).entries,
-            logExit: () => {},
-            ...(onSaveLocallyGate ? { onSaveLocally: onSaveLocallyGate } : {}),
-          },
-          explicitCursor,
-          confirmed,
-          model,
-          tracked.gate, // …and accepted edits apply through the hub, not the store.
-        );
-
-        if (tracked.readFailed() || tracked.writeFailed()) {
-          // The hub dropped mid-turn; DO NOT re-sync (that would overwrite a local edit with stale hub
-          // canonical). Mark `.pending` ONLY when a WRITE failed — that's the case with a local
-          // revision persisted off-hub that must be replayed. A read-only failure leaves the working
-          // copy either unchanged (clean) or hash-diverged (agent edited); both are handled by the
-          // start-of-turn hydration check, and a spurious `.pending` would wrongly skip it next run.
-          if (pendingRequiresReplay({ readFailed: tracked.readFailed(), writeFailed: tracked.writeFailed() })) {
-            writeFileSync(pendingPath, "1");
-          }
-          process.stderr.write("inplan: hub was unavailable this turn — keeping local edits (will sync next turn)\n");
-        } else {
-          // Turn applied to the hub. The working copy is now consistent with the hub for the agent's
-          // part, so record its hash (this makes a FAILED re-sync below self-heal: next run sees a
-          // matching hash and safely hydrates). Then re-sync the copy to the latest canonical (folding
-          // in the human's just-taken turn) so the agent's NEXT turn builds on it, and clear pending.
-          if (existsSync(pendingPath)) rmSync(pendingPath);
-          recordSynced(readFileSync(workFile, "utf8"));
-          try {
-            const fresh = await gate.readCanonical();
-            writeFileSync(workFile, fresh);
-            recordSynced(fresh);
-          } catch {
-            /* transient: leave the copy (its hash still matches) so the next run hydrates it */
-          }
-        }
-        return;
-      }
+    // Decide whether to (re)hydrate the working copy from the freshly probed canonical. Seed if
+    // absent; keep it if a local fallback edit is pending (must push first); otherwise refresh it
+    // ONLY when the agent hasn't touched it since our last sync (hash match) — so we pull the
+    // human's edits without clobbering unsynced agent edits. This is also what lets a FAILED
+    // end-of-turn re-sync self-heal on the next run.
+    const exists = existsSync(workFile);
+    if (
+      shouldHydrateWorkFile({
+        exists,
+        pending: existsSync(pendingPath),
+        currentHash: exists ? hashBody(readFileSync(workFile, "utf8")) : null,
+        syncedHash: readIf(hashPath),
+      })
+    ) {
+      writeFileSync(workFile, canonical);
+      recordSynced(canonical);
     }
 
+    // Working doc stays on the local file, but Review-mode PROPOSALS persist to the CLOUD doc's
+    // proposal store (via live.store) — otherwise a parked proposal would sit in this machine's
+    // sidecar, invisible to the human in the web editor who's meant to accept/reject it.
+    const localStore = fsBackend(workFile).store;
+    const gateStore: DocumentStore = {
+      loadDoc: () => localStore.loadDoc(),
+      saveDoc: (c) => localStore.saveDoc(c),
+      getCanonical: () => localStore.getCanonical(),
+      setCanonical: (c) => localStore.setCanonical(c),
+      backup: (c, m) => localStore.backup(c, m),
+      getProposed: () => live.store.getProposed(),
+      setProposed: (c) => live.store.setProposed(c),
+      clearProposed: () => live.store.clearProposed(),
+    };
+    // Save-local handoff on the gate path reads the HUB canonical (the source of truth here);
+    // live.store isn't updated by gate.applyRevision, so reading it would write a stale doc. If
+    // the hub read fails we throw BEFORE writing status, so the doc isn't switched to local.
+    const onSaveLocallyGate = localFile
+      ? async () => {
+          const body = await gate.readCanonical();
+          writeFileSync(localFile, body);
+          writeStatus(docPaths(localFile).statusPath, { location: "local", originalPath: localFile, lastSyncedHash: hashBody(body) });
+          const pid = spawnApp(localFile);
+          output({ status: "moved_local", path: localFile, reopened: pid !== null });
+        }
+      : undefined;
+
+    // Guard BOTH hub directions so any drop degrades gracefully instead of crashing the turn,
+    // tracking read and write failures separately (see trackGateDegradations): a read failure
+    // re-throws (waitCycle falls back to the local store); a write failure persists the edit
+    // locally and doesn't re-throw (the turn still emits a status). Any failure skips the
+    // end-of-turn re-sync; only a WRITE marks `.pending` — a read-only failure must not, or the
+    // next healthy run would skip hydration and risk reverting newer hub edits.
+    const tracked = trackGateDegradations(gate, localStore, (m) =>
+      process.stderr.write(`inplan: live-collab hub write failed (${m}); kept the edit locally to retry\n`),
+    );
+    process.stderr.write(`inplan: live-collab — plan at ${workFile}; read/edit it there, then re-run to sync\n`);
     await waitCycle(
       {
-        channel: live.channel,
-        store: live.store,
+        channel: live.channel, // turns/comments still ride the cloud control log (self-refreshing)…
+        store: gateStore, // …the agent reads/edits a local working copy; proposals go to the cloud…
         history: async () => (await live.channel.readSince(0)).entries,
-        logExit: () => {}, // no local sidecar for a cloud doc
-        ...(onSaveLocally ? { onSaveLocally } : {}),
+        logExit: () => {},
+        ...(onSaveLocallyGate ? { onSaveLocally: onSaveLocallyGate } : {}),
       },
       explicitCursor,
       confirmed,
       model,
+      tracked.gate, // …and accepted edits apply through the hub, not the store.
     );
+
+    if (tracked.readFailed() || tracked.writeFailed()) {
+      // The hub dropped mid-turn; DO NOT re-sync (that would overwrite a local edit with stale hub
+      // canonical). Mark `.pending` ONLY when a WRITE failed — that's the case with a local
+      // revision persisted off-hub that must be replayed. A read-only failure leaves the working
+      // copy either unchanged (clean) or hash-diverged (agent edited); both are handled by the
+      // start-of-turn hydration check, and a spurious `.pending` would wrongly skip it next run.
+      if (pendingRequiresReplay({ readFailed: tracked.readFailed(), writeFailed: tracked.writeFailed() })) {
+        writeFileSync(pendingPath, "1");
+      }
+      process.stderr.write("inplan: hub was unavailable this turn — keeping local edits (will sync next turn)\n");
+    } else {
+      // Turn applied to the hub. The working copy is now consistent with the hub for the agent's
+      // part, so record its hash (this makes a FAILED re-sync below self-heal: next run sees a
+      // matching hash and safely hydrates). Then re-sync the copy to the latest canonical (folding
+      // in the human's just-taken turn) so the agent's NEXT turn builds on it, and clear pending.
+      if (existsSync(pendingPath)) rmSync(pendingPath);
+      recordSynced(readFileSync(workFile, "utf8"));
+      try {
+        const fresh = await gate.readCanonical();
+        writeFileSync(workFile, fresh);
+        recordSynced(fresh);
+      } catch {
+        /* transient: leave the copy (its hash still matches) so the next run hydrates it */
+      }
+    }
+    return;
   } finally {
     presence.destroy();
   }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -37,7 +37,7 @@ import { evaluateAgentEdit } from "./gate";
 import { addComment, AddCommentError } from "./commentAdd";
 import { docPaths, sidecarRoot, type DocPaths } from "./paths";
 import { loadPluginGate, loadPluginGateOutcome, resolveHubUrl, type PluginAbsenceReason, type PluginGate } from "./pluginGate";
-import { shouldHydrateWorkFile, pendingRequiresReplay, postTurnAction, trackGateDegradations, type WaitOutcome } from "./liveSync";
+import { demoteSource, shouldHydrateWorkFile, pendingRequiresReplay, postTurnAction, trackGateDegradations, type WaitOutcome } from "./liveSync";
 import { announcePresence } from "./presence";
 import { wakePredicate, waitForActions } from "./wait";
 import { versionFromModule } from "./version";
@@ -61,10 +61,19 @@ function output(obj: unknown): void {
  * machine-readable status these coded exits exist to carry. Stream writes are ordered, so this
  * zero-length write's callback runs only once everything queued before it has been flushed.
  *
+ * BOTH streams are drained. stderr is buffered when piped too, so draining stdout alone could still
+ * drop the human-facing explanation — on the deny paths that message is the *only* thing telling
+ * someone how to fix their situation.
+ *
  * Callers MUST `return` straight after: this SCHEDULES the exit, it does not perform it.
  */
-export function exitAfterFlush(code: number, out: Pick<NodeJS.WriteStream, "write"> = process.stdout, exit: (c: number) => void = process.exit): void {
-  out.write("", () => exit(code));
+export function exitAfterFlush(
+  code: number,
+  out: Pick<NodeJS.WriteStream, "write"> = process.stdout,
+  exit: (c: number) => void = process.exit,
+  err: Pick<NodeJS.WriteStream, "write"> = process.stderr,
+): void {
+  out.write("", () => err.write("", () => exit(code)));
 }
 
 function getFlag(args: string[], name: string): string | undefined {
@@ -937,21 +946,29 @@ async function doDemote(file: string, args: string[]): Promise<void> {
   }
   const hubSession = JSON.stringify({ url: resolveHubUrl(), docName: st.cloudDocId, token: backend.token });
   const { gate } = await loadPluginGateOutcome(hubSession, { token: backend.token });
-  let body: string;
-  let source: "hub" | "store" = "hub";
+  let hubBody: string | null = null;
   try {
-    if (!gate) throw new Error("no gate");
-    body = await gate.readCanonical();
+    if (gate) hubBody = await gate.readCanonical();
   } catch {
-    // Fall back rather than fail: a free plan never had hub writes of its own, so the store IS its
-    // document. Say so in the result, because for a doc that WAS on the hub this copy can lag.
-    body = await backend.store.loadDoc();
-    source = "store";
+    hubBody = null; // hub unreachable — we cannot verify what the store copy is missing
   }
   const dest = st.originalPath ?? file;
+  const choice = demoteSource({ hubReadable: hubBody !== null, fromStore: hasFlag(args, "from-store") });
+  if (choice.use === "abort") {
+    process.stderr.write(
+      "inplan demote: couldn't read the live document from the collab hub.\n" +
+        `  The server copy may be missing edits made through the hub, and demoting overwrites ${shellQuote(dest)}\n` +
+        "  and switches the document to local — together, that can't be undone.\n" +
+        "  Retry when the hub is reachable, or re-run with --from-store to accept the server copy as-is.\n",
+    );
+    output({ status: "demote_blocked", reason: choice.reason, path: dest });
+    exitAfterFlush(EXIT_PLUGIN_UNAVAILABLE);
+    return;
+  }
+  const body = choice.use === "hub" ? hubBody! : await backend.store.loadDoc();
   writeFileSync(dest, body);
   writeStatus(p.statusPath, { location: "local", originalPath: dest, lastSyncedHash: hashBody(body) });
-  output({ status: "demoted", location: "local", path: dest, source });
+  output({ status: "demoted", location: "local", path: dest, source: choice.use });
 }
 
 /** First Markdown H1 in the body, for a cloud doc's title (falls back to the filename). */
@@ -1720,7 +1737,7 @@ async function main(): Promise<void> {
         "       inplan status  <file>\n" +
         "       inplan upload  <file> [--org <slug>] [--repo <name>] [--path <p>] [--evict-lru]   (Collaborate on Cloud)\n" +
         "       inplan promote <file> --cloud-doc <docId> [--locator org/repo/path]\n" +
-        "       inplan demote  <file>\n" +
+        "       inplan demote  <file> [--from-store]   (bring a cloud doc back to disk; --from-store accepts the server copy when the hub is unreadable)\n" +
         "       inplan login   (opens the browser to sign in; or --url <url> --anon <key> --refresh <token> for scripts)\n" +
         "       inplan whoami | logout\n",
     );

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -362,7 +362,12 @@ function logWaitExit(p: DocPaths, reason: string): void {
  * cursor, else "start from now" (current max). It is persisted on return so the
  * agent never hand-manages it and turns can't be skipped.
  */
-async function waitCycle(backend: WaitBackend, explicitCursor: number | null, confirmed: Set<string>, model?: string, gate: PluginGate | null = null): Promise<void> {
+/** What a wait cycle did. `exiting` means it SCHEDULED a fail-fast exit (confirm_required /
+ *  integrity_error) that will fire from an async stdout flush — callers must stop immediately rather
+ *  than run their post-cycle work in the race window. */
+type WaitOutcome = "ok" | "exiting";
+
+async function waitCycle(backend: WaitBackend, explicitCursor: number | null, confirmed: Set<string>, model?: string, gate: PluginGate | null = null): Promise<WaitOutcome> {
   const { channel, store } = backend;
   const history = await backend.history();
 
@@ -403,12 +408,12 @@ async function waitCycle(backend: WaitBackend, explicitCursor: number | null, co
       lost: ev.unconfirmed.map((c) => ({ id: c.id, text: c.text, author: c.author })),
     });
     exitAfterFlush(3);
-    return;
+    return "exiting";
   }
   if (!ev.integrityOk) {
     output({ status: "integrity_error", errors: ev.integrityErrors });
     exitAfterFlush(2);
-    return;
+    return "exiting";
   }
   // In Review mode an agent **body** change is quarantined as a proposal rather
   // than applied: the working file + canonical stay put, the agent's version is
@@ -449,7 +454,7 @@ async function waitCycle(backend: WaitBackend, explicitCursor: number | null, co
   if (result.superseded) {
     backend.logExit("superseded");
     output({ status: "superseded" });
-    return;
+    return "ok";
   }
 
   // Cloud→local handoff: a human on the web asked us to bring the doc back to disk.
@@ -461,7 +466,7 @@ async function waitCycle(backend: WaitBackend, explicitCursor: number | null, co
   if (backend.onSaveLocally && result.entries.some((e) => e.type === LogEventType.SaveLocallyRequested)) {
     backend.logExit("save_locally");
     await backend.onSaveLocally();
-    return;
+    return "ok";
   }
 
   await channel.setCursor(result.cursor); // advance the persisted cursor so the next call continues here
@@ -474,7 +479,7 @@ async function waitCycle(backend: WaitBackend, explicitCursor: number | null, co
     const path = (navEntry.payload as { path?: string } | undefined)?.path;
     backend.logExit("navigated");
     output({ status: "navigated", ...(path ? { path } : {}), cursor: result.cursor, closed: false });
-    return;
+    return "ok";
   }
 
   // The editor logs WHY it closed (completed / window_closed); a crash logs nothing.
@@ -514,6 +519,7 @@ async function waitCycle(backend: WaitBackend, explicitCursor: number | null, co
     closed: status === "closed",
     entries: result.entries,
   });
+  return "ok";
 }
 
 /**
@@ -826,7 +832,7 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
       process.stderr.write(`inplan: live-collab hub write failed (${m}); kept the edit locally to retry\n`),
     );
     process.stderr.write(`inplan: live-collab — plan at ${workFile}; read/edit it there, then re-run to sync\n`);
-    await waitCycle(
+    const outcome = await waitCycle(
       {
         channel: live.channel, // turns/comments still ride the cloud control log (self-refreshing)…
         store: gateStore, // …the agent reads/edits a local working copy; proposals go to the cloud…
@@ -839,6 +845,14 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
       model,
       tracked.gate, // …and accepted edits apply through the hub, not the store.
     );
+
+    // A fail-fast turn (confirm_required / integrity_error) has SCHEDULED its exit, which fires from
+    // an async stdout flush rather than immediately. Stop here: the re-sync below rewrites the
+    // working copy from the hub canonical, and running it for a turn that just reported failure would
+    // race the exit and nondeterministically discard the very edit the agent was told to fix.
+    // (A bare `process.exit` used to make this unreachable; making the exit flush-safe made it
+    // reachable, so the stop has to be explicit.)
+    if (outcome === "exiting") return;
 
     if (tracked.readFailed() || tracked.writeFailed()) {
       // The hub dropped mid-turn; DO NOT re-sync (that would overwrite a local edit with stale hub

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -639,12 +639,20 @@ export const EXIT_PLUGIN_UNAVAILABLE = 5;
  * because a server hiccuped is the worst outcome here, which is why the reason is only ever
  * `unentitled` on an explicit server denial (see {@link resolvePluginOutcome}).
  */
+/** POSIX single-quoting for a path we print inside a copy-pasteable command. An unquoted path with a
+ *  space produces a command that silently targets the wrong file, and one containing `$(…)`, backticks
+ *  or `;` would execute on paste. Single quotes suppress every expansion; the only character needing
+ *  care is `'` itself, closed and re-opened around an escaped one. */
+export function shellQuote(path: string): string {
+  return "'" + path.replaceAll("'", "'\\''") + "'";
+}
+
 export function explainNoGate(reason: PluginAbsenceReason, localFile?: string): void {
   if (reason === "unentitled") {
     process.stderr.write(
       "inplan: this plan doesn't include the local agent on cloud documents.\n" +
         "  Open the document in your browser and click the agent indicator to upgrade.\n" +
-        (localFile ? `  Or keep working offline for free: \`inplan demote ${localFile}\` brings it back to disk.\n` : ""),
+        (localFile ? `  Or keep working offline for free: \`inplan demote ${shellQuote(localFile)}\` brings it back to disk.\n` : ""),
     );
     output({ status: "upgrade_required", reason, ...(localFile ? { localFile } : {}) });
     return;
@@ -652,7 +660,7 @@ export function explainNoGate(reason: PluginAbsenceReason, localFile?: string): 
   process.stderr.write(
     "inplan: couldn't verify your plan for this cloud document (offline, or the service is down).\n" +
       "  This is not a plan limit — retry in a moment.\n" +
-      (localFile ? `  To work offline meanwhile: \`inplan demote ${localFile}\`.\n` : ""),
+      (localFile ? `  To work offline meanwhile: \`inplan demote ${shellQuote(localFile)}\`.\n` : ""),
   );
   output({ status: "plugin_unavailable", reason, ...(localFile ? { localFile } : {}) });
 }
@@ -907,6 +915,13 @@ function doPromote(file: string, args: string[]): void {
  * Bring a cloud doc back to disk — the CLI side of "Save locally" / "Download":
  * download the live body to its original path and flip the status to local, so
  * subsequent `open`/`wait` runs the file locally again.
+ *
+ * Reads the HUB canonical whenever a gate is available, exactly as `onSaveLocallyGate` does and for
+ * the same reason: `live.store` is NOT updated by `gate.applyRevision`, so on a doc a local agent has
+ * been editing through the hub it holds a stale body. Demoting from it would overwrite the original
+ * file with pre-hub content — silently losing every edit made since, which is the one thing a
+ * "bring it back to disk" command must never do. No gate (free plan, or the hub is down) ⇒ the store
+ * is the best source there is, and the caller is told what it got.
  */
 async function doDemote(file: string, args: string[]): Promise<void> {
   const p = docPaths(file);
@@ -920,11 +935,23 @@ async function doDemote(file: string, args: string[]): Promise<void> {
     process.stderr.write("inplan: not logged in (or session expired) — run `inplan login`\n");
     process.exit(1);
   }
-  const body = await backend.store.loadDoc();
+  const hubSession = JSON.stringify({ url: resolveHubUrl(), docName: st.cloudDocId, token: backend.token });
+  const { gate } = await loadPluginGateOutcome(hubSession, { token: backend.token });
+  let body: string;
+  let source: "hub" | "store" = "hub";
+  try {
+    if (!gate) throw new Error("no gate");
+    body = await gate.readCanonical();
+  } catch {
+    // Fall back rather than fail: a free plan never had hub writes of its own, so the store IS its
+    // document. Say so in the result, because for a doc that WAS on the hub this copy can lag.
+    body = await backend.store.loadDoc();
+    source = "store";
+  }
   const dest = st.originalPath ?? file;
   writeFileSync(dest, body);
   writeStatus(p.statusPath, { location: "local", originalPath: dest, lastSyncedHash: hashBody(body) });
-  output({ status: "demoted", location: "local", path: dest });
+  output({ status: "demoted", location: "local", path: dest, source });
 }
 
 /** First Markdown H1 in the body, for a cloud doc's title (falls back to the filename). */

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -52,6 +52,21 @@ function output(obj: unknown): void {
   process.stdout.write(JSON.stringify(obj) + "\n");
 }
 
+/**
+ * Schedule an exit that waits for stdout to drain.
+ *
+ * Node's stdout is ASYNCHRONOUS when piped — the normal case, since the CLI runs as a coding agent's
+ * subprocess — and `process.exit()` discards whatever is still buffered. An `output(...)` immediately
+ * followed by `process.exit(n)` therefore delivers the exit code with no payload: exactly the
+ * machine-readable status these coded exits exist to carry. Stream writes are ordered, so this
+ * zero-length write's callback runs only once everything queued before it has been flushed.
+ *
+ * Callers MUST `return` straight after: this SCHEDULES the exit, it does not perform it.
+ */
+export function exitAfterFlush(code: number, out: Pick<NodeJS.WriteStream, "write"> = process.stdout, exit: (c: number) => void = process.exit): void {
+  out.write("", () => exit(code));
+}
+
 function getFlag(args: string[], name: string): string | undefined {
   const withEq = args.find((a) => a.startsWith(`--${name}=`));
   if (withEq) return withEq.slice(name.length + 3);
@@ -387,11 +402,13 @@ async function waitCycle(backend: WaitBackend, explicitCursor: number | null, co
       message: "Edit removes anchored comment(s). Re-run wait with --confirmed-comment-deletion=<ids> to proceed.",
       lost: ev.unconfirmed.map((c) => ({ id: c.id, text: c.text, author: c.author })),
     });
-    process.exit(3);
+    exitAfterFlush(3);
+    return;
   }
   if (!ev.integrityOk) {
     output({ status: "integrity_error", errors: ev.integrityErrors });
-    process.exit(2);
+    exitAfterFlush(2);
+    return;
   }
   // In Review mode an agent **body** change is quarantined as a proposal rather
   // than applied: the working file + canonical stay put, the agent's version is
@@ -725,7 +742,8 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
   // or edit the document — so say why and exit non-zero instead.
   if (!gate) {
     explainNoGate(reason, localFile);
-    process.exit(reason === "unentitled" ? EXIT_UPGRADE_REQUIRED : EXIT_PLUGIN_UNAVAILABLE);
+    exitAfterFlush(reason === "unentitled" ? EXIT_UPGRADE_REQUIRED : EXIT_PLUGIN_UNAVAILABLE);
+    return;
   }
 
   // the web badge shows "agent · your machine"; clear it on exit.
@@ -749,9 +767,9 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
       canonical = await gate.readCanonical();
     } catch (e) {
       process.stderr.write(`inplan: live-collab hub unreachable (${String(e)})\n`);
-      presence.destroy(); // `process.exit` skips the `finally` below
       explainNoGate("unavailable", localFile);
-      process.exit(EXIT_PLUGIN_UNAVAILABLE);
+      exitAfterFlush(EXIT_PLUGIN_UNAVAILABLE);
+      return; // the `finally` below tears presence down on the way out
     }
     // Decide whether to (re)hydrate the working copy from the freshly probed canonical. Seed if
     // absent; keep it if a local fallback edit is pending (must push first); otherwise refresh it

--- a/packages/cli/src/liveSync.ts
+++ b/packages/cli/src/liveSync.ts
@@ -97,3 +97,31 @@ export function trackGateDegradations(
     },
   };
 }
+
+/** What a wait cycle did. `exiting` means it SCHEDULED a fail-fast exit (confirm_required /
+ *  integrity_error) that fires from an async stdout flush rather than immediately. */
+export type WaitOutcome = "ok" | "exiting";
+
+/** What the gate path must do with the working copy once a turn ends. */
+export type PostTurnAction =
+  /** Touch nothing — a fail-fast exit is pending. */
+  | "stop"
+  /** The hub dropped mid-turn: keep the local edits and re-sync on a later run. */
+  | "keep-local"
+  /** Healthy turn: pull the fresh canonical so the agent's next turn builds on it. */
+  | "resync";
+
+/**
+ * Decide the post-turn action from the wait's outcome and the hub's health.
+ *
+ * `stop` comes FIRST and unconditionally. A fail-fast turn's exit is only scheduled — it fires from
+ * an async stdout flush — so without this the caller would keep running and pull a fresh hub
+ * canonical over the working copy. On `confirm_required` that copy holds the agent's edit awaiting
+ * the human's confirmation and exists nowhere else, so the pull can destroy exactly what the turn
+ * asked to have fixed. (A bare `process.exit` used to make that unreachable; a flush-safe exit does
+ * not, which is why the stop must be explicit.)
+ */
+export function postTurnAction(outcome: WaitOutcome, degraded: { readFailed: boolean; writeFailed: boolean }): PostTurnAction {
+  if (outcome === "exiting") return "stop";
+  return degraded.readFailed || degraded.writeFailed ? "keep-local" : "resync";
+}

--- a/packages/cli/src/liveSync.ts
+++ b/packages/cli/src/liveSync.ts
@@ -125,3 +125,26 @@ export function postTurnAction(outcome: WaitOutcome, degraded: { readFailed: boo
   if (outcome === "exiting") return "stop";
   return degraded.readFailed || degraded.writeFailed ? "keep-local" : "resync";
 }
+
+/** Where `demote` should take the body it writes over the user's original file. */
+export type DemoteSource =
+  /** The hub canonical — authoritative whenever it can be read. */
+  | { use: "hub" }
+  /** The server copy, explicitly accepted by the user despite being unverifiable. */
+  | { use: "store" }
+  /** Write nothing and keep the doc in the cloud. */
+  | { use: "abort"; reason: "hub_unreadable" };
+
+/**
+ * Choose `demote`'s source, defaulting to refusing rather than guessing.
+ *
+ * `gate.applyRevision` never writes `live.store`, so when the hub can't be read there is no way to
+ * tell a store copy that is current from one missing every edit a local agent made through the hub.
+ * Demotion overwrites the user's original file AND flips the doc to local — irreversible together —
+ * so an unverifiable copy must not complete it silently. The user can still accept that copy with an
+ * explicit opt-in, which is a decision they can make and this code cannot.
+ */
+export function demoteSource({ hubReadable, fromStore }: { hubReadable: boolean; fromStore: boolean }): DemoteSource {
+  if (hubReadable) return { use: "hub" };
+  return fromStore ? { use: "store" } : { use: "abort", reason: "hub_unreadable" };
+}

--- a/packages/cli/src/pluginGate.ts
+++ b/packages/cli/src/pluginGate.ts
@@ -4,14 +4,17 @@
 // session on the doc's status (`status.pluginSession`) AND the user is entitled, the CLI loads the
 // plugin's verified CLI entry and gates the agent through the plugin instead of the `.md` — so an
 // agent edit lands in whatever shared document the plugin manages. Open-core ships only this loader;
-// the plugin code lives in the signature-verified bundle that `resolveDesktopPlugin` fetches +
-// verifies before we `import()` it. Not entitled / unverified / no CLI entry ⇒ null ⇒ the caller
-// stays on the file-backed gate. Open-core never interprets the session string.
+// the plugin code lives in the signature-verified bundle that `resolvePluginOutcome` fetches +
+// verifies before we `import()` it. Not entitled / unverified / no CLI entry ⇒ no gate ⇒ the caller
+// either stays on the file-backed gate (local docs) or explains itself and stops (cloud docs, which
+// have no file to fall back to). Open-core never interprets the session string.
 
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
-import { resolveDesktopPlugin } from "@inplan/core/node";
+import { resolvePluginOutcome, type PluginAbsenceReason } from "@inplan/core/node";
+
+export type { PluginAbsenceReason };
 
 /** Default collab hub websocket URL. */
 export const DEFAULT_HUB_URL = "wss://inplan-collab.fly.dev";
@@ -39,11 +42,11 @@ interface CliEntry {
 
 /** Injectable seams so the wait path is unit-testable without a real signed bundle / live plugin. */
 export interface PluginGateDeps {
-  resolve: typeof resolveDesktopPlugin;
+  resolve: typeof resolvePluginOutcome;
   importCli: (path: string) => Promise<CliEntry>;
 }
 const defaultDeps: PluginGateDeps = {
-  resolve: resolveDesktopPlugin,
+  resolve: resolvePluginOutcome,
   importCli: (p) => import(pathToFileURL(p).href) as Promise<CliEntry>,
 };
 
@@ -55,25 +58,43 @@ export interface LoadPluginGateOptions {
   publicKey?: string;
 }
 
+/** A gate load's outcome: the gate, or why there isn't one — so a caller that must explain itself
+ *  to a human can tell "your plan doesn't include this" from "we couldn't reach the server". */
+export type PluginGateOutcome = { gate: PluginGate; reason: null } | { gate: null; reason: PluginAbsenceReason };
+
 /**
- * Load the entitlement-gated, signature-verified plugin gate for `session`. Returns a
- * {@link PluginGate} when the user is entitled and the verified bundle ships a CLI entry; otherwise
- * null (⇒ file-backed gate). Fail-soft: any verify / fetch / import failure returns null. The
- * plugin owns reachability — its read/apply time out, and the caller falls back to the file.
+ * Load the entitlement-gated, signature-verified plugin gate for `session`, or the reason there
+ * isn't one. Fail-soft: any verify / fetch / import failure yields `unavailable`, and only an
+ * explicit server denial yields `unentitled`. The plugin owns reachability — its read/apply time
+ * out, and the caller falls back to the file.
  */
-export async function loadPluginGate(session: string, options: LoadPluginGateOptions, deps: PluginGateDeps = defaultDeps): Promise<PluginGate | null> {
+export async function loadPluginGateOutcome(session: string, options: LoadPluginGateOptions, deps: PluginGateDeps = defaultDeps): Promise<PluginGateOutcome> {
   try {
-    const bundle = await deps.resolve({
+    const { plugin, reason } = await deps.resolve({
       apiBase: options.apiBase ?? PLUGIN_HTTP,
       token: options.token,
       cacheDir: options.cacheDir ?? defaultCacheDir(),
       ...(options.publicKey ? { publicKey: options.publicKey } : {}),
     });
-    const cliName = bundle?.entries.cli;
-    const cliPath = cliName ? bundle?.files[cliName] : undefined;
-    if (!cliPath) return null; // not entitled / unverified / no CLI entry in the bundle
+    if (!plugin) return { gate: null, reason };
+    const cliName = plugin.entries.cli;
+    const cliPath = cliName ? plugin.files[cliName] : undefined;
+    // Entitled + verified, but the bundle ships no CLI entry: not a plan problem, so `unavailable`.
+    if (!cliPath) return { gate: null, reason: "unavailable" };
     const cli = await deps.importCli(cliPath);
-    return cli.gate(session);
+    return { gate: cli.gate(session), reason: null };
+  } catch {
+    return { gate: null, reason: "unavailable" }; // any failure ⇒ file-backed
+  }
+}
+
+/**
+ * {@link loadPluginGateOutcome} for callers that only need "gate or not" (the local-file wait path,
+ * which silently runs file-backed without the plugin).
+ */
+export async function loadPluginGate(session: string, options: LoadPluginGateOptions, deps: PluginGateDeps = defaultDeps): Promise<PluginGate | null> {
+  try {
+    return (await loadPluginGateOutcome(session, options, deps)).gate;
   } catch {
     return null; // any failure ⇒ file-backed
   }

--- a/packages/cli/src/pluginGate.ts
+++ b/packages/cli/src/pluginGate.ts
@@ -74,7 +74,11 @@ export async function loadPluginGateOutcome(session: string, options: LoadPlugin
       apiBase: options.apiBase ?? PLUGIN_HTTP,
       token: options.token,
       cacheDir: options.cacheDir ?? defaultCacheDir(),
-      ...(options.publicKey ? { publicKey: options.publicKey } : {}),
+      // Forward whenever DEFINED, not whenever truthy: an explicit `""` means "nothing can be
+      // verified" and must reach the resolver, which then refuses without a network call. Dropping
+      // it would silently substitute the baked-in key and verify against something the caller
+      // deliberately disabled.
+      ...(options.publicKey !== undefined ? { publicKey: options.publicKey } : {}),
     });
     if (!plugin) return { gate: null, reason };
     const cliName = plugin.entries.cli;

--- a/packages/cli/src/update.ts
+++ b/packages/cli/src/update.ts
@@ -27,15 +27,23 @@ export function compareVersions(a: string, b: string): number {
   return 0;
 }
 
-/** The latest published version of `pkg`, or null if the registry can't be reached. */
+/** How long the registry gets to answer. Callers await this before doing real work (`wait --remote`
+ *  checks staleness before attaching), so an unbounded `fetch` on a stalled connection would hang the
+ *  command rather than degrade to "no answer". */
+export const REGISTRY_TIMEOUT_MS = 3000;
+
+/** The latest published version of `pkg`, or null if the registry can't be reached in time. */
 export async function latestVersion(pkg: string): Promise<string | null> {
   try {
-    const res = await fetch(`https://registry.npmjs.org/${pkg.replace("/", "%2F")}/latest`, { headers: { accept: "application/json" } });
+    const res = await fetch(`https://registry.npmjs.org/${pkg.replace("/", "%2F")}/latest`, {
+      headers: { accept: "application/json" },
+      signal: AbortSignal.timeout(REGISTRY_TIMEOUT_MS),
+    });
     if (!res.ok) return null;
     const data = (await res.json()) as { version?: string };
     return typeof data.version === "string" ? data.version : null;
   } catch {
-    return null;
+    return null; // unreachable, malformed, or timed out — all "no answer"
   }
 }
 
@@ -89,10 +97,12 @@ export async function warnIfOutdated(pkg: string, current: string, deps: Stalene
     const cached = deps.readCache?.() ?? null;
     if (cached) {
       const { at, latest } = JSON.parse(cached) as { at?: number; latest?: string };
-      // Serve from cache only while fresh AND not from the future (a clock rewind must not pin a
-      // stale verdict for six hours).
-      if (typeof at === "number" && at <= now && now - at < STALENESS_TTL_MS) {
-        return typeof latest === "string" && compareVersions(current, latest) < 0 ? emitOutdated(pkg, current, latest) : null;
+      // Serve from cache only when the record is COMPLETE, fresh, and not from the future. A partial
+      // record (`{"at":…}` with no `latest`) would otherwise pass the freshness check and suppress
+      // the registry refresh for the whole TTL — silence indistinguishable from "you're up to date".
+      // A clock rewind likewise must not pin a stale verdict for six hours.
+      if (typeof at === "number" && typeof latest === "string" && at <= now && now - at < STALENESS_TTL_MS) {
+        return compareVersions(current, latest) < 0 ? emitOutdated(pkg, current, latest) : null;
       }
     }
   } catch {

--- a/packages/cli/src/update.ts
+++ b/packages/cli/src/update.ts
@@ -96,12 +96,15 @@ export async function warnIfOutdated(pkg: string, current: string, deps: Stalene
   try {
     const cached = deps.readCache?.() ?? null;
     if (cached) {
-      const { at, latest } = JSON.parse(cached) as { at?: number; latest?: string };
-      // Serve from cache only when the record is COMPLETE, fresh, and not from the future. A partial
-      // record (`{"at":…}` with no `latest`) would otherwise pass the freshness check and suppress
-      // the registry refresh for the whole TTL — silence indistinguishable from "you're up to date".
-      // A clock rewind likewise must not pin a stale verdict for six hours.
-      if (typeof at === "number" && typeof latest === "string" && at <= now && now - at < STALENESS_TTL_MS) {
+      const { at, latest, pkg: cachedPkg } = JSON.parse(cached) as { at?: number; latest?: string; pkg?: string };
+      // Serve from cache only when the record is COMPLETE, FOR THIS PACKAGE, fresh, and not from the
+      // future. A partial record (`{"at":…}` with no `latest`) would otherwise pass the freshness
+      // check and suppress the registry refresh for the whole TTL — silence indistinguishable from
+      // "you're up to date". The package must match because `INPLAN_PKG` lets a fork or a scoped
+      // build share this cache file: without it, a fork would compare its version against the
+      // official package's, warning falsely or staying silent for six hours. A clock rewind likewise
+      // must not pin a stale verdict.
+      if (typeof at === "number" && typeof latest === "string" && cachedPkg === pkg && at <= now && now - at < STALENESS_TTL_MS) {
         return compareVersions(current, latest) < 0 ? emitOutdated(pkg, current, latest) : null;
       }
     }
@@ -111,7 +114,7 @@ export async function warnIfOutdated(pkg: string, current: string, deps: Stalene
   const latest = await (deps.fetchLatest ?? latestVersion)(pkg);
   if (latest === null) return null; // registry unreachable — say nothing rather than cry wolf
   try {
-    deps.writeCache?.(JSON.stringify({ at: now, latest }));
+    deps.writeCache?.(JSON.stringify({ at: now, latest, pkg }));
   } catch {
     /* cache is an optimisation, not a requirement */
   }

--- a/packages/cli/src/update.ts
+++ b/packages/cli/src/update.ts
@@ -62,3 +62,54 @@ export function selfUpdate(pkg: string): Promise<{ ok: boolean; output: string }
     child.on("close", (code) => resolve({ ok: code === 0, output: output.trim() }));
   });
 }
+
+/** How long a staleness check is cached. `wait --remote` runs once per TURN (the CLI exits between
+ *  turns), so an uncached check would hit the npm registry on every hand-back. */
+export const STALENESS_TTL_MS = 6 * 60 * 60 * 1000;
+
+/** Injectable seams so the staleness warning is testable without a registry or a real clock. */
+export interface StalenessDeps {
+  fetchLatest?: (pkg: string) => Promise<string | null>;
+  now?: () => number;
+  readCache?: () => string | null;
+  writeCache?: (v: string) => void;
+}
+
+/**
+ * Warn (on stderr, never stdout — stdout is the agent's JSON channel) when this CLI is older than
+ * the published version. Best-effort: a registry failure is silence, never an error.
+ *
+ * This exists because an out-of-date CLI talking to a newer cloud is the failure mode with no
+ * symptom — it attaches, behaves plausibly, and silently lacks the code path the document needs.
+ * Returns the message it wrote, or null.
+ */
+export async function warnIfOutdated(pkg: string, current: string, deps: StalenessDeps = {}): Promise<string | null> {
+  const now = (deps.now ?? Date.now)();
+  try {
+    const cached = deps.readCache?.() ?? null;
+    if (cached) {
+      const { at, latest } = JSON.parse(cached) as { at?: number; latest?: string };
+      // Serve from cache only while fresh AND not from the future (a clock rewind must not pin a
+      // stale verdict for six hours).
+      if (typeof at === "number" && at <= now && now - at < STALENESS_TTL_MS) {
+        return typeof latest === "string" && compareVersions(current, latest) < 0 ? emitOutdated(pkg, current, latest) : null;
+      }
+    }
+  } catch {
+    /* unreadable cache ⇒ just re-check */
+  }
+  const latest = await (deps.fetchLatest ?? latestVersion)(pkg);
+  if (latest === null) return null; // registry unreachable — say nothing rather than cry wolf
+  try {
+    deps.writeCache?.(JSON.stringify({ at: now, latest }));
+  } catch {
+    /* cache is an optimisation, not a requirement */
+  }
+  return compareVersions(current, latest) < 0 ? emitOutdated(pkg, current, latest) : null;
+}
+
+function emitOutdated(pkg: string, current: string, latest: string): string {
+  const msg = `inplan: your CLI is ${current}; ${latest} is available. Some cloud documents need a newer CLI — update with \`npm i -g ${pkg}@latest\`.`;
+  process.stderr.write(`${msg}\n`);
+  return msg;
+}

--- a/packages/cli/test/liveSync.test.ts
+++ b/packages/cli/test/liveSync.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, expect, it } from "vitest";
-import { shouldHydrateWorkFile, pendingRequiresReplay, trackGateDegradations } from "../src/liveSync";
+import { shouldHydrateWorkFile, pendingRequiresReplay, postTurnAction, trackGateDegradations } from "../src/liveSync";
 
 describe("shouldHydrateWorkFile", () => {
   it("seeds when the working copy doesn't exist yet", () => {
@@ -92,5 +92,42 @@ describe("trackGateDegradations", () => {
     expect(t.readFailed()).toBe(false);
     expect(t.writeFailed()).toBe(false);
     expect(calls.setCanonical).toEqual([]); // no local persistence on the happy path
+  });
+});
+
+// `exitAfterFlush` SCHEDULES an exit rather than performing one, so a fail-fast turn no longer stops
+// its caller by itself. This is the decision that has to stop it — and it is the one that protects
+// the working copy, which on `confirm_required` holds the agent's pending edit and nothing else does.
+describe("postTurnAction", () => {
+  const healthy = { readFailed: false, writeFailed: false };
+
+  it("stops on a fail-fast outcome, so the re-sync can't race the pending exit", () => {
+    expect(postTurnAction("exiting", healthy)).toBe("stop");
+  });
+
+  it("stops on a fail-fast outcome even when the hub also degraded", () => {
+    // `stop` must win outright: `keep-local` writes a `.pending` marker, which is still a mutation
+    // on behalf of a turn that already reported failure.
+    for (const d of [{ readFailed: true, writeFailed: false }, { readFailed: false, writeFailed: true }, { readFailed: true, writeFailed: true }]) {
+      expect(postTurnAction("exiting", d), JSON.stringify(d)).toBe("stop");
+    }
+  });
+
+  it("keeps local edits when the hub dropped mid-turn", () => {
+    expect(postTurnAction("ok", { readFailed: true, writeFailed: false })).toBe("keep-local");
+    expect(postTurnAction("ok", { readFailed: false, writeFailed: true })).toBe("keep-local");
+    expect(postTurnAction("ok", { readFailed: true, writeFailed: true })).toBe("keep-local");
+  });
+
+  it("re-syncs only on a healthy turn", () => {
+    expect(postTurnAction("ok", healthy)).toBe("resync");
+  });
+
+  it("is total: every outcome × degradation pair yields exactly one action", () => {
+    const actions = new Set<string>();
+    for (const outcome of ["ok", "exiting"] as const)
+      for (const readFailed of [true, false])
+        for (const writeFailed of [true, false]) actions.add(postTurnAction(outcome, { readFailed, writeFailed }));
+    expect([...actions].sort()).toEqual(["keep-local", "resync", "stop"]);
   });
 });

--- a/packages/cli/test/liveSync.test.ts
+++ b/packages/cli/test/liveSync.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, expect, it } from "vitest";
-import { shouldHydrateWorkFile, pendingRequiresReplay, postTurnAction, trackGateDegradations } from "../src/liveSync";
+import { demoteSource, shouldHydrateWorkFile, pendingRequiresReplay, postTurnAction, trackGateDegradations } from "../src/liveSync";
 
 describe("shouldHydrateWorkFile", () => {
   it("seeds when the working copy doesn't exist yet", () => {
@@ -129,5 +129,26 @@ describe("postTurnAction", () => {
       for (const readFailed of [true, false])
         for (const writeFailed of [true, false]) actions.add(postTurnAction(outcome, { readFailed, writeFailed }));
     expect([...actions].sort()).toEqual(["keep-local", "resync", "stop"]);
+  });
+});
+
+// `demote` overwrites the user's original file AND flips the doc to local — irreversible together.
+// `gate.applyRevision` never writes `live.store`, so when the hub is unreadable there is no way to
+// distinguish a current server copy from one missing every hub edit. Refusing beats guessing.
+describe("demoteSource", () => {
+  it("uses the hub whenever it can be read", () => {
+    expect(demoteSource({ hubReadable: true, fromStore: false })).toEqual({ use: "hub" });
+  });
+
+  it("prefers the hub even when --from-store was passed (the flag is a fallback, not an override)", () => {
+    expect(demoteSource({ hubReadable: true, fromStore: true })).toEqual({ use: "hub" });
+  });
+
+  it("refuses rather than silently writing an unverifiable copy", () => {
+    expect(demoteSource({ hubReadable: false, fromStore: false })).toEqual({ use: "abort", reason: "hub_unreadable" });
+  });
+
+  it("accepts the store copy only on an explicit opt-in", () => {
+    expect(demoteSource({ hubReadable: false, fromStore: true })).toEqual({ use: "store" });
   });
 });

--- a/packages/cli/test/pluginGate.test.ts
+++ b/packages/cli/test/pluginGate.test.ts
@@ -69,6 +69,21 @@ describe("loadPluginGate", () => {
     await loadPluginGate(SESSION, { token: null, apiBase: "https://plugin.test", cacheDir: "/tmp/cache", publicKey: "PEM" }, deps({ resolve }));
     expect(resolve).toHaveBeenCalledWith(expect.objectContaining({ token: null, apiBase: "https://plugin.test", cacheDir: "/tmp/cache", publicKey: "PEM" }));
   });
+
+  // `""` means "nothing can be verified" and must REACH the resolver, which then refuses without a
+  // network call. Forwarding on truthiness would drop it and silently substitute the baked-in key —
+  // verifying against exactly the thing the caller disabled.
+  it("forwards an explicit empty publicKey instead of falling back to the baked-in key", async () => {
+    const resolve = vi.fn(async () => offline);
+    await loadPluginGate(SESSION, { token: "jwt", publicKey: "" }, deps({ resolve }));
+    expect(resolve).toHaveBeenCalledWith(expect.objectContaining({ publicKey: "" }));
+  });
+
+  it("omits publicKey entirely when the caller gives none (resolver uses its default)", async () => {
+    const resolve = vi.fn(async () => resolved(bundle({ "cli.js": "/c.js" }, "cli.js")));
+    await loadPluginGate(SESSION, { token: "jwt" }, deps({ resolve }));
+    expect(resolve).toHaveBeenCalledWith(expect.not.objectContaining({ publicKey: expect.anything() }));
+  });
 });
 
 describe("loadPluginGateOutcome", () => {

--- a/packages/cli/test/pluginGate.test.ts
+++ b/packages/cli/test/pluginGate.test.ts
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, expect, it, vi } from "vitest";
-import { loadPluginGate, type PluginGateDeps } from "../src/pluginGate";
-import type { ResolvedPlugin } from "@inplan/core/node";
+import { loadPluginGate, loadPluginGateOutcome, type PluginGateDeps } from "../src/pluginGate";
+import type { PluginOutcome, ResolvedPlugin } from "@inplan/core/node";
 
 const SESSION = "ws://127.0.0.1:51234";
 
@@ -14,11 +14,16 @@ const bundle = (files: Record<string, string>, cli?: string): ResolvedPlugin => 
   entries: cli ? { cli } : {},
 });
 
+/** Resolve outcomes, mirroring what resolvePluginOutcome returns. */
+const resolved = (p: ResolvedPlugin): PluginOutcome => ({ plugin: p, reason: null });
+const denied: PluginOutcome = { plugin: null, reason: "unentitled" };
+const offline: PluginOutcome = { plugin: null, reason: "unavailable" };
+
 /** Build injectable deps with a stub resolve + a stub CLI entry whose gate() returns a PluginGate. */
 function deps(over: Partial<PluginGateDeps> & { gate?: { readCanonical: ReturnType<typeof vi.fn>; applyRevision: ReturnType<typeof vi.fn> } } = {}): PluginGateDeps {
   const gate = over.gate ?? { readCanonical: vi.fn(async () => "live body"), applyRevision: vi.fn(async () => {}) };
   return {
-    resolve: over.resolve ?? (async () => bundle({ "cli.js": "/cache/v1/cli.js" }, "cli.js")),
+    resolve: over.resolve ?? (async () => resolved(bundle({ "cli.js": "/cache/v1/cli.js" }, "cli.js"))),
     importCli: over.importCli ?? (async () => ({ gate: () => gate })),
   };
 }
@@ -35,16 +40,16 @@ describe("loadPluginGate", () => {
     expect(gateImpl.applyRevision).toHaveBeenCalledWith("new body");
   });
 
-  it("not entitled (resolve → null) → null, and never imports the CLI entry", async () => {
+  it("not entitled (resolve denies) → null, and never imports the CLI entry", async () => {
     const importCli = vi.fn();
-    const gate = await loadPluginGate(SESSION, { token: "jwt" }, deps({ resolve: async () => null, importCli }));
+    const gate = await loadPluginGate(SESSION, { token: "jwt" }, deps({ resolve: async () => denied, importCli }));
     expect(gate).toBeNull();
     expect(importCli).not.toHaveBeenCalled();
   });
 
   it("bundle has no cli entry (renderer-only plugin) → null, and never imports", async () => {
     const importCli = vi.fn();
-    const gate = await loadPluginGate(SESSION, { token: "jwt" }, deps({ resolve: async () => bundle({ "renderer.js": "/cache/v1/renderer.js" }), importCli }));
+    const gate = await loadPluginGate(SESSION, { token: "jwt" }, deps({ resolve: async () => resolved(bundle({ "renderer.js": "/cache/v1/renderer.js" })), importCli }));
     expect(gate).toBeNull();
     expect(importCli).not.toHaveBeenCalled();
   });
@@ -60,8 +65,41 @@ describe("loadPluginGate", () => {
   });
 
   it("threads token + an explicit publicKey/cacheDir/apiBase into resolve", async () => {
-    const resolve = vi.fn(async () => bundle({ "cli.js": "/cache/v1/cli.js" }, "cli.js"));
+    const resolve = vi.fn(async () => resolved(bundle({ "cli.js": "/cache/v1/cli.js" }, "cli.js")));
     await loadPluginGate(SESSION, { token: null, apiBase: "https://plugin.test", cacheDir: "/tmp/cache", publicKey: "PEM" }, deps({ resolve }));
     expect(resolve).toHaveBeenCalledWith(expect.objectContaining({ token: null, apiBase: "https://plugin.test", cacheDir: "/tmp/cache", publicKey: "PEM" }));
+  });
+});
+
+describe("loadPluginGateOutcome", () => {
+  it("propagates `unentitled` — the one answer that justifies telling the human to upgrade", async () => {
+    const out = await loadPluginGateOutcome(SESSION, { token: "jwt" }, deps({ resolve: async () => denied }));
+    expect(out).toEqual({ gate: null, reason: "unentitled" });
+  });
+
+  it("propagates `unavailable` for an outage, so it is never mistaken for a paywall", async () => {
+    const out = await loadPluginGateOutcome(SESSION, { token: "jwt" }, deps({ resolve: async () => offline }));
+    expect(out).toEqual({ gate: null, reason: "unavailable" });
+  });
+
+  it("a resolve that throws is `unavailable`, never `unentitled`", async () => {
+    const out = await loadPluginGateOutcome(SESSION, { token: "jwt" }, deps({ resolve: async () => { throw new Error("network"); } }));
+    expect(out).toEqual({ gate: null, reason: "unavailable" });
+  });
+
+  it("entitled but the bundle ships no CLI entry → `unavailable` (not a plan problem)", async () => {
+    const out = await loadPluginGateOutcome(SESSION, { token: "jwt" }, deps({ resolve: async () => resolved(bundle({ "renderer.js": "/r.js" })) }));
+    expect(out).toEqual({ gate: null, reason: "unavailable" });
+  });
+
+  it("a failing import of the verified CLI entry is `unavailable`", async () => {
+    const out = await loadPluginGateOutcome(SESSION, { token: "jwt" }, deps({ importCli: async () => { throw new Error("bad module"); } }));
+    expect(out).toEqual({ gate: null, reason: "unavailable" });
+  });
+
+  it("success carries the gate and no reason", async () => {
+    const out = await loadPluginGateOutcome(SESSION, { token: "jwt" }, deps());
+    expect(out.reason).toBeNull();
+    expect(await out.gate!.readCanonical()).toBe("live body");
   });
 });

--- a/packages/cli/test/remoteGating.test.ts
+++ b/packages/cli/test/remoteGating.test.ts
@@ -9,6 +9,7 @@
 // distinct: telling a paying customer to upgrade because a server hiccuped is the worst outcome.
 
 import { describe, expect, it, vi } from "vitest";
+import { readFile } from "node:fs/promises";
 import { EXIT_PLUGIN_UNAVAILABLE, EXIT_UPGRADE_REQUIRED, exitAfterFlush, explainNoGate } from "../src/cli";
 
 function capture(fn: () => void): { err: string; out: string } {
@@ -97,5 +98,28 @@ describe("exitAfterFlush", () => {
     const out = { write: vi.fn((_c: string, cb?: (e?: Error) => void) => (cb?.(new Error("EPIPE")), true)) };
     exitAfterFlush(5, out as never, exit);
     expect(exit).toHaveBeenCalledWith(5); // a broken pipe must not hang the process
+  });
+});
+
+// `exitAfterFlush` SCHEDULES an exit rather than performing one, so a fail-fast turn no longer stops
+// its caller by itself. `waitCycle` therefore reports the outcome, and the gate path must bail on it
+// — otherwise the end-of-turn re-sync rewrites the working copy from the hub canonical for a turn
+// that just reported failure, racing the exit and discarding the edit the agent was told to fix.
+describe("fail-fast outcome propagation", () => {
+  it("the gate path stops on `exiting` instead of running its end-of-turn re-sync", async () => {
+    const src = await readFile(new URL("../src/cli.ts", import.meta.url), "utf8");
+
+    // waitCycle reports the scheduled exit rather than returning void…
+    expect(src).toMatch(/async function waitCycle\([^)]*\): Promise<WaitOutcome>/s);
+    for (const code of ["exitAfterFlush(3);", "exitAfterFlush(2);"]) {
+      const after = src.slice(src.indexOf(code) + code.length, src.indexOf(code) + code.length + 40);
+      expect(after, code).toMatch(/return "exiting";/);
+    }
+
+    // …and the caller bails BEFORE the block that mutates the working copy.
+    const bail = src.indexOf('if (outcome === "exiting") return;');
+    expect(bail).toBeGreaterThan(-1);
+    const resync = src.indexOf("recordSynced(readFileSync(workFile", bail);
+    expect(resync).toBeGreaterThan(bail);
   });
 });

--- a/packages/cli/test/remoteGating.test.ts
+++ b/packages/cli/test/remoteGating.test.ts
@@ -9,7 +9,7 @@
 // distinct: telling a paying customer to upgrade because a server hiccuped is the worst outcome.
 
 import { describe, expect, it, vi } from "vitest";
-import { EXIT_PLUGIN_UNAVAILABLE, EXIT_UPGRADE_REQUIRED, explainNoGate } from "../src/cli";
+import { EXIT_PLUGIN_UNAVAILABLE, EXIT_UPGRADE_REQUIRED, exitAfterFlush, explainNoGate } from "../src/cli";
 
 function capture(fn: () => void): { err: string; out: string } {
   let err = "";
@@ -66,5 +66,36 @@ describe("explainNoGate", () => {
     // 1 generic, 2 integrity_error, 3 confirm_required, 64 usage.
     expect(EXIT_UPGRADE_REQUIRED).not.toBe(EXIT_PLUGIN_UNAVAILABLE);
     expect([EXIT_UPGRADE_REQUIRED, EXIT_PLUGIN_UNAVAILABLE].every((c) => ![0, 1, 2, 3, 64].includes(c))).toBe(true);
+  });
+});
+
+// The coded exits exist to hand the agent a machine-readable status. Node's stdout is ASYNC when
+// piped — the normal case under a coding agent — so `output(...)` followed by a bare `process.exit`
+// delivers the code with no payload. These pin that the exit waits for the drain.
+describe("exitAfterFlush", () => {
+  it("does not exit until the stdout write has flushed", () => {
+    const exit = vi.fn();
+    let cb: (() => void) | undefined;
+    const out = { write: vi.fn((_c: string, c?: () => void) => ((cb = c), true)) };
+    exitAfterFlush(7, out as never, exit);
+    expect(exit).not.toHaveBeenCalled(); // still buffered — exiting here would truncate the JSON
+    cb!();
+    expect(exit).toHaveBeenCalledWith(7);
+  });
+
+  it("queues its barrier AFTER the payload, so ordering guarantees the flush covers it", () => {
+    const writes: string[] = [];
+    const out = { write: vi.fn((c: string, cb?: () => void) => (writes.push(c), cb?.(), true)) };
+    out.write(JSON.stringify({ status: "upgrade_required" }) + "\n");
+    exitAfterFlush(4, out as never, vi.fn());
+    expect(writes[0]).toContain("upgrade_required");
+    expect(writes[1]).toBe(""); // the zero-length drain barrier, written last
+  });
+
+  it("still exits when the stream reports an error to the callback", () => {
+    const exit = vi.fn();
+    const out = { write: vi.fn((_c: string, cb?: (e?: Error) => void) => (cb?.(new Error("EPIPE")), true)) };
+    exitAfterFlush(5, out as never, exit);
+    expect(exit).toHaveBeenCalledWith(5); // a broken pipe must not hang the process
   });
 });

--- a/packages/cli/test/remoteGating.test.ts
+++ b/packages/cli/test/remoteGating.test.ts
@@ -9,7 +9,6 @@
 // distinct: telling a paying customer to upgrade because a server hiccuped is the worst outcome.
 
 import { describe, expect, it, vi } from "vitest";
-import { readFile } from "node:fs/promises";
 import { EXIT_PLUGIN_UNAVAILABLE, EXIT_UPGRADE_REQUIRED, exitAfterFlush, explainNoGate } from "../src/cli";
 
 function capture(fn: () => void): { err: string; out: string } {
@@ -98,28 +97,5 @@ describe("exitAfterFlush", () => {
     const out = { write: vi.fn((_c: string, cb?: (e?: Error) => void) => (cb?.(new Error("EPIPE")), true)) };
     exitAfterFlush(5, out as never, exit);
     expect(exit).toHaveBeenCalledWith(5); // a broken pipe must not hang the process
-  });
-});
-
-// `exitAfterFlush` SCHEDULES an exit rather than performing one, so a fail-fast turn no longer stops
-// its caller by itself. `waitCycle` therefore reports the outcome, and the gate path must bail on it
-// — otherwise the end-of-turn re-sync rewrites the working copy from the hub canonical for a turn
-// that just reported failure, racing the exit and discarding the edit the agent was told to fix.
-describe("fail-fast outcome propagation", () => {
-  it("the gate path stops on `exiting` instead of running its end-of-turn re-sync", async () => {
-    const src = await readFile(new URL("../src/cli.ts", import.meta.url), "utf8");
-
-    // waitCycle reports the scheduled exit rather than returning void…
-    expect(src).toMatch(/async function waitCycle\([^)]*\): Promise<WaitOutcome>/s);
-    for (const code of ["exitAfterFlush(3);", "exitAfterFlush(2);"]) {
-      const after = src.slice(src.indexOf(code) + code.length, src.indexOf(code) + code.length + 40);
-      expect(after, code).toMatch(/return "exiting";/);
-    }
-
-    // …and the caller bails BEFORE the block that mutates the working copy.
-    const bail = src.indexOf('if (outcome === "exiting") return;');
-    expect(bail).toBeGreaterThan(-1);
-    const resync = src.indexOf("recordSynced(readFileSync(workFile", bail);
-    expect(resync).toBeGreaterThan(bail);
   });
 });

--- a/packages/cli/test/remoteGating.test.ts
+++ b/packages/cli/test/remoteGating.test.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// `wait --remote` needs the plugin gate to materialize a working copy: an out-of-process local agent
+// can only read and write FILES, and the turn-based store path below the gate was built for the
+// managed cloud agent, which holds the body in memory. Without a gate the CLI used to fall through
+// and attach anyway — consuming the human's turns while provably unable to read or edit the doc.
+//
+// These pin the explanation that replaced that silence, and above all that the two reasons stay
+// distinct: telling a paying customer to upgrade because a server hiccuped is the worst outcome.
+
+import { describe, expect, it, vi } from "vitest";
+import { EXIT_PLUGIN_UNAVAILABLE, EXIT_UPGRADE_REQUIRED, explainNoGate } from "../src/cli";
+
+function capture(fn: () => void): { err: string; out: string } {
+  let err = "";
+  let out = "";
+  const se = vi.spyOn(process.stderr, "write").mockImplementation((c: unknown) => ((err += String(c)), true));
+  const so = vi.spyOn(process.stdout, "write").mockImplementation((c: unknown) => ((out += String(c)), true));
+  try {
+    fn();
+    return { err, out };
+  } finally {
+    se.mockRestore();
+    so.mockRestore();
+  }
+}
+
+describe("explainNoGate", () => {
+  it("unentitled → names the plan limit and points at the in-product upgrade", () => {
+    const { err, out } = capture(() => explainNoGate("unentitled"));
+    expect(err).toContain("doesn't include the local agent");
+    expect(err).toContain("agent indicator to upgrade");
+    expect(JSON.parse(out)).toEqual({ status: "upgrade_required", reason: "unentitled" });
+  });
+
+  it("unavailable → explicitly NOT a plan limit, and tells the human to retry", () => {
+    const { err, out } = capture(() => explainNoGate("unavailable"));
+    expect(err).toContain("not a plan limit");
+    expect(err).toContain("retry");
+    expect(err).not.toContain("upgrade");
+    expect(JSON.parse(out)).toEqual({ status: "plugin_unavailable", reason: "unavailable" });
+  });
+
+  it("offers `demote` as the free escape hatch only when a local file exists to demote to", () => {
+    const withFile = capture(() => explainNoGate("unentitled", "/w/plan.plan.md"));
+    expect(withFile.err).toContain("inplan demote /w/plan.plan.md");
+    expect(JSON.parse(withFile.out)).toMatchObject({ localFile: "/w/plan.plan.md" });
+
+    // A bare `--remote <docId>` has no file on disk, so promising `demote` would be a dead end.
+    const bare = capture(() => explainNoGate("unentitled"));
+    expect(bare.err).not.toContain("demote");
+    expect(JSON.parse(bare.out)).not.toHaveProperty("localFile");
+  });
+
+  it("the transient path also offers demote when there is a local file", () => {
+    const { err } = capture(() => explainNoGate("unavailable", "/w/plan.plan.md"));
+    expect(err).toContain("inplan demote /w/plan.plan.md");
+  });
+
+  it("emits exactly one JSON object on stdout, so the agent's parser stays happy", () => {
+    const { out } = capture(() => explainNoGate("unentitled", "/w/plan.plan.md"));
+    expect(out.trim().split("\n")).toHaveLength(1);
+  });
+
+  it("the two exit codes are distinct and neither collides with the existing ones", () => {
+    // 1 generic, 2 integrity_error, 3 confirm_required, 64 usage.
+    expect(EXIT_UPGRADE_REQUIRED).not.toBe(EXIT_PLUGIN_UNAVAILABLE);
+    expect([EXIT_UPGRADE_REQUIRED, EXIT_PLUGIN_UNAVAILABLE].every((c) => ![0, 1, 2, 3, 64].includes(c))).toBe(true);
+  });
+});

--- a/packages/cli/test/remoteGating.test.ts
+++ b/packages/cli/test/remoteGating.test.ts
@@ -9,7 +9,7 @@
 // distinct: telling a paying customer to upgrade because a server hiccuped is the worst outcome.
 
 import { describe, expect, it, vi } from "vitest";
-import { EXIT_PLUGIN_UNAVAILABLE, EXIT_UPGRADE_REQUIRED, exitAfterFlush, explainNoGate } from "../src/cli";
+import { EXIT_PLUGIN_UNAVAILABLE, EXIT_UPGRADE_REQUIRED, exitAfterFlush, explainNoGate, shellQuote } from "../src/cli";
 
 function capture(fn: () => void): { err: string; out: string } {
   let err = "";
@@ -43,7 +43,7 @@ describe("explainNoGate", () => {
 
   it("offers `demote` as the free escape hatch only when a local file exists to demote to", () => {
     const withFile = capture(() => explainNoGate("unentitled", "/w/plan.plan.md"));
-    expect(withFile.err).toContain("inplan demote /w/plan.plan.md");
+    expect(withFile.err).toContain("inplan demote '/w/plan.plan.md'");
     expect(JSON.parse(withFile.out)).toMatchObject({ localFile: "/w/plan.plan.md" });
 
     // A bare `--remote <docId>` has no file on disk, so promising `demote` would be a dead end.
@@ -54,7 +54,7 @@ describe("explainNoGate", () => {
 
   it("the transient path also offers demote when there is a local file", () => {
     const { err } = capture(() => explainNoGate("unavailable", "/w/plan.plan.md"));
-    expect(err).toContain("inplan demote /w/plan.plan.md");
+    expect(err).toContain("inplan demote '/w/plan.plan.md'");
   });
 
   it("emits exactly one JSON object on stdout, so the agent's parser stays happy", () => {
@@ -97,5 +97,58 @@ describe("exitAfterFlush", () => {
     const out = { write: vi.fn((_c: string, cb?: (e?: Error) => void) => (cb?.(new Error("EPIPE")), true)) };
     exitAfterFlush(5, out as never, exit);
     expect(exit).toHaveBeenCalledWith(5); // a broken pipe must not hang the process
+  });
+});
+
+// The hint is copy-pasted into a shell. An unquoted path with a space silently targets the wrong
+// file, and one carrying `$(…)`/backticks/`;` would EXECUTE on paste — a command we printed.
+describe("shellQuote", () => {
+  it("quotes a plain path", () => {
+    expect(shellQuote("/w/plan.plan.md")).toBe("'/w/plan.plan.md'");
+  });
+
+  it("keeps a path with spaces a single argument", () => {
+    expect(shellQuote("/My Docs/road map.plan.md")).toBe("'/My Docs/road map.plan.md'");
+  });
+
+  it("neutralises command substitution, backticks and separators", () => {
+    for (const evil of ["/w/$(rm -rf ~).md", "/w/`id`.md", "/w/a;rm -rf /.md", "/w/a&&b.md", "/w/a|b.md", "/w/a$HOME.md"]) {
+      const q = shellQuote(evil);
+      expect(q.startsWith("'") && q.endsWith("'")).toBe(true);
+      expect(q.slice(1, -1)).not.toContain("'"); // nothing can terminate the quote early
+    }
+  });
+
+  it("escapes an embedded single quote by closing, escaping, and reopening", () => {
+    expect(shellQuote("/w/it's.md")).toBe("'/w/it'" + String.fromCharCode(92) + "''s.md'");
+  });
+});
+
+// `demote` overwrites the user's original file. On a doc a local agent has been editing through the
+// hub, `live.store` holds pre-hub content (`gate.applyRevision` never writes it) — so reading the
+// store there would destroy every edit since. `onSaveLocallyGate` already reads the hub for exactly
+// this reason; these pin that `demote` makes the same choice, and degrades honestly when it can't.
+describe("demote source selection", () => {
+  const pick = async (gate: { readCanonical: () => Promise<string> } | null, storeBody: string) => {
+    try {
+      if (!gate) throw new Error("no gate");
+      return { body: await gate.readCanonical(), source: "hub" as const };
+    } catch {
+      return { body: storeBody, source: "store" as const };
+    }
+  };
+
+  it("prefers the hub canonical when a gate is available", async () => {
+    const gate = { readCanonical: async () => "hub body (agent's latest)" };
+    expect(await pick(gate, "stale pre-hub body")).toEqual({ body: "hub body (agent's latest)", source: "hub" });
+  });
+
+  it("falls back to the store with no gate, and reports which it used", async () => {
+    expect(await pick(null, "store body")).toEqual({ body: "store body", source: "store" });
+  });
+
+  it("falls back rather than failing when the hub read throws (hub down)", async () => {
+    const gate = { readCanonical: async () => { throw new Error("hub unreachable"); } };
+    expect(await pick(gate, "store body")).toEqual({ body: "store body", source: "store" });
   });
 });

--- a/packages/cli/test/remoteGating.test.ts
+++ b/packages/cli/test/remoteGating.test.ts
@@ -73,21 +73,27 @@ describe("explainNoGate", () => {
 // piped — the normal case under a coding agent — so `output(...)` followed by a bare `process.exit`
 // delivers the code with no payload. These pin that the exit waits for the drain.
 describe("exitAfterFlush", () => {
-  it("does not exit until the stdout write has flushed", () => {
+  it("does not exit until BOTH streams have flushed", () => {
     const exit = vi.fn();
-    let cb: (() => void) | undefined;
-    const out = { write: vi.fn((_c: string, c?: () => void) => ((cb = c), true)) };
-    exitAfterFlush(7, out as never, exit);
-    expect(exit).not.toHaveBeenCalled(); // still buffered — exiting here would truncate the JSON
-    cb!();
+    let outCb: (() => void) | undefined;
+    let errCb: (() => void) | undefined;
+    const out = { write: vi.fn((_c: string, c?: () => void) => ((outCb = c), true)) };
+    const err = { write: vi.fn((_c: string, c?: () => void) => ((errCb = c), true)) };
+    exitAfterFlush(7, out as never, exit, err as never);
+    expect(exit).not.toHaveBeenCalled(); // stdout still buffered — exiting here truncates the JSON
+    outCb!();
+    expect(err.write).toHaveBeenCalled();
+    expect(exit).not.toHaveBeenCalled(); // stderr is buffered when piped too — the guidance would be lost
+    errCb!();
     expect(exit).toHaveBeenCalledWith(7);
   });
 
   it("queues its barrier AFTER the payload, so ordering guarantees the flush covers it", () => {
     const writes: string[] = [];
     const out = { write: vi.fn((c: string, cb?: () => void) => (writes.push(c), cb?.(), true)) };
+    const err = { write: vi.fn((_c: string, cb?: () => void) => (cb?.(), true)) };
     out.write(JSON.stringify({ status: "upgrade_required" }) + "\n");
-    exitAfterFlush(4, out as never, vi.fn());
+    exitAfterFlush(4, out as never, vi.fn(), err as never);
     expect(writes[0]).toContain("upgrade_required");
     expect(writes[1]).toBe(""); // the zero-length drain barrier, written last
   });
@@ -95,7 +101,8 @@ describe("exitAfterFlush", () => {
   it("still exits when the stream reports an error to the callback", () => {
     const exit = vi.fn();
     const out = { write: vi.fn((_c: string, cb?: (e?: Error) => void) => (cb?.(new Error("EPIPE")), true)) };
-    exitAfterFlush(5, out as never, exit);
+    const err = { write: vi.fn((_c: string, cb?: (e?: Error) => void) => (cb?.(new Error("EPIPE")), true)) };
+    exitAfterFlush(5, out as never, exit, err as never);
     expect(exit).toHaveBeenCalledWith(5); // a broken pipe must not hang the process
   });
 });
@@ -121,34 +128,5 @@ describe("shellQuote", () => {
 
   it("escapes an embedded single quote by closing, escaping, and reopening", () => {
     expect(shellQuote("/w/it's.md")).toBe("'/w/it'" + String.fromCharCode(92) + "''s.md'");
-  });
-});
-
-// `demote` overwrites the user's original file. On a doc a local agent has been editing through the
-// hub, `live.store` holds pre-hub content (`gate.applyRevision` never writes it) — so reading the
-// store there would destroy every edit since. `onSaveLocallyGate` already reads the hub for exactly
-// this reason; these pin that `demote` makes the same choice, and degrades honestly when it can't.
-describe("demote source selection", () => {
-  const pick = async (gate: { readCanonical: () => Promise<string> } | null, storeBody: string) => {
-    try {
-      if (!gate) throw new Error("no gate");
-      return { body: await gate.readCanonical(), source: "hub" as const };
-    } catch {
-      return { body: storeBody, source: "store" as const };
-    }
-  };
-
-  it("prefers the hub canonical when a gate is available", async () => {
-    const gate = { readCanonical: async () => "hub body (agent's latest)" };
-    expect(await pick(gate, "stale pre-hub body")).toEqual({ body: "hub body (agent's latest)", source: "hub" });
-  });
-
-  it("falls back to the store with no gate, and reports which it used", async () => {
-    expect(await pick(null, "store body")).toEqual({ body: "store body", source: "store" });
-  });
-
-  it("falls back rather than failing when the hub read throws (hub down)", async () => {
-    const gate = { readCanonical: async () => { throw new Error("hub unreachable"); } };
-    expect(await pick(gate, "store body")).toEqual({ body: "store body", source: "store" });
   });
 });

--- a/packages/cli/test/update.network.test.ts
+++ b/packages/cli/test/update.network.test.ts
@@ -9,7 +9,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 const spawnMock = vi.fn();
 vi.mock("node:child_process", () => ({ spawn: (...a: unknown[]) => spawnMock(...a) }));
 
-import { latestVersion, selfUpdate } from "../src/update";
+import { latestVersion, REGISTRY_TIMEOUT_MS, selfUpdate } from "../src/update";
 
 afterEach(() => vi.restoreAllMocks());
 
@@ -67,5 +67,29 @@ describe("selfUpdate", () => {
     const p = selfUpdate("p");
     child.emit("error", new Error("npm not found"));
     await expect(p).resolves.toEqual({ ok: false, output: "npm not found" });
+  });
+});
+
+// `wait --remote` awaits the staleness check before it attaches, so an unbounded registry request
+// would turn a stalled connection into a hung command instead of a skipped warning.
+describe("latestVersion request bounding", () => {
+  it("aborts after REGISTRY_TIMEOUT_MS and reports no answer", async () => {
+    const seen: (AbortSignal | undefined)[] = [];
+    const stub = vi.fn(async (_u: string, init?: { signal?: AbortSignal }) => {
+      seen.push(init?.signal);
+      // Resolve only if the caller's signal fires — i.e. prove the request is actually bounded.
+      return await new Promise<Response>((_res, rej) => init?.signal?.addEventListener("abort", () => rej(new Error("aborted"))));
+    });
+    vi.stubGlobal("fetch", stub as unknown as typeof fetch);
+    try {
+      expect(await latestVersion("inplan")).toBeNull();
+      expect(seen[0]).toBeInstanceOf(AbortSignal);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  }, 10_000);
+
+  it("REGISTRY_TIMEOUT_MS is short enough to keep a turn responsive", () => {
+    expect(REGISTRY_TIMEOUT_MS).toBeLessThanOrEqual(5000);
   });
 });

--- a/packages/cli/test/update.network.test.ts
+++ b/packages/cli/test/update.network.test.ts
@@ -77,8 +77,11 @@ describe("latestVersion request bounding", () => {
     const seen: (AbortSignal | undefined)[] = [];
     const stub = vi.fn(async (_u: string, init?: { signal?: AbortSignal }) => {
       seen.push(init?.signal);
-      // Resolve only if the caller's signal fires — i.e. prove the request is actually bounded.
-      return await new Promise<Response>((_res, rej) => init?.signal?.addEventListener("abort", () => rej(new Error("aborted"))));
+      // Fail LOUDLY rather than hang: without a signal the promise below would never settle, and a
+      // regression that dropped the bound would surface as a 10s Vitest timeout instead of a message.
+      if (!init?.signal) throw new Error("latestVersion must pass an AbortSignal");
+      // Settle only when the caller's signal fires — i.e. prove the request is actually bounded.
+      return await new Promise<Response>((_res, rej) => init.signal!.addEventListener("abort", () => rej(new Error("aborted"))));
     });
     vi.stubGlobal("fetch", stub as unknown as typeof fetch);
     try {

--- a/packages/cli/test/updateStaleness.test.ts
+++ b/packages/cli/test/updateStaleness.test.ts
@@ -79,6 +79,18 @@ describe("warnIfOutdated", () => {
     expect(result).toContain("0.1.26");
   });
 
+  // A partial record passes the freshness check but carries no verdict, so serving it would suppress
+  // the refresh for the whole TTL — silence a user cannot tell from "you're up to date".
+  it("treats an incomplete cache record as a miss and re-checks", async () => {
+    for (const bad of [{ at: 1000 }, { at: 1000, latest: 42 }, { at: 1000, latest: null }, { latest: "0.1.26" }]) {
+      const fetchLatest = vi.fn(async () => "0.1.26");
+      const cache = memCache(JSON.stringify(bad));
+      const { result } = await capture(() => warnIfOutdated("inplan", "0.1.25", { fetchLatest, now: () => 1500, ...cache }));
+      expect(fetchLatest, JSON.stringify(bad)).toHaveBeenCalledTimes(1);
+      expect(result).toContain("0.1.26");
+    }
+  });
+
   it("a corrupt cache is ignored, not fatal", async () => {
     const fetchLatest = vi.fn(async () => "0.1.26");
     const cache = memCache("{not json");

--- a/packages/cli/test/updateStaleness.test.ts
+++ b/packages/cli/test/updateStaleness.test.ts
@@ -25,7 +25,7 @@ async function capture(fn: () => Promise<string | null>): Promise<{ result: stri
 /** An in-memory staleness cache. */
 function memCache(initial: string | null = null) {
   let v = initial;
-  return { readCache: () => v, writeCache: (s: string) => void (v = s), peek: () => v };
+  return { readCache: () => v, writeCache: (s: string) => void (v = s) };
 }
 
 describe("warnIfOutdated", () => {
@@ -73,7 +73,7 @@ describe("warnIfOutdated", () => {
 
   it("a cache stamped in the future is re-checked, not trusted (clock rewind)", async () => {
     const fetchLatest = vi.fn(async () => "0.1.26");
-    const cache = memCache(JSON.stringify({ at: 50_000, latest: "0.1.25" }));
+    const cache = memCache(JSON.stringify({ at: 50_000, latest: "0.1.25", pkg: "inplan" }));
     const { result } = await capture(() => warnIfOutdated("inplan", "0.1.25", { fetchLatest, now: () => 1000, ...cache }));
     expect(fetchLatest).toHaveBeenCalledTimes(1);
     expect(result).toContain("0.1.26");
@@ -82,13 +82,30 @@ describe("warnIfOutdated", () => {
   // A partial record passes the freshness check but carries no verdict, so serving it would suppress
   // the refresh for the whole TTL — silence a user cannot tell from "you're up to date".
   it("treats an incomplete cache record as a miss and re-checks", async () => {
-    for (const bad of [{ at: 1000 }, { at: 1000, latest: 42 }, { at: 1000, latest: null }, { latest: "0.1.26" }]) {
+    for (const bad of [{ at: 1000, pkg: "inplan" }, { at: 1000, latest: 42, pkg: "inplan" }, { at: 1000, latest: null, pkg: "inplan" }, { latest: "0.1.26", pkg: "inplan" }]) {
       const fetchLatest = vi.fn(async () => "0.1.26");
       const cache = memCache(JSON.stringify(bad));
       const { result } = await capture(() => warnIfOutdated("inplan", "0.1.25", { fetchLatest, now: () => 1500, ...cache }));
       expect(fetchLatest, JSON.stringify(bad)).toHaveBeenCalledTimes(1);
       expect(result).toContain("0.1.26");
     }
+  });
+
+  // `INPLAN_PKG` lets a fork or scoped build share this cache file. Without the package in the
+  // record, a fork would compare its own version against the OFFICIAL package's latest — warning
+  // falsely, or staying silent about a real fork update, for the whole TTL.
+  it("treats a cache written for a different package as a miss", async () => {
+    const fetchLatest = vi.fn(async () => "2.0.0");
+    const cache = memCache(JSON.stringify({ at: 1000, latest: "0.1.26", pkg: "inplan" }));
+    const { result } = await capture(() => warnIfOutdated("@acme/inplan-fork", "1.0.0", { fetchLatest, now: () => 1500, ...cache }));
+    expect(fetchLatest).toHaveBeenCalledTimes(1);
+    expect(result).toContain("2.0.0");
+  });
+
+  it("records the package it checked, so the next run can tell whose verdict it holds", async () => {
+    const cache = memCache();
+    await capture(() => warnIfOutdated("inplan", "0.1.25", { fetchLatest: async () => "0.1.26", now: () => 1000, ...cache }));
+    expect(JSON.parse(cache.readCache()!)).toEqual({ at: 1000, latest: "0.1.26", pkg: "inplan" });
   });
 
   it("a corrupt cache is ignored, not fatal", async () => {

--- a/packages/cli/test/updateStaleness.test.ts
+++ b/packages/cli/test/updateStaleness.test.ts
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// An out-of-date CLI against a newer cloud is the failure mode with no symptom: it attaches, prints
+// a normal turn status, and silently lacks the code path the document needs. These pin the warning
+// that makes it visible — and, just as importantly, pin that it stays QUIET when it has nothing
+// certain to say (registry down) and cheap when called every turn (TTL cache).
+
+import { describe, expect, it, vi } from "vitest";
+import { STALENESS_TTL_MS, warnIfOutdated } from "../src/update";
+
+/** Capture stderr for one call; the warning must never touch stdout (the agent's JSON channel). */
+async function capture(fn: () => Promise<string | null>): Promise<{ result: string | null; err: string; out: string }> {
+  let err = "";
+  let out = "";
+  const se = vi.spyOn(process.stderr, "write").mockImplementation((c: unknown) => ((err += String(c)), true));
+  const so = vi.spyOn(process.stdout, "write").mockImplementation((c: unknown) => ((out += String(c)), true));
+  try {
+    return { result: await fn(), err, out };
+  } finally {
+    se.mockRestore();
+    so.mockRestore();
+  }
+}
+
+/** An in-memory staleness cache. */
+function memCache(initial: string | null = null) {
+  let v = initial;
+  return { readCache: () => v, writeCache: (s: string) => void (v = s), peek: () => v };
+}
+
+describe("warnIfOutdated", () => {
+  it("warns on stderr (never stdout) when the registry has a newer version", async () => {
+    const { result, err, out } = await capture(() => warnIfOutdated("inplan", "0.1.25", { fetchLatest: async () => "0.1.26", now: () => 1000, ...memCache() }));
+    expect(result).toContain("0.1.25");
+    expect(result).toContain("0.1.26");
+    expect(err).toContain("npm i -g inplan@latest");
+    expect(out).toBe(""); // stdout carries the agent's JSON — a human warning must not corrupt it
+  });
+
+  it("stays silent when current is the latest", async () => {
+    const { result, err } = await capture(() => warnIfOutdated("inplan", "0.1.26", { fetchLatest: async () => "0.1.26", now: () => 1000, ...memCache() }));
+    expect(result).toBeNull();
+    expect(err).toBe("");
+  });
+
+  it("stays silent when ahead of the registry (a local dev build)", async () => {
+    const { result } = await capture(() => warnIfOutdated("inplan", "0.2.0", { fetchLatest: async () => "0.1.26", now: () => 1000, ...memCache() }));
+    expect(result).toBeNull();
+  });
+
+  it("an unreachable registry says nothing rather than crying wolf", async () => {
+    const { result, err } = await capture(() => warnIfOutdated("inplan", "0.1.25", { fetchLatest: async () => null, now: () => 1000, ...memCache() }));
+    expect(result).toBeNull();
+    expect(err).toBe("");
+  });
+
+  it("caches the verdict so a per-turn call costs one registry hit per TTL", async () => {
+    const cache = memCache();
+    const fetchLatest = vi.fn(async () => "0.1.26");
+    await capture(() => warnIfOutdated("inplan", "0.1.25", { fetchLatest, now: () => 1000, ...cache }));
+    const second = await capture(() => warnIfOutdated("inplan", "0.1.25", { fetchLatest, now: () => 1000 + STALENESS_TTL_MS - 1, ...cache }));
+    expect(fetchLatest).toHaveBeenCalledTimes(1);
+    expect(second.result).toContain("0.1.26"); // still warns — served from cache
+  });
+
+  it("re-checks once the cache goes stale", async () => {
+    const cache = memCache();
+    const fetchLatest = vi.fn(async () => "0.1.26");
+    await capture(() => warnIfOutdated("inplan", "0.1.25", { fetchLatest, now: () => 1000, ...cache }));
+    await capture(() => warnIfOutdated("inplan", "0.1.25", { fetchLatest, now: () => 1000 + STALENESS_TTL_MS, ...cache }));
+    expect(fetchLatest).toHaveBeenCalledTimes(2);
+  });
+
+  it("a cache stamped in the future is re-checked, not trusted (clock rewind)", async () => {
+    const fetchLatest = vi.fn(async () => "0.1.26");
+    const cache = memCache(JSON.stringify({ at: 50_000, latest: "0.1.25" }));
+    const { result } = await capture(() => warnIfOutdated("inplan", "0.1.25", { fetchLatest, now: () => 1000, ...cache }));
+    expect(fetchLatest).toHaveBeenCalledTimes(1);
+    expect(result).toContain("0.1.26");
+  });
+
+  it("a corrupt cache is ignored, not fatal", async () => {
+    const fetchLatest = vi.fn(async () => "0.1.26");
+    const cache = memCache("{not json");
+    const { result } = await capture(() => warnIfOutdated("inplan", "0.1.25", { fetchLatest, ...cache }));
+    expect(fetchLatest).toHaveBeenCalledTimes(1);
+    expect(result).toContain("0.1.26");
+  });
+
+  it("a cache that can't be written is an optimisation loss, not a failure", async () => {
+    const { result } = await capture(() =>
+      warnIfOutdated("inplan", "0.1.25", {
+        fetchLatest: async () => "0.1.26",
+        now: () => 1000,
+        readCache: () => null,
+        writeCache: () => {
+          throw new Error("read-only fs");
+        },
+      }),
+    );
+    expect(result).toContain("0.1.26");
+  });
+});

--- a/packages/core/src/pluginFetch.ts
+++ b/packages/core/src/pluginFetch.ts
@@ -128,15 +128,41 @@ async function fetchAndCache(bundleUrl: string, leaseToken: string, opts: Requir
 }
 
 /**
+ * Why a resolve produced no plugin. Callers that merely run without the plugin can ignore this, but
+ * anything that must EXPLAIN the absence to a human needs to tell a paywall from an outage:
+ *  - `unentitled` — the server answered definitively: this user's plan doesn't include the perk.
+ *    Only ever set by an explicit `entitled: false`, never inferred from a failure.
+ *  - `unavailable` — we couldn't get a verified answer: logged out, offline, server error, no
+ *    public key, or a bundle/lease that failed verification. Says nothing about the user's plan.
+ */
+export type PluginAbsenceReason = "unentitled" | "unavailable";
+
+/** A resolve attempt's full outcome: the plugin, or why there isn't one. */
+export type PluginOutcome = { plugin: ResolvedPlugin; reason: null } | { plugin: null; reason: PluginAbsenceReason };
+
+/**
  * Resolve the desktop plugin bundle for this user: prefer a fresh server check (catches a lapsed
  * entitlement), fall back to the cached bundle offline. Returns the verified lease + local file
- * paths + entry roles, or null (⇒ run without the plugin). Fail-closed on every error / missing key.
+ * paths + entry roles, or the reason there is none. Fail-closed on every error / missing key.
+ *
+ * Only an explicit `entitled: false` yields `unentitled` — every other miss is `unavailable`, so a
+ * transient outage can never be reported to the user as "your plan doesn't include this".
  */
-export async function resolveDesktopPlugin(options: ResolvePluginOptions): Promise<ResolvedPlugin | null> {
+export async function resolvePluginOutcome(options: ResolvePluginOptions): Promise<PluginOutcome> {
   const publicKey = options.publicKey ?? PLUGIN_PUBLIC_KEY;
   const now = options.now ?? Date.now();
   const fetchImpl = options.fetchImpl ?? fetch;
-  if (!publicKey) return null; // nothing can be verified ⇒ no plugin
+  const cached = (): PluginOutcome => {
+    // Offline (or the online path didn't yield a bundle): use the cached version while its lease holds.
+    try {
+      const current = readFileSync(join(options.cacheDir, "current.txt"), "utf8").trim();
+      const plugin = current ? loadCached(options.cacheDir, current, publicKey, now) : null;
+      return plugin ? { plugin, reason: null } : { plugin: null, reason: "unavailable" };
+    } catch {
+      return { plugin: null, reason: "unavailable" };
+    }
+  };
+  if (!publicKey) return { plugin: null, reason: "unavailable" }; // nothing can be verified ⇒ no plugin
 
   // 1. Online check (only when we have a token).
   if (options.token) {
@@ -144,14 +170,19 @@ export async function resolveDesktopPlugin(options: ResolvePluginOptions): Promi
       const res = await fetchImpl(`${base(options.apiBase)}api/v1/desktop-plugin`, { headers: { authorization: `Bearer ${options.token}` } });
       if (res.ok) {
         const grant = (await res.json()) as { entitled?: boolean; lease?: string; bundleUrl?: string };
-        if (grant.entitled === false) return null; // server says no — don't fall back to a stale cache
+        // Server says no — don't fall back to a stale cache. This is the ONE path that reports a
+        // paywall, because it's the only definitive answer about the user's plan we ever get.
+        if (grant.entitled === false) return { plugin: null, reason: "unentitled" };
         if (grant.entitled && grant.lease && grant.bundleUrl) {
           // A positive grant ships a fresh, signed lease. A lease that fails verification is a
           // tampering signal — fail closed rather than silently using the cache. (A transient
           // bundle-CDN miss still falls through to the independently re-verified cache below.)
-          if (!verifyLease(grant.lease, publicKey, now)) return null;
+          if (!verifyLease(grant.lease, publicKey, now)) return { plugin: null, reason: "unavailable" };
           const version = await fetchAndCache(grant.bundleUrl, grant.lease, { cacheDir: options.cacheDir, publicKey, fetchImpl });
-          if (version) return loadCached(options.cacheDir, version, publicKey, now);
+          if (version) {
+            const plugin = loadCached(options.cacheDir, version, publicKey, now);
+            if (plugin) return { plugin, reason: null };
+          }
         }
       }
     } catch {
@@ -159,11 +190,13 @@ export async function resolveDesktopPlugin(options: ResolvePluginOptions): Promi
     }
   }
 
-  // 2. Offline (or the online path didn't yield a bundle): use the cached version while its lease holds.
-  try {
-    const current = readFileSync(join(options.cacheDir, "current.txt"), "utf8").trim();
-    return current ? loadCached(options.cacheDir, current, publicKey, now) : null;
-  } catch {
-    return null;
-  }
+  return cached();
+}
+
+/**
+ * {@link resolvePluginOutcome} for callers that only need "plugin or not" — the app main and any
+ * path that silently runs without the perk. Returns the verified bundle, or null.
+ */
+export async function resolveDesktopPlugin(options: ResolvePluginOptions): Promise<ResolvedPlugin | null> {
+  return (await resolvePluginOutcome(options)).plugin;
 }

--- a/packages/core/test/pluginFetch.test.ts
+++ b/packages/core/test/pluginFetch.test.ts
@@ -5,7 +5,7 @@ import { existsSync, mkdtempSync, readFileSync, writeFileSync, rmSync } from "no
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createHash, generateKeyPairSync, sign } from "node:crypto";
-import { resolveDesktopPlugin, type LeaseClaims } from "../src/node";
+import { resolveDesktopPlugin, resolvePluginOutcome, type LeaseClaims } from "../src/node";
 
 const { publicKey, privateKey } = generateKeyPairSync("ed25519");
 const pub = publicKey.export({ type: "spki", format: "pem" }).toString();
@@ -149,5 +149,70 @@ describe("resolveDesktopPlugin", () => {
     const forgedLease = `${body}.${sign(null, Buffer.from(body), other).toString("base64url")}`; // signed by the wrong key
     const tbl = { [`${API}/api/v1/desktop-plugin`]: { ok: true, json: { entitled: true, lease: forgedLease, bundleUrl: BUNDLE } } };
     expect(await resolveDesktopPlugin({ apiBase: API, token: "jwt", cacheDir: cd, publicKey: pub, now: 2000, fetchImpl: fakeFetch(tbl) })).toBeNull();
+  });
+});
+
+// The reason a resolve produced no plugin is user-facing: a CLI turns `unentitled` into "upgrade
+// your plan" and `unavailable` into "try again". Mislabelling an outage as a paywall would tell a
+// paying customer to buy what they already own, so every failure mode is pinned here.
+describe("resolvePluginOutcome — absence reasons", () => {
+  it("entitled online → the plugin, with no reason", async () => {
+    const out = await resolvePluginOutcome({ apiBase: API, token: "jwt", cacheDir: cacheDir(), publicKey: pub, now: 1000, fetchImpl: fakeFetch(happyTable) });
+    expect(out.reason).toBeNull();
+    expect(out.plugin?.version).toBe("v1");
+  });
+
+  it("an explicit `entitled: false` is the ONLY thing that reports `unentitled`", async () => {
+    const tbl = { [`${API}/api/v1/desktop-plugin`]: { ok: true, json: { entitled: false } } };
+    const out = await resolvePluginOutcome({ apiBase: API, token: "jwt", cacheDir: cacheDir(), publicKey: pub, now: 1000, fetchImpl: fakeFetch(tbl) });
+    expect(out).toEqual({ plugin: null, reason: "unentitled" });
+  });
+
+  it("a denial still wins over a primed cache (a lapsed plan must stop the perk)", async () => {
+    const cd = cacheDir();
+    await resolvePluginOutcome({ apiBase: API, token: "jwt", cacheDir: cd, publicKey: pub, now: 1000, fetchImpl: fakeFetch(happyTable) });
+    const tbl = { [`${API}/api/v1/desktop-plugin`]: { ok: true, json: { entitled: false } } };
+    const out = await resolvePluginOutcome({ apiBase: API, token: "jwt", cacheDir: cd, publicKey: pub, now: 2000, fetchImpl: fakeFetch(tbl) });
+    expect(out).toEqual({ plugin: null, reason: "unentitled" });
+  });
+
+  it("a network error with no cache is `unavailable`, not `unentitled`", async () => {
+    const boom = (async () => { throw new Error("offline"); }) as unknown as typeof fetch;
+    const out = await resolvePluginOutcome({ apiBase: API, token: "jwt", cacheDir: cacheDir(), publicKey: pub, now: 1000, fetchImpl: boom });
+    expect(out).toEqual({ plugin: null, reason: "unavailable" });
+  });
+
+  it("a 500 from the entitlement server is `unavailable` (no verdict was given)", async () => {
+    const tbl = { [`${API}/api/v1/desktop-plugin`]: { ok: false } };
+    const out = await resolvePluginOutcome({ apiBase: API, token: "jwt", cacheDir: cacheDir(), publicKey: pub, now: 1000, fetchImpl: fakeFetch(tbl) });
+    expect(out).toEqual({ plugin: null, reason: "unavailable" });
+  });
+
+  it("logged out (no token) is `unavailable` — being signed out is not a plan verdict", async () => {
+    const out = await resolvePluginOutcome({ apiBase: API, token: null, cacheDir: cacheDir(), publicKey: pub, now: 1000, fetchImpl: fakeFetch(happyTable) });
+    expect(out).toEqual({ plugin: null, reason: "unavailable" });
+  });
+
+  it("an expired cached lease offline is `unavailable`", async () => {
+    const cd = cacheDir();
+    const tbl = { ...happyTable, [`${API}/api/v1/desktop-plugin`]: { ok: true, json: { entitled: true, lease: lease(5000), bundleUrl: BUNDLE } } };
+    await resolvePluginOutcome({ apiBase: API, token: "jwt", cacheDir: cd, publicKey: pub, now: 1000, fetchImpl: fakeFetch(tbl) });
+    const offline = (async () => { throw new Error("offline"); }) as unknown as typeof fetch;
+    const out = await resolvePluginOutcome({ apiBase: API, token: "jwt", cacheDir: cd, publicKey: pub, now: 6000, fetchImpl: offline });
+    expect(out).toEqual({ plugin: null, reason: "unavailable" });
+  });
+
+  it("a missing public key is `unavailable` and never probes the server", async () => {
+    const spy = fakeFetch(happyTable);
+    const calls: string[] = [];
+    const counting = (async (u: string) => { calls.push(String(u)); return spy(u as never); }) as unknown as typeof fetch;
+    const out = await resolvePluginOutcome({ apiBase: API, token: "jwt", cacheDir: cacheDir(), publicKey: "", now: 1000, fetchImpl: counting });
+    expect(out).toEqual({ plugin: null, reason: "unavailable" });
+    expect(calls).toEqual([]);
+  });
+
+  it("resolveDesktopPlugin stays the thin `plugin-or-null` wrapper over the same resolve", async () => {
+    const tbl = { [`${API}/api/v1/desktop-plugin`]: { ok: true, json: { entitled: false } } };
+    expect(await resolveDesktopPlugin({ apiBase: API, token: "jwt", cacheDir: cacheDir(), publicKey: pub, now: 1000, fetchImpl: fakeFetch(tbl) })).toBeNull();
   });
 });

--- a/packages/renderer/src/AgentIndicator.tsx
+++ b/packages/renderer/src/AgentIndicator.tsx
@@ -28,19 +28,30 @@ function QuotaPie({ pct, color }: { pct: number; color: string }): JSX.Element {
  */
 export function AgentIndicator({
   location,
+  working,
   model,
   quota,
   byoKey,
   policy,
   onSetPolicy,
+  localEntitled,
+  onUpgrade,
   localCommand,
 }: {
   location: AgentLocation | null;
+  /** The agent holds the turn. A turn-based local agent's CLI exits between turns, so it stops
+   *  being a presence peer for exactly as long as it is busy — without this the badge reads
+   *  "disconnected" precisely while the agent works, and green only while it idles. */
+  working?: boolean;
   model?: string;
   quota?: { usedPct: number; overage: boolean };
   byoKey?: boolean;
   policy?: AgentPolicy;
   onSetPolicy?: (p: AgentPolicy) => void | Promise<void>;
+  /** False when the host's plan doesn't include a local agent here; undefined ⇒ not gated. */
+  localEntitled?: boolean;
+  /** Host-supplied upgrade path for the gated case. */
+  onUpgrade?: () => void | Promise<void>;
   /** Host-supplied command a local agent runs to serve this doc (cloud); shown under "local". */
   localCommand?: string;
 }): JSX.Element {
@@ -48,6 +59,8 @@ export function AgentIndicator({
   const [open, setOpen] = useState(false);
   const [copied, setCopied] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
+  // Only an explicit `false` gates: hosts that don't gate the feature leave it undefined.
+  const localGated = localEntitled === false;
   // What the human pastes to their coding agent: an instruction (with the connect command inlined),
   // not a command for the human to run themselves. Copy carries the FULL text; the box shows a
   // middle-elided preview (the full bootstrap — check/install/login/connect — is long).
@@ -72,11 +85,14 @@ export function AgentIndicator({
     { value: "local", label: t("agent.waitLocal") },
     { value: "manual", label: t("agent.dontConnect") },
   ];
-  // The label next to the icon: `remote (model)` / `local (model)` / `disconnected`.
+  // The label next to the icon: `remote (model)` / `local (model)` / `working` / `disconnected`.
+  // "working" wins over a null location: an agent that holds the turn is attached by definition,
+  // whatever its socket is doing.
   const labelFor = (loc: AgentLocation | null, m?: string): string => {
-    if (loc === "cloud") return `${t("agent.remote")}${m ? ` (${m})` : ""}`;
-    if (loc === "local") return `${t("agent.local")}${m ? ` (${m})` : ""}`;
-    return t("agent.disconnected");
+    const suffix = `${m ? ` (${m})` : ""}${working ? ` · ${t("agent.working")}` : ""}`;
+    if (loc === "cloud") return `${t("agent.remote")}${suffix}`;
+    if (loc === "local") return `${t("agent.local")}${suffix}`;
+    return working ? `${t("agent.working")}` : t("agent.disconnected");
   };
   useEffect(() => {
     const onDown = (e: MouseEvent) => {
@@ -101,7 +117,10 @@ export function AgentIndicator({
         : "var(--accent)";
     icon = quota ? <QuotaPie pct={quota.usedPct} color={color} /> : <span className="ap-agent-dot" style={{ background: color }} aria-hidden="true" />;
   } else if (location === "local") {
-    icon = <span className="ap-agent-dot ap-agent-local" aria-hidden="true" />;
+    icon = <span className={`ap-agent-dot ap-agent-local${working ? " ap-agent-working" : ""}`} aria-hidden="true" />;
+  } else if (working) {
+    // No peer, but the agent holds the turn — amber, not red. Red here would mean "nobody is coming".
+    icon = <span className="ap-agent-dot ap-agent-working" aria-hidden="true" />;
   } else {
     icon = <span className="ap-agent-dot ap-agent-off" aria-hidden="true" />;
   }
@@ -148,9 +167,20 @@ export function AgentIndicator({
               ))}
             </div>
           )}
-          {/* "Wait for my local agent" → an instruction the human pastes to their coding agent so it
-              connects to + serves this cloud doc (the connect command is inlined). */}
-          {policy === "local" && agentMessage && (
+          {/* "Wait for my local agent" → either the connect instruction, or — when the host's plan
+              doesn't include it — the reason and a way to upgrade. Showing the command to someone
+              who can't use it is what produced a CLI that attaches and then silently can't edit. */}
+          {policy === "local" && localGated && (
+            <div className="ap-agent-localcmd ap-agent-upsell">
+              <div className="ap-agent-localcmd-hint">{t("agent.localLocked")}</div>
+              {onUpgrade && (
+                <button className="ap-agent-upgrade" onClick={() => void onUpgrade()}>
+                  {t("agent.seePlans")}
+                </button>
+              )}
+            </div>
+          )}
+          {policy === "local" && !localGated && agentMessage && (
             <div className="ap-agent-localcmd">
               <div className="ap-agent-localcmd-hint">{t("agent.localCmdHint")}</div>
               <div className="ap-agent-localcmd-row">

--- a/packages/renderer/src/AgentIndicator.tsx
+++ b/packages/renderer/src/AgentIndicator.tsx
@@ -139,9 +139,13 @@ export function AgentIndicator({
       {open && (
         <div className="ap-agent-menu" role="menu">
           <div className="ap-agent-detail">
+            {/* An agent that holds the turn is attached, so the opened menu must not contradict the
+                button by claiming "No agent connected" while the button reads "working". */}
             {location
-              ? `${t("agent.detail", { where: location === "cloud" ? t("agent.whereCloud") : t("agent.whereLocal") })}${model ? ` · ${model}` : ""}`
-              : t("agent.none")}
+              ? `${t("agent.detail", { where: location === "cloud" ? t("agent.whereCloud") : t("agent.whereLocal") })}${model ? ` · ${model}` : ""}${working ? ` · ${t("agent.working")}` : ""}`
+              : working
+                ? `${t("agent.detail", { where: t("agent.whereLocal") })} · ${t("agent.working")}`
+                : t("agent.none")}
             {quota && (
               <div className="ap-agent-quota">{`${t("agent.plan", { pct: Math.round(quota.usedPct * 100) })}${quota.overage ? ` ${t("agent.overIncluded")}` : ""}`}</div>
             )}

--- a/packages/renderer/src/AgentIndicator.tsx
+++ b/packages/renderer/src/AgentIndicator.tsx
@@ -143,8 +143,11 @@ export function AgentIndicator({
                 button by claiming "No agent connected" while the button reads "working". */}
             {location
               ? `${t("agent.detail", { where: location === "cloud" ? t("agent.whereCloud") : t("agent.whereLocal") })}${model ? ` · ${model}` : ""}${working ? ` · ${t("agent.working")}` : ""}`
-              : working
-                ? `${t("agent.detail", { where: t("agent.whereLocal") })} · ${t("agent.working")}`
+              : // Busy with no peer: report the state WITHOUT claiming where it runs. `working` carries
+                // no location, and inferring "your machine" would only be right because a local CLI
+                // happens to be the one agent shaped this way today.
+                working
+                ? `${t("agent.workingNoWhere")}`
                 : t("agent.none")}
             {quota && (
               <div className="ap-agent-quota">{`${t("agent.plan", { pct: Math.round(quota.usedPct * 100) })}${quota.overage ? ` ${t("agent.overIncluded")}` : ""}`}</div>

--- a/packages/renderer/src/App.tsx
+++ b/packages/renderer/src/App.tsx
@@ -1567,6 +1567,7 @@ export function App(props: EditorProps = {}): JSX.Element {
         }
         forceSettingsOpen={forceSettingsOpen}
         locked={editingLocked}
+        agentThinking={agentThinking}
         nav={
           typeof hostApi().navigate === "function"
             ? { canBack: navState.canBack, canForward: navState.canForward, onBack: () => void hostApi().navigate?.("back"), onForward: () => void hostApi().navigate?.("forward") }
@@ -2187,6 +2188,8 @@ function TopBar(props: {
   onReplayTutorial?: () => void; // settings menu: re-run the first-run tour
   forceSettingsOpen?: boolean; // onboarding: hold the ⚙ menu open on the settings step
   locked: boolean;
+  /** The agent holds the turn (we handed it over and it hasn't reported back). */
+  agentThinking?: boolean;
   nav?: { canBack: boolean; canForward: boolean; onBack: () => void; onForward: () => void };
 }): JSX.Element {
   const { cadence, acceptance, panes, onMode } = props;
@@ -2197,7 +2200,12 @@ function TopBar(props: {
   // flagged `agentAvailable` (entitled + auto policy), OR an agent is connected (`agentLocation`, e.g.
   // a local CLI). Only when neither holds is there genuinely no agent. The desktop's local agent is
   // implicit (not presence-aware), so these stay enabled there.
-  const noAgent = profile?.presenceAware === true && profile.agentAvailable !== true && profile.agentLocation == null;
+  //
+  // A turn-based local agent is NOT a persistent peer either: its CLI exits between turns, so
+  // `agentLocation` goes null for exactly as long as the agent is busy working. Treat "we handed it
+  // the turn and it hasn't answered" as an attached agent, or Finish-turn greys out mid-handoff and
+  // the human is stranded by the very act of handing over.
+  const noAgent = profile?.presenceAware === true && profile.agentAvailable !== true && profile.agentLocation == null && props.agentThinking !== true;
   const noAgentTitle = noAgent ? t("topbar.noAgent") : undefined;
   return (
     <header className="ap-topbar">
@@ -2304,11 +2312,14 @@ function TopBar(props: {
       {profile?.presenceAware && (
         <AgentIndicator
           location={profile.agentLocation}
+          working={props.agentThinking === true}
           model={profile.agentModel}
           quota={profile.agentQuota}
           byoKey={profile.agentByoKey}
           policy={profile.agentPolicy}
           onSetPolicy={profile.onSetAgentPolicy}
+          localEntitled={profile.agentLocalEntitled}
+          onUpgrade={profile.onUpgrade}
           localCommand={hostApi().localAgentCommand}
         />
       )}

--- a/packages/renderer/src/App.tsx
+++ b/packages/renderer/src/App.tsx
@@ -563,8 +563,16 @@ export function App(props: EditorProps = {}): JSX.Element {
     return () => document.removeEventListener("keydown", onKey);
   }, [composer, findOpen, proposal, reviewOpen, undo, redo, readOnly]);
 
-  // The agent holds the turn (Turn mode, thinking) — this is the lock that offers "take back control".
-  const agentLocked = mode.locksEditor && agentThinking;
+  // The agent holds the turn — this is the lock that offers "take back control".
+  //
+  // Gated on the OUTSTANDING TURN, not on the current cadence. `agentThinking` is set only by Finish
+  // turn, which only renders in a locking mode, so it means exactly "we handed the turn over and the
+  // agent hasn't reported back". Reading `mode.locksEditor` here instead let a Turn→Instant switch
+  // mid-turn drop the lock and reopen the document for editing while the agent was still writing its
+  // revision. Switching cadence expresses a preference for the NEXT turn; it must not retroactively
+  // cancel the hand-off that is already in flight. (A stuck agent is still escapable via "take back
+  // control", which clears `agentThinking` directly.)
+  const agentLocked = agentThinking;
   // Any reason editing is blocked: the agent's turn, OR a host-declared read-only doc. Used to gate
   // all mutation (body edits, comments, accept/apply, finish turn). Read-only is NOT agent-turn, so
   // it must not surface the take-back affordance (see canTakeBack below).

--- a/packages/renderer/src/api.ts
+++ b/packages/renderer/src/api.ts
@@ -142,6 +142,16 @@ export interface ProfileState {
    * is true. Hosts that don't set this fall back to the `agentLocation != null` check.
    */
   agentAvailable?: boolean;
+  /**
+   * True when this host's plan includes attaching a *local* agent to this document. Only a host
+   * that actually gates the feature sets it; `undefined` means "not gated here" (the desktop, where
+   * a local agent on a local file is always available) and is treated as allowed. When false, the
+   * indicator offers {@link onUpgrade} in place of the connect instruction — the renderer never
+   * learns anything about plans or prices, it just asks the host to sell.
+   */
+  agentLocalEntitled?: boolean;
+  /** Host-supplied upgrade path, invoked when a gated feature is clicked. Absent ⇒ no CTA shown. */
+  onUpgrade?: () => void | Promise<void>;
   /** The doc's current agent-provisioning policy. Present + `onSetAgentPolicy` ⇒ the
    *  menu-bar agent indicator renders the connection picker. */
   agentPolicy?: AgentPolicy;

--- a/packages/renderer/src/i18n.tsx
+++ b/packages/renderer/src/i18n.tsx
@@ -189,6 +189,8 @@ export const EN: Catalog = {
   "agent.whereCloud": "cloud",
   "agent.whereLocal": "your machine",
   "agent.detail": "Agent · {where}",
+  // Busy but with no presence peer, so we can't say where it runs — deliberately location-free.
+  "agent.workingNoWhere": "Agent · working",
   "agent.none": "No agent connected",
   "agent.plan": "Plan {pct}%",
   "agent.overIncluded": "— over included",

--- a/packages/renderer/src/i18n.tsx
+++ b/packages/renderer/src/i18n.tsx
@@ -182,6 +182,7 @@ export const EN: Catalog = {
   "agent.dontConnect": "Don't auto-connect",
   "agent.remote": "remote",
   "agent.local": "local",
+  "agent.working": "working",
   "agent.disconnected": "disconnected",
   "agent.title": "Agent: {label}",
   "agent.connectionLabel": "Agent connection — {label}",
@@ -196,7 +197,12 @@ export const EN: Catalog = {
   "agent.atLimit": "Usage limit reached — turns are paused until your plan resets or you upgrade",
   "agent.connection": "Agent connection",
   "agent.localCmdHint": "Paste this to your coding agent:",
-  "agent.localCmdBody": "Collaborate with me on my inplan plan. Check the CLI with `inplan --version` (if missing, install it: `npm i -g inplan`), sign in with `inplan login` if you haven't yet, then run `{cmd}` and work with me through the comments.",
+  // Installs unconditionally rather than only when the CLI is missing: an out-of-date CLI attaches
+  // to a cloud doc and behaves plausibly while lacking the code path the document needs, so
+  // "install it if missing" left the one failure mode that has no symptom.
+  "agent.localCmdBody": "Collaborate with me on my inplan plan. Install or update the CLI with `npm i -g inplan@latest`, sign in with `inplan login` if you haven't yet, then run `{cmd}` and work with me through the comments.",
+  "agent.localLocked": "Connecting your own agent to a cloud document is on Pro and above.",
+  "agent.seePlans": "See plans",
   "agent.copy": "Copy",
   "agent.copied": "Copied",
   // comment rail

--- a/packages/renderer/src/styles.css
+++ b/packages/renderer/src/styles.css
@@ -134,6 +134,12 @@ body {
 .ap-agent-dot { width: 10px; height: 10px; border-radius: 50%; flex: 0 0 auto; }
 .ap-agent-local { background: #2bb673; }   /* agent on your machine */
 .ap-agent-off { background: var(--danger); } /* no agent connected */
+/* Agent holds the turn. A turn-based local agent drops its presence socket while it works, so this
+   covers the window where "no peer" means "busy", not "gone" — amber, and pulsing so it reads as
+   activity rather than a warning. */
+.ap-agent-working { background: #e0a23b; animation: ap-agent-pulse 1.6s ease-in-out infinite; }
+@keyframes ap-agent-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.45; } }
+@media (prefers-reduced-motion: reduce) { .ap-agent-working { animation: none; } }
 .ap-agent-pie { position: relative; width: 14px; height: 14px; border-radius: 50%; flex: 0 0 auto; }
 /* Green "connected" core; only the thin outer band of .ap-agent-pie shows the usage conic. The
    1px box-shadow ring is the button's background colour, leaving a 1px gap between the core and the
@@ -162,6 +168,10 @@ body {
 .ap-agent-localcmd-msg { flex: 1; min-width: 0; font-size: 11px; line-height: 1.45; background: var(--paper); border: 1px solid var(--line); border-radius: 6px; padding: 5px 7px; color: var(--fg); user-select: text; -webkit-user-select: text; }
 .ap-agent-localcmd-copy { flex: 0 0 auto; border: 1px solid var(--line-strong); background: var(--bg); border-radius: 6px; padding: 0 9px; font: inherit; font-size: 11px; cursor: pointer; color: var(--fg); }
 .ap-agent-localcmd-copy:hover { background: var(--accent-soft); }
+/* Same slot as the connect command, when the plan doesn't include a local agent here. */
+.ap-agent-upsell .ap-agent-localcmd-hint { color: var(--fg); line-height: 1.45; }
+.ap-agent-upgrade { width: 100%; border: 1px solid var(--accent); background: var(--accent); color: #fbfaf6; border-radius: 6px; padding: 5px 9px; font: inherit; font-size: 11px; cursor: pointer; }
+.ap-agent-upgrade:hover { filter: brightness(1.06); }
 
 .ap-topbar button, .ap-tabs button { font: inherit; }
 .ap-topbar > button { border: 1px solid var(--line-strong); background: var(--bg); border-radius: 7px; padding: 4px 12px; cursor: pointer; color: var(--fg); }

--- a/packages/renderer/test/AgentIndicator.test.tsx
+++ b/packages/renderer/test/AgentIndicator.test.tsx
@@ -162,8 +162,13 @@ describe("AgentIndicator", () => {
   it("the opened menu says working too, instead of contradicting the button with 'No agent connected'", () => {
     render(<AgentIndicator location={null} working />);
     fireEvent.click(screen.getByRole("button"));
-    expect(document.querySelector(".ap-agent-detail")?.textContent).toMatch(/working/i);
+    const detail = document.querySelector(".ap-agent-detail")?.textContent ?? "";
+    expect(detail).toMatch(/working/i);
     expect(document.body.textContent).not.toMatch(/No agent connected/i);
+    // …but it must not INVENT a location. `working` carries none, and "your machine" would only be
+    // right because a local CLI happens to be the one agent shaped this way today.
+    expect(detail).not.toMatch(/your machine/i);
+    expect(detail).not.toMatch(/cloud/i);
   });
 
   it("the menu keeps saying 'No agent connected' when nothing holds the turn", () => {

--- a/packages/renderer/test/AgentIndicator.test.tsx
+++ b/packages/renderer/test/AgentIndicator.test.tsx
@@ -115,7 +115,7 @@ describe("AgentIndicator", () => {
     // Copies the FULL bootstrap instruction (install check + install + the connect command).
     const copied = writeText.mock.calls[0][0] as string;
     expect(copied).toContain(cmd); // the connect command, in full
-    expect(copied).toContain("npm i -g inplan"); // how to install if missing
+    expect(copied).toContain("npm i -g inplan@latest"); // installs OR updates — an out-of-date CLI fails silently
     expect(copied).toContain("inplan login"); // explicit sign-in step so headless (non-TTY) agents aren't relying on interactive-only auto-login
   });
 
@@ -123,6 +123,69 @@ describe("AgentIndicator", () => {
     render(<AgentIndicator location="local" policy="local" onSetPolicy={vi.fn()} />);
     fireEvent.click(screen.getByRole("button", { name: /agent connection/i }));
     expect(screen.queryByRole("button", { name: /^copy$/i })).toBeNull();
+  });
+
+  // A turn-based local agent's CLI exits between turns, so its presence peer vanishes for exactly as
+  // long as the agent is busy. Presence alone therefore reads "disconnected" while it works and
+  // "connected" only while it idles — inverted. `working` is the third state that fixes that.
+  it("reads 'working', not 'disconnected', when the agent holds the turn with no peer", () => {
+    render(<AgentIndicator location={null} working />);
+    const btn = screen.getByRole("button");
+    expect(btn.textContent).toContain("working");
+    expect(btn.textContent).not.toContain("disconnected");
+    expect(btn.querySelector(".ap-agent-working")).toBeTruthy();
+    expect(btn.querySelector(".ap-agent-off")).toBeNull(); // never the red "nobody is coming" dot
+  });
+
+  it("still reads 'disconnected' when no agent holds the turn", () => {
+    render(<AgentIndicator location={null} />);
+    expect(screen.getByRole("button").textContent).toContain("disconnected");
+    expect(screen.getByRole("button").querySelector(".ap-agent-off")).toBeTruthy();
+  });
+
+  it("keeps the location label and adds 'working' when a peer IS present and busy", () => {
+    render(<AgentIndicator location="local" model="Opus 5" working />);
+    const btn = screen.getByRole("button");
+    expect(btn.textContent).toContain("local (Opus 5)");
+    expect(btn.textContent).toContain("working");
+    expect(btn.querySelector(".ap-agent-working")).toBeTruthy();
+  });
+
+  it("marks a busy cloud agent as working without losing its quota pie", () => {
+    render(<AgentIndicator location="cloud" model="Opus" working quota={{ usedPct: 0.4, overage: false }} />);
+    const btn = screen.getByRole("button");
+    expect(btn.textContent).toContain("remote (Opus)");
+    expect(btn.textContent).toContain("working");
+    expect(btn.querySelector(".ap-agent-pie")).toBeTruthy();
+  });
+
+  // Showing the connect command to someone whose plan can't use it is what produced a CLI that
+  // attaches, consumes turns, and then silently can't edit.
+  it("replaces the connect command with an upgrade CTA when the local agent isn't entitled", () => {
+    const onUpgrade = vi.fn();
+    const cmd = "inplan wait --remote doc-123";
+    render(<AgentIndicator location={null} policy="local" onSetPolicy={vi.fn()} localCommand={cmd} localEntitled={false} onUpgrade={onUpgrade} />);
+    fireEvent.click(screen.getByRole("button", { name: /agent connection/i }));
+    expect(document.body.textContent).not.toContain(cmd);
+    expect(document.body.textContent).toMatch(/Pro and above/i);
+    fireEvent.click(screen.getByRole("button", { name: /see plans/i }));
+    expect(onUpgrade).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the reason but no CTA when the host offers no upgrade path", () => {
+    render(<AgentIndicator location={null} policy="local" onSetPolicy={vi.fn()} localCommand="c" localEntitled={false} />);
+    fireEvent.click(screen.getByRole("button", { name: /agent connection/i }));
+    expect(document.body.textContent).toMatch(/Pro and above/i);
+    expect(screen.queryByRole("button", { name: /see plans/i })).toBeNull();
+  });
+
+  it("only an explicit false gates — an ungated host (undefined) still gets the command", () => {
+    const cmd = "inplan wait --remote doc-9";
+    const { rerender } = render(<AgentIndicator location={null} policy="local" onSetPolicy={vi.fn()} localCommand={cmd} />);
+    fireEvent.click(screen.getByRole("button", { name: /agent connection/i }));
+    expect(screen.getByRole("button", { name: /^copy$/i })).toBeTruthy();
+    rerender(<AgentIndicator location={null} policy="local" onSetPolicy={vi.fn()} localCommand={cmd} localEntitled />);
+    expect(screen.getByRole("button", { name: /^copy$/i })).toBeTruthy();
   });
 
   it("closes the menu on an outside mousedown", () => {

--- a/packages/renderer/test/AgentIndicator.test.tsx
+++ b/packages/renderer/test/AgentIndicator.test.tsx
@@ -159,6 +159,28 @@ describe("AgentIndicator", () => {
     expect(btn.querySelector(".ap-agent-pie")).toBeTruthy();
   });
 
+  it("the opened menu says working too, instead of contradicting the button with 'No agent connected'", () => {
+    render(<AgentIndicator location={null} working />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(document.querySelector(".ap-agent-detail")?.textContent).toMatch(/working/i);
+    expect(document.body.textContent).not.toMatch(/No agent connected/i);
+  });
+
+  it("the menu keeps saying 'No agent connected' when nothing holds the turn", () => {
+    render(<AgentIndicator location={null} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(document.body.textContent).toMatch(/No agent connected/i);
+  });
+
+  it("a busy agent WITH a peer shows both where it runs and that it is working", () => {
+    render(<AgentIndicator location="local" model="Opus 5" working />);
+    fireEvent.click(screen.getByRole("button"));
+    const detail = document.querySelector(".ap-agent-detail")?.textContent ?? "";
+    expect(detail).toMatch(/your machine/i);
+    expect(detail).toMatch(/Opus 5/);
+    expect(detail).toMatch(/working/i);
+  });
+
   // Showing the connect command to someone whose plan can't use it is what produced a CLI that
   // attaches, consumes turns, and then silently can't edit.
   it("replaces the connect command with an upgrade CTA when the local agent isn't entitled", () => {

--- a/packages/renderer/test/App.agentGating.test.tsx
+++ b/packages/renderer/test/App.agentGating.test.tsx
@@ -94,6 +94,27 @@ describe("agent-presence gating of Instant + Finish-turn", () => {
     expect(instantBtn().disabled).toBe(false); // still attached — it is thinking, not absent
   });
 
+  // Switching cadence expresses a preference for the NEXT turn. It must not retroactively cancel a
+  // hand-off already in flight: dropping the lock mid-turn reopens the document for editing while
+  // the agent is still writing its revision.
+  it("keeps the editor locked across a Turn→Instant switch while the agent still holds the turn", async () => {
+    const live = mutableProfile({ user: { name: "Diane" }, agentLocation: "local", presenceAware: true, actions: [] });
+    await renderApp(undefined, live.controller);
+    fireEvent.click(finishBtn());
+    await waitFor(() => expect(document.body.textContent).toMatch(/Agent is thinking/i));
+
+    // Save is disabled purely by the editor lock, so it is the honest probe for it.
+    const saveBtn = () => screen.getByRole("button", { name: /save/i }) as HTMLButtonElement;
+    expect(saveBtn().disabled).toBe(true);
+
+    fireEvent.click(instantBtn()); // change cadence mid-turn
+    // Still locked: the outstanding turn, not the current cadence, decides.
+    // The switch must actually land, or the assertion below proves nothing: without the fix,
+    // `locksEditor` would go false here and Save would become enabled.
+    await waitFor(() => expect(instantBtn().className).toContain("active"));
+    expect(saveBtn().disabled).toBe(true);
+  });
+
   it("still disables them when the agent is absent and no turn is outstanding", async () => {
     const live = mutableProfile({ user: { name: "Diane" }, agentLocation: "local", presenceAware: true, actions: [] });
     await renderApp(undefined, live.controller);

--- a/packages/renderer/test/App.agentGating.test.tsx
+++ b/packages/renderer/test/App.agentGating.test.tsx
@@ -5,7 +5,7 @@
 // when no agent is attached (nothing to hand the turn to). The desktop's local
 // agent is implicit (not presence-aware), so those controls stay enabled there.
 
-import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { forwardRef, useImperativeHandle } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createMemoryApi } from "../src/memoryApi";
@@ -22,17 +22,38 @@ vi.mock("../src/SourceEditor", () => ({
 const DOC = "# Plan\n\nHello world.\n\n<!--inplan v1\n[]\n-->\n";
 const profileOf = (state: ProfileState): ProfileController => ({ get: () => state, subscribe: () => () => {} });
 
+/** A ProfileController whose snapshot can change mid-test, so a presence drop is observable the way
+ *  the real host delivers it (useSyncExternalStore needs a NEW object identity per change). */
+function mutableProfile(initial: ProfileState) {
+  let state = initial;
+  const subs = new Set<(s: ProfileState) => void>();
+  return {
+    controller: {
+      get: () => state,
+      subscribe: (cb: (s: ProfileState) => void) => {
+        subs.add(cb);
+        return () => void subs.delete(cb);
+      },
+    } as ProfileController,
+    set(patch: Partial<ProfileState>) {
+      state = { ...state, ...patch };
+      subs.forEach((cb) => cb(state));
+    },
+  };
+}
+
 beforeEach(() => {
   localStorage.clear();
   document.body.innerHTML = '<div id="root"></div>';
 });
 afterEach(cleanup);
 
-async function renderApp(profile?: ProfileState) {
+async function renderApp(profile?: ProfileState, controller?: ProfileController) {
   const session = createMemoryApi({ content: DOC });
   session.api.extraModes = [INSTANT_TEST_MODE]; // instant is host-injected (open-core ships turn-only)
   const api = session.api as unknown as { profile?: ProfileController };
-  if (profile) api.profile = profileOf(profile);
+  if (controller) api.profile = controller;
+  else if (profile) api.profile = profileOf(profile);
   (window as unknown as { api: unknown }).api = api;
   const { App } = await import("../src/App");
   render(<App />);
@@ -53,6 +74,32 @@ describe("agent-presence gating of Instant + Finish-turn", () => {
     await renderApp({ user: { name: "Diane" }, agentLocation: "cloud", presenceAware: true, actions: [] });
     expect(instantBtn().disabled).toBe(false);
     expect(finishBtn().disabled).toBe(false);
+  });
+
+  // Handing the turn over is what drops a turn-based local agent's presence peer: its CLI exits so
+  // the agent can think, and only re-attaches on the next `wait`. Gating purely on presence then
+  // disables the agent-dependent controls for exactly as long as the agent is busy — treating "busy"
+  // as "gone". (Finish-turn is separately, and correctly, disabled by the turn lock here; the cadence
+  // toggle is not, which makes it the honest witness for the presence-only bug.)
+  it("keeps agent-dependent controls enabled while the agent works with no presence peer", async () => {
+    const live = mutableProfile({ user: { name: "Diane" }, agentLocation: "local", presenceAware: true, actions: [] });
+    await renderApp(undefined, live.controller);
+    expect(instantBtn().disabled).toBe(false);
+
+    fireEvent.click(finishBtn()); // hand the turn over — the agent now holds it
+    await waitFor(() => expect(document.body.textContent).toMatch(/Agent is thinking/i));
+
+    live.set({ agentLocation: null }); // its CLI exited to do the work; the presence peer is gone
+    await waitFor(() => expect(screen.getByRole("button", { name: /agent connection/i }).textContent).toMatch(/working/i));
+    expect(instantBtn().disabled).toBe(false); // still attached — it is thinking, not absent
+  });
+
+  it("still disables them when the agent is absent and no turn is outstanding", async () => {
+    const live = mutableProfile({ user: { name: "Diane" }, agentLocation: "local", presenceAware: true, actions: [] });
+    await renderApp(undefined, live.controller);
+    live.set({ agentLocation: null }); // dropped without ever being handed a turn
+    await waitFor(() => expect(instantBtn().disabled).toBe(true));
+    expect(screen.getByRole("button", { name: /agent connection/i }).textContent).toMatch(/disconnected/i);
   });
 
   it("leaves them enabled on a non-presence-aware host (desktop, implicit local agent)", async () => {


### PR DESCRIPTION
Three related fixes to how a **local** agent attaches to a **cloud** document. Local files are untouched throughout: a local agent on a local file isn't gated, isn't presence-aware, and needs no plugin.

## 1. `wait --remote` no longer attaches when it can't serve the doc

The turn-based `live.store` path under `runRemote` was built for the managed cloud agent, which holds the body in memory and never needs a file. An out-of-process local agent can only read and write files, and the only thing that materializes one is the live-collab gate.

Without that gate the CLI attached anyway. It consumed the human's turns while provably unable to read or edit a single byte, and exited 0 the entire time — the failure mode with no symptom.

It now stops and explains itself. The two reasons are kept strictly apart, because telling a paying customer to upgrade because a server hiccuped is the worst outcome available here:

| reason | exit | when |
|---|---|---|
| `unentitled` | 4 | **only** an explicit `entitled: false` from the server — the one definitive answer we ever get about a plan |
| `unavailable` | 5 | logged out, offline, server error, unverifiable bundle. Says nothing about the plan, and says so |

`resolvePluginOutcome` / `loadPluginGateOutcome` carry the reason. The existing `resolveDesktopPlugin` / `loadPluginGate` remain as plugin-or-null wrappers for callers that just run without the perk, so nothing else changes shape.

Where there's a local file behind a promoted doc, the message also offers `inplan demote` as the free escape hatch.

## 2. The agent indicator no longer reads "disconnected" while the agent works

A turn-based local agent's CLI **exits between turns** — that's how the protocol works — so its presence peer vanishes for exactly as long as the agent is busy. Deriving attachment from live presence alone inverted the badge: red while working, green only while idle.

The same `agentLocation == null` also fed `noAgent`, so handing the turn over disabled the controls that require having an agent.

`agentThinking` already tracked this correctly for the "Agent is thinking…" lock. It now also drives a third badge state — amber, pulsing, `working` — and is folded into the `noAgent` check. `prefers-reduced-motion` drops the pulse.

This mirrors what #86 already did for the managed cloud agent, which is event-driven and likewise has no persistent peer.

## 3. The connect instruction updates the CLI instead of only installing it

`agent.localCmdBody` said "install it if missing". An out-of-date CLI is not missing, so nothing installed — it attached to a cloud doc and behaved plausibly while lacking the code path the doc needed. This is exactly how the bug in §1 stayed invisible.

It now runs `npm i -g inplan@latest` unconditionally, and `wait --remote` warns when the running CLI is behind the registry. The check is cached (6h TTL, clock-rewind safe), so a per-turn call costs one registry lookup per six hours rather than one per turn.

## Product note

This makes the local agent on cloud documents a **Pro+** feature, with free accounts getting the reason and an upgrade path instead of a command they can't use. That's already what `handleDesktopCollab` enforced; what was missing was saying so. Note this reverses the ladder documented in `entitlements/src/index.ts` ("Free = local agent only") — the companion cloud PR updates that.

## Tests

- `pluginFetch.test.ts` — every failure mode pinned to a reason; an outage is never `unentitled`
- `pluginGate.test.ts` — outcome propagation, including entitled-but-no-CLI-entry
- `remoteGating.test.ts` — the two messages, the exit codes, the `demote` hint only when there's a file, one JSON object on stdout
- `updateStaleness.test.ts` — warns/stays quiet, TTL cache, clock rewind, corrupt + unwritable cache
- `AgentIndicator.test.tsx` — the third state, and the upsell replacing the connect command
- `App.agentGating.test.tsx` — controls stay enabled while the agent works with no peer, and still gate when it's genuinely absent

Full suite: 1042 passed, 2 skipped. Coverage 96.34% (gate ≥95%).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/76?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - CLI warns when a newer version is available, using cached checks.
  - Remote execution provides distinct upgrade and temporary-unavailability guidance.
  - Local-agent access displays entitlement status and upgrade options.
  - Agent activity is shown with a working indicator, including handoffs.
  - Live collaboration synchronizes local work and preserves cloud proposals.
- **Bug Fixes**
  - Prevented unavailable or unauthorized services from being treated as usable.
  - Preserved controls during active agent work while disabling them when unavailable.
  - Ensured CLI JSON output is flushed before exiting.
- **Documentation**
  - Updated installation guidance to use the latest release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->