### PR TITLE
Stop a failed token refresh from revoking the session and killing the wait

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -453,6 +453,17 @@ async function waitCycle(backend: WaitBackend, explicitCursor: number | null, co
   const isActionable = wakePredicate(mode.wake);
   const result = await waitForActions({ channel, cursor, debounceMs, pollMs, isActionable, token: lockToken });
 
+  // The wait gave up after a streak of failed polls — an expired session is the common cause. Report
+  // it as a status the agent can act on and exit non-zero. It used to reach here as an unhandled
+  // rejection that killed the process mid-poll: a stack trace on stderr, nothing on stdout.
+  if (result.failed) {
+    backend.logExit("poll_failed");
+    process.stderr.write(`inplan: lost contact with the document (${result.failed.message}).\n  If your session expired, run \`inplan login\` and re-attach.\n`);
+    output({ status: "wait_failed", message: result.failed.message });
+    exitAfterFlush(EXIT_WAIT_FAILED);
+    return "exiting";
+  }
+
   // Superseded: a newer waiter owns the doc now. Step down quietly without
   // advancing the cursor (the live waiter handles it).
   if (result.superseded) {
@@ -639,6 +650,8 @@ function stalenessCache(): { readCache: () => string | null; writeCache: (v: str
 export const EXIT_UPGRADE_REQUIRED = 4;
 /** `wait --remote` when we couldn't get a verified answer (offline / server error / bad bundle). */
 export const EXIT_PLUGIN_UNAVAILABLE = 5;
+/** A wait that gave up after repeated poll failures (usually an expired session). */
+export const EXIT_WAIT_FAILED = 6;
 
 /**
  * Explain, to a human and to the coding agent reading our JSON, why we can't serve this cloud doc.
@@ -1952,8 +1965,19 @@ function isProgramEntry(): boolean {
   }
 }
 if (isProgramEntry()) {
+  // Backstop: stdout is the agent's JSON channel, so NOTHING may reach it as a raw Node stack trace.
+  // An unhandled rejection anywhere (a stray promise in a poll loop, a listener callback) otherwise
+  // kills the process under Node's default `--unhandled-rejections=throw`, leaving the agent with an
+  // exit code, a stack trace on stderr, and no parseable result at all.
+  process.on("unhandledRejection", (reason) => {
+    const message = reason instanceof Error ? reason.message : String(reason);
+    process.stderr.write(`inplan: unexpected error — ${message}\n`);
+    output({ status: "internal_error", message });
+    exitAfterFlush(1);
+  });
   main().catch((err) => {
     process.stderr.write(`inplan: ${(err as Error).message}\n`);
-    process.exit(1);
+    output({ status: "internal_error", message: (err as Error).message });
+    exitAfterFlush(1);
   });
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1969,7 +1969,13 @@ if (isProgramEntry()) {
   // An unhandled rejection anywhere (a stray promise in a poll loop, a listener callback) otherwise
   // kills the process under Node's default `--unhandled-rejections=throw`, leaving the agent with an
   // exit code, a stack trace on stderr, and no parseable result at all.
+  // Latch: `exitAfterFlush` only SCHEDULES the exit, so concurrent rejections would each emit their
+  // own JSON before the process actually goes — breaking the one-object-per-run stdout contract the
+  // agent parses. First one wins; the rest are dropped.
+  let exitingForUnhandledRejection = false;
   process.on("unhandledRejection", (reason) => {
+    if (exitingForUnhandledRejection) return;
+    exitingForUnhandledRejection = true;
     const message = reason instanceof Error ? reason.message : String(reason);
     process.stderr.write(`inplan: unexpected error — ${message}\n`);
     output({ status: "internal_error", message });

--- a/packages/cli/src/cliAuth.ts
+++ b/packages/cli/src/cliAuth.ts
@@ -235,13 +235,19 @@ async function reuseCached(auth: AuthFile, skewS = ACCESS_SKEW_S): Promise<Authe
   return error || !data.session ? null : { db, session: data.session };
 }
 
-export async function authedSession(): Promise<AuthedSession | null> {
+/** Proactive margin for a LONG-LIVED `wait`: refresh this far before expiry so a failure has room to
+ *  retry. The 2-minute {@link ACCESS_SKEW_S} leaves ~2 minutes of budget, which is how a single bad
+ *  refresh became a dead session. One-shot commands keep the small skew — they exit immediately, and
+ *  a wide margin there would only rotate the single-use token more often than necessary. */
+export const LIVE_REFRESH_SKEW_S = 10 * 60;
+
+export async function authedSession(skewS = ACCESS_SKEW_S): Promise<AuthedSession | null> {
   const cached = loadAuth();
   if (!cached) return null;
 
   // Fast path — reuse a still-valid access token: no refresh, no rotation, no lock. This is what
   // makes concurrent `inplan` processes safe (they never touch the single-use refresh token).
-  const reused = await reuseCached(cached);
+  const reused = await reuseCached(cached, skewS);
   if (reused) return reused;
 
   // Slow path — the cached token is missing/expiring: refresh (which rotates the refresh token)
@@ -250,7 +256,7 @@ export async function authedSession(): Promise<AuthedSession | null> {
   const locked = await withAuthLock<AuthedSession | null>(async ({ stillMine }) => {
     const auth = loadAuth();
     if (!auth) return null;
-    const fresh = await reuseCached(auth); // a peer may have refreshed while we waited for the lock
+    const fresh = await reuseCached(auth, skewS); // a peer may have refreshed while we waited for the lock
     if (fresh) return fresh;
 
     // Fence the single-use rotation: if we were paused past staleMs and reclaimed, bail rather than
@@ -261,11 +267,21 @@ export async function authedSession(): Promise<AuthedSession | null> {
     const { data, error } = await db.auth.refreshSession({ refresh_token: auth.refreshToken });
     if (error || !data.session) return null;
 
+    // A refresh response with no rotated token is anomalous, and the old fallback (`|| auth.refreshToken`)
+    // hid it in the most damaging way: rotation had almost certainly happened server-side, so we'd
+    // persist a CONSUMED token, look healthy for the rest of the access token's hour, and then fail
+    // every refresh forever. Treat it as a failed refresh instead — we keep the stored token untouched,
+    // so a server that genuinely doesn't rotate stays usable on the next attempt.
+    if (!data.session.refresh_token) {
+      process.stderr.write("inplan: refresh returned no new refresh token; keeping the stored one and retrying rather than persisting a possibly-spent token\n");
+      return null;
+    }
+
     // Persist the rotated refresh token + the new access token (& expiry) so the fast path can
     // reuse it, and `whoami` has an identity without another round-trip.
     saveAuth({
       ...auth,
-      refreshToken: data.session.refresh_token || auth.refreshToken,
+      refreshToken: data.session.refresh_token,
       accessToken: data.session.access_token,
       ...(data.session.expires_at ? { expiresAt: data.session.expires_at } : {}),
       ...(data.session.user?.email ? { email: data.session.user.email } : {}),
@@ -310,8 +326,8 @@ export interface RemoteBackend {
  * Bind an authenticated client to one cloud document. Returns null when not
  * logged in (the caller prints "run `inplan login`").
  */
-export async function remoteBackend(docId: string, consumerId = "cli-agent"): Promise<RemoteBackend | null> {
-  const s = await authedSession();
+export async function remoteBackend(docId: string, consumerId = "cli-agent", skewS?: number): Promise<RemoteBackend | null> {
+  const s = await authedSession(skewS);
   if (!s) return null;
   return {
     db: s.db,
@@ -339,20 +355,38 @@ export interface LiveRemoteBackend {
   /** The freshest access token (for presence/websocket re-auth), or null if the session is gone. */
   tokenNow(): string | null;
 }
+/** Backoff after a failed re-mint. The poll loop calls through here every `pollMs` (200ms), so an
+ *  unthrottled retry replays the SAME single-use refresh token hundreds of times a minute — which is
+ *  how GoTrue's reuse detection gets tripped and the whole token family revoked. A failing refresh
+ *  must therefore get slower, not faster. */
+const REFRESH_BACKOFF_BASE_MS = 1_000;
+const REFRESH_BACKOFF_MAX_MS = 60_000;
+/** Exported for the test that pins the schedule. */
+export const refreshBackoffMs = (failures: number): number => Math.min(REFRESH_BACKOFF_BASE_MS * 2 ** Math.max(0, failures - 1), REFRESH_BACKOFF_MAX_MS);
+
 export function liveRemoteBackend(docId: string, consumerId = "cli-agent"): LiveRemoteBackend {
   let inner: RemoteBackend | null = null;
   let expiresAt = 0; // the cached inner's access-token expiry (unix seconds)
   let inflight: Promise<RemoteBackend | null> | null = null; // the single in-progress re-mint, if any
+  let failures = 0; // consecutive failed re-mints, driving the backoff
+  let retryAfterMs = 0; // epoch ms before which we must NOT touch the refresh token again
   const fresh = async (): Promise<RemoteBackend | null> => {
     const now = Math.floor(Date.now() / 1000);
-    if (inner && expiresAt - now > ACCESS_SKEW_S) return inner; // cached token still valid — reuse
+    // Refresh well BEFORE expiry (10 min, not 2) so a failure has a real retry budget instead of one
+    // shot at the cliff.
+    if (inner && expiresAt - now > LIVE_REFRESH_SKEW_S) return inner; // cached token still valid — reuse
+    // Cooling off after a failure: serve the cached client while its token is genuinely unexpired,
+    // and otherwise report unavailable WITHOUT another rotation attempt.
+    if (Date.now() < retryAfterMs && !inflight) return inner && expiresAt > now ? inner : null;
     // Coalesce concurrent re-mints into ONE refresh: every channel/store call routes through here, so
     // without this several could each acquire the lock and rotate the refresh token in series. A
     // re-mint goes through remoteBackend()→authedSession(), which re-reads auth.json INSIDE the lock —
     // so it always starts from the freshest persisted token even if another process just rotated it.
-    inflight ??= remoteBackend(docId, consumerId)
+    inflight ??= remoteBackend(docId, consumerId, LIVE_REFRESH_SKEW_S)
       .then((b) => {
         if (b) {
+          failures = 0;
+          retryAfterMs = 0;
           inner = b;
           // Trust the persisted expiry; if a session somehow carried none, assume a short validity so
           // we reuse rather than re-mint on every call, while still re-checking soon.
@@ -364,6 +398,8 @@ export function liveRemoteBackend(docId: string, consumerId = "cli-agent"): Live
         // doesn't drop a valid session. Otherwise (another process logged out ⇒ no creds, or the token
         // expired) DISCARD it: clear inner/expiresAt so tokenNow()/subscribe(), which bypass need(),
         // can't keep serving a stale/expired/revoked client, and callers get a clean "unavailable".
+        failures += 1;
+        retryAfterMs = Date.now() + refreshBackoffMs(failures);
         const stillLoggedIn = loadAuth() !== null;
         if (stillLoggedIn && inner && expiresAt > Math.floor(Date.now() / 1000)) return inner;
         inner = null;

--- a/packages/cli/src/wait.ts
+++ b/packages/cli/src/wait.ts
@@ -13,6 +13,30 @@ export const DEFAULT_ERROR_GRACE_MS = 5 * 60_000;
  *  means "unknown", which must not end a wait, but must not freeze it either. */
 export const DEFAULT_POLL_TIMEOUT_MS = 30_000;
 
+/** Tracks whether a previously timed-out request is STILL running.
+ *
+ *  `withTimeout` abandons the caller's view of a request; it cannot cancel the request itself,
+ *  because `ControlChannel` exposes no `AbortSignal` (adding one reaches into `@inplan/core` and the
+ *  Supabase backend — worth doing, but not in this change). Without this gate each timeout would
+ *  immediately fire a duplicate while its predecessor was still in flight, stacking requests against
+ *  a service that is, by hypothesis, already struggling. */
+function inFlightGate(): { busy: () => boolean; run: <T>(start: () => Promise<T>, ms: number) => Promise<T> } {
+  let pending = 0;
+  return {
+    busy: () => pending > 0,
+    run: <T,>(start: () => Promise<T>, ms: number): Promise<T> => {
+      pending += 1;
+      const underlying = start();
+      // Settle-tracking only; the rejection is surfaced by the race below, not here.
+      void underlying.then(
+        () => (pending -= 1),
+        () => (pending -= 1),
+      );
+      return withTimeout(underlying, ms);
+    },
+  };
+}
+
 /** Reject if `p` hasn't settled within `ms`. The timer is always cleared, so a resolved poll never
  *  leaves a pending handle holding the process open. */
 async function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
@@ -114,6 +138,10 @@ export function waitForActions(opts: WaitOptions): Promise<WaitResult> {
     let busy = false;
     let done = false;
     let failingSince: number | null = null; // when the current unbroken failure run started
+    // One gate per call site: a stalled read must not block the lock probe, or vice versa.
+    const reads = inFlightGate();
+    const locks = inFlightGate();
+    const presences = inFlightGate();
 
     const cleanup = () => {
       clearInterval(timer);
@@ -135,16 +163,25 @@ export function waitForActions(opts: WaitOptions): Promise<WaitResult> {
     // Channel reads are async; guard against overlapping ticks and post-resolve work.
     const tick = async () => {
       if (busy || done) return;
+      // A previous read timed out but is still running: issuing another would stack duplicates on a
+      // service that is evidently struggling. Skip this tick, and keep the failure run going so the
+      // grace budget still advances toward giving up rather than stalling silently.
+      if (reads.busy()) {
+        const at = now();
+        failingSince ??= at;
+        if (at - failingSince >= errorGraceMs) finish({ entries: [], cursor: opts.cursor, failed: new Error("polls timed out and are still in flight") });
+        return;
+      }
       busy = true;
       try {
-        const { entries, cursor } = await withTimeout(ch.readSince(opts.cursor), pollTimeoutMs);
+        const { entries, cursor } = await reads.run(() => ch.readSince(opts.cursor), pollTimeoutMs);
         if (done) return;
 
         // Single-waiter lock: if a newer waiter claimed the doc, step down so only
         // one waiter is ever live. A read blip is treated as "still ours".
         if (opts.token) {
           try {
-            if (await withTimeout(ch.isSuperseded(opts.token), pollTimeoutMs)) {
+            if (!locks.busy() && (await locks.run(() => ch.isSuperseded(opts.token!), pollTimeoutMs))) {
               finish({ entries, cursor, superseded: true });
               return;
             }
@@ -156,14 +193,18 @@ export function waitForActions(opts: WaitOptions): Promise<WaitResult> {
         // Editor liveness: once we've seen the editor present, exit if it goes
         // away — so a wait never lingers as a zombie after the window is gone.
         if (watchEditor) {
-          let alive = false;
+          // UNKNOWN and FALSE are different answers. `alive` starting at `false` meant a presence
+          // call that threw was read as "the editor is gone" — and once this poll gained a timeout,
+          // a mere 30s stall could end a live session with `editorGone` after a single earlier
+          // success. Only a presence read that actually returned `false` may end the wait.
+          let alive: boolean | undefined;
           try {
-            alive = await withTimeout(ch.presence(), pollTimeoutMs);
+            if (!presences.busy()) alive = await presences.run(() => ch.presence(), pollTimeoutMs);
           } catch {
             /* presence unknown — keep waiting */
           }
-          if (alive) sawEditorAlive = true;
-          else if (sawEditorAlive) {
+          if (alive === true) sawEditorAlive = true;
+          else if (alive === false && sawEditorAlive) {
             finish({ entries, cursor, editorGone: true });
             return;
           }

--- a/packages/cli/src/wait.ts
+++ b/packages/cli/src/wait.ts
@@ -2,6 +2,10 @@
 
 import { LogEventType, type ControlChannel, type LogEntry } from "@inplan/core/node";
 
+/** How long a wait tolerates CONTINUOUS poll failure before giving up. Exported so the test that
+ *  claims it outlasts a full refresh cooldown asserts the REAL value rather than a copy of it. */
+export const DEFAULT_ERROR_GRACE_MS = 5 * 60_000;
+
 export interface WaitResult {
   /** Set when the wait gave up after repeated poll failures (expired session, network gone).
    *  A wait must END on this, never die — the agent's channel is JSON, not a stack trace. */
@@ -70,7 +74,7 @@ export function waitForActions(opts: WaitOptions): Promise<WaitResult> {
   const pollMs = opts.pollMs ?? 200;
   const isActionable = opts.isActionable ?? defaultActionable;
   const watchEditor = opts.watchEditor ?? true;
-  const errorGraceMs = opts.errorGraceMs ?? 5 * 60_000;
+  const errorGraceMs = opts.errorGraceMs ?? DEFAULT_ERROR_GRACE_MS;
   const now = opts.now ?? Date.now;
   const ch = opts.channel;
 

--- a/packages/cli/src/wait.ts
+++ b/packages/cli/src/wait.ts
@@ -6,6 +6,26 @@ import { LogEventType, type ControlChannel, type LogEntry } from "@inplan/core/n
  *  claims it outlasts a full refresh cooldown asserts the REAL value rather than a copy of it. */
 export const DEFAULT_ERROR_GRACE_MS = 5 * 60_000;
 
+/** How long a single poll may take before it is abandoned. `SupabaseControlChannel.readSince` has no
+ *  client-side timeout, so without this a stalled request pins `busy` and the wait hangs. */
+export const DEFAULT_POLL_TIMEOUT_MS = 30_000;
+
+/** Reject if `p` hasn't settled within `ms`. The timer is always cleared, so a resolved poll never
+ *  leaves a pending handle holding the process open. */
+async function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      p,
+      new Promise<never>((_res, rej) => {
+        timer = setTimeout(() => rej(new Error(`poll timed out after ${ms}ms`)), ms);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 export interface WaitResult {
   /** Set when the wait gave up after repeated poll failures (expired session, network gone).
    *  A wait must END on this, never die — the agent's channel is JSON, not a stack trace. */
@@ -36,6 +56,11 @@ export interface WaitOptions {
   errorGraceMs?: number;
   /** Injectable clock (tests). */
   now?: () => number;
+  /** Abandon a single poll after this long. Default 30s. A hung read is NOT the same as a failing
+   *  one: `busy` stays true, the interval's next tick returns immediately, and the wait neither
+   *  progresses nor ever reaches `failed` — it just stops, silently, forever. Bounding each poll
+   *  turns that into an ordinary failure the grace budget can reason about. */
+  pollTimeoutMs?: number;
   /** Watch editor presence and resolve (editorGone) if a once-alive editor dies. Default true. */
   watchEditor?: boolean;
   /** This waiter's single-waiter token; if a newer waiter supersedes it, step down. */
@@ -75,6 +100,7 @@ export function waitForActions(opts: WaitOptions): Promise<WaitResult> {
   const isActionable = opts.isActionable ?? defaultActionable;
   const watchEditor = opts.watchEditor ?? true;
   const errorGraceMs = opts.errorGraceMs ?? DEFAULT_ERROR_GRACE_MS;
+  const pollTimeoutMs = opts.pollTimeoutMs ?? DEFAULT_POLL_TIMEOUT_MS;
   const now = opts.now ?? Date.now;
   const ch = opts.channel;
 
@@ -108,7 +134,7 @@ export function waitForActions(opts: WaitOptions): Promise<WaitResult> {
       if (busy || done) return;
       busy = true;
       try {
-        const { entries, cursor } = await ch.readSince(opts.cursor);
+        const { entries, cursor } = await withTimeout(ch.readSince(opts.cursor), pollTimeoutMs);
         if (done) return;
 
         // Single-waiter lock: if a newer waiter claimed the doc, step down so only
@@ -156,8 +182,11 @@ export function waitForActions(opts: WaitOptions): Promise<WaitResult> {
         // END the wait with a result. Before this, the rejection escaped `void tick()` as an
         // unhandled rejection and Node killed the process — printing a stack trace where the agent
         // expects one line of JSON, and losing the turn entirely.
-        failingSince ??= now();
-        if (now() - failingSince >= errorGraceMs) {
+        // ONE sample per failed poll: `now` is injectable, and a clock that advances per call would
+        // otherwise tick twice per failure and expire the budget early.
+        const at = now();
+        failingSince ??= at;
+        if (at - failingSince >= errorGraceMs) {
           finish({ entries: [], cursor: opts.cursor, failed: e instanceof Error ? e : new Error(String(e)) });
         }
       } finally {

--- a/packages/cli/src/wait.ts
+++ b/packages/cli/src/wait.ts
@@ -3,6 +3,9 @@
 import { LogEventType, type ControlChannel, type LogEntry } from "@inplan/core/node";
 
 export interface WaitResult {
+  /** Set when the wait gave up after repeated poll failures (expired session, network gone).
+   *  A wait must END on this, never die — the agent's channel is JSON, not a stack trace. */
+  failed?: Error;
   entries: LogEntry[];
   cursor: number;
   /** True when the wait ended because the editor process went away (not via a turn/close action). */
@@ -22,6 +25,9 @@ export interface WaitOptions {
   pollMs?: number;
   /** Which entries should wake the agent. Default: any user-authored entry. */
   isActionable?: (e: LogEntry) => boolean;
+  /** Give up after this many CONSECUTIVE failed polls and resolve with `failed`. Default 30 —
+   *  with the 200ms cadence and the auth backoff, comfortably minutes of transient tolerance. */
+  maxConsecutiveErrors?: number;
   /** Watch editor presence and resolve (editorGone) if a once-alive editor dies. Default true. */
   watchEditor?: boolean;
   /** This waiter's single-waiter token; if a newer waiter supersedes it, step down. */
@@ -60,6 +66,7 @@ export function waitForActions(opts: WaitOptions): Promise<WaitResult> {
   const pollMs = opts.pollMs ?? 200;
   const isActionable = opts.isActionable ?? defaultActionable;
   const watchEditor = opts.watchEditor ?? true;
+  const maxConsecutiveErrors = opts.maxConsecutiveErrors ?? 30;
   const ch = opts.channel;
 
   return new Promise<WaitResult>((resolve, reject) => {
@@ -68,6 +75,7 @@ export function waitForActions(opts: WaitOptions): Promise<WaitResult> {
     let sawEditorAlive = false;
     let busy = false;
     let done = false;
+    let consecutiveErrors = 0;
 
     const cleanup = () => {
       clearInterval(timer);
@@ -131,6 +139,17 @@ export function waitForActions(opts: WaitOptions): Promise<WaitResult> {
           } else if (deadline !== null && Date.now() >= deadline) {
             finish({ entries, cursor });
           }
+        }
+        consecutiveErrors = 0; // a clean poll clears the streak
+      } catch (e) {
+        // A poll can fail for reasons that resolve themselves (a blip, a 5xx, an in-flight token
+        // refresh) and for reasons that never will (the session is gone). Tolerate a streak, then
+        // END the wait with a result. Before this, the rejection escaped `void tick()` as an
+        // unhandled rejection and Node killed the process — printing a stack trace where the agent
+        // expects one line of JSON, and losing the turn entirely.
+        consecutiveErrors += 1;
+        if (consecutiveErrors >= maxConsecutiveErrors) {
+          finish({ entries: [], cursor: opts.cursor, failed: e instanceof Error ? e : new Error(String(e)) });
         }
       } finally {
         busy = false;

--- a/packages/cli/src/wait.ts
+++ b/packages/cli/src/wait.ts
@@ -6,8 +6,11 @@ import { LogEventType, type ControlChannel, type LogEntry } from "@inplan/core/n
  *  claims it outlasts a full refresh cooldown asserts the REAL value rather than a copy of it. */
 export const DEFAULT_ERROR_GRACE_MS = 5 * 60_000;
 
-/** How long a single poll may take before it is abandoned. `SupabaseControlChannel.readSince` has no
- *  client-side timeout, so without this a stalled request pins `busy` and the wait hangs. */
+/** How long a single channel request may take before it is abandoned. The Supabase channel has no
+ *  client-side timeout on ANY of its calls, so a stall in `readSince`, `isSuperseded`, or `presence`
+ *  alike pins `busy` and the wait hangs — bounding only the first would just move the hang. The two
+ *  probe calls keep their existing swallow-and-continue handling: a timed-out lock or presence read
+ *  means "unknown", which must not end a wait, but must not freeze it either. */
 export const DEFAULT_POLL_TIMEOUT_MS = 30_000;
 
 /** Reject if `p` hasn't settled within `ms`. The timer is always cleared, so a resolved poll never
@@ -141,7 +144,7 @@ export function waitForActions(opts: WaitOptions): Promise<WaitResult> {
         // one waiter is ever live. A read blip is treated as "still ours".
         if (opts.token) {
           try {
-            if (await ch.isSuperseded(opts.token)) {
+            if (await withTimeout(ch.isSuperseded(opts.token), pollTimeoutMs)) {
               finish({ entries, cursor, superseded: true });
               return;
             }
@@ -155,7 +158,7 @@ export function waitForActions(opts: WaitOptions): Promise<WaitResult> {
         if (watchEditor) {
           let alive = false;
           try {
-            alive = await ch.presence();
+            alive = await withTimeout(ch.presence(), pollTimeoutMs);
           } catch {
             /* presence unknown — keep waiting */
           }

--- a/packages/cli/src/wait.ts
+++ b/packages/cli/src/wait.ts
@@ -25,9 +25,13 @@ export interface WaitOptions {
   pollMs?: number;
   /** Which entries should wake the agent. Default: any user-authored entry. */
   isActionable?: (e: LogEntry) => boolean;
-  /** Give up after this many CONSECUTIVE failed polls and resolve with `failed`. Default 30 —
-   *  with the 200ms cadence and the auth backoff, comfortably minutes of transient tolerance. */
-  maxConsecutiveErrors?: number;
+  /** Give up only after this long of CONTINUOUS poll failure, resolving with `failed`. Expressed in
+   *  TIME, not tick count, on purpose: a token refresh backs off up to 60s, during which every poll
+   *  fails for one underlying reason. Counting ticks would treat a single cooldown as hundreds of
+   *  independent failures and abandon the wait seconds into a backoff designed to outlast it. */
+  errorGraceMs?: number;
+  /** Injectable clock (tests). */
+  now?: () => number;
   /** Watch editor presence and resolve (editorGone) if a once-alive editor dies. Default true. */
   watchEditor?: boolean;
   /** This waiter's single-waiter token; if a newer waiter supersedes it, step down. */
@@ -66,7 +70,8 @@ export function waitForActions(opts: WaitOptions): Promise<WaitResult> {
   const pollMs = opts.pollMs ?? 200;
   const isActionable = opts.isActionable ?? defaultActionable;
   const watchEditor = opts.watchEditor ?? true;
-  const maxConsecutiveErrors = opts.maxConsecutiveErrors ?? 30;
+  const errorGraceMs = opts.errorGraceMs ?? 5 * 60_000;
+  const now = opts.now ?? Date.now;
   const ch = opts.channel;
 
   return new Promise<WaitResult>((resolve, reject) => {
@@ -75,7 +80,7 @@ export function waitForActions(opts: WaitOptions): Promise<WaitResult> {
     let sawEditorAlive = false;
     let busy = false;
     let done = false;
-    let consecutiveErrors = 0;
+    let failingSince: number | null = null; // when the current unbroken failure run started
 
     const cleanup = () => {
       clearInterval(timer);
@@ -140,15 +145,15 @@ export function waitForActions(opts: WaitOptions): Promise<WaitResult> {
             finish({ entries, cursor });
           }
         }
-        consecutiveErrors = 0; // a clean poll clears the streak
+        failingSince = null; // a clean poll ends the failure run
       } catch (e) {
         // A poll can fail for reasons that resolve themselves (a blip, a 5xx, an in-flight token
         // refresh) and for reasons that never will (the session is gone). Tolerate a streak, then
         // END the wait with a result. Before this, the rejection escaped `void tick()` as an
         // unhandled rejection and Node killed the process — printing a stack trace where the agent
         // expects one line of JSON, and losing the turn entirely.
-        consecutiveErrors += 1;
-        if (consecutiveErrors >= maxConsecutiveErrors) {
+        failingSince ??= now();
+        if (now() - failingSince >= errorGraceMs) {
           finish({ entries: [], cursor: opts.cursor, failed: e instanceof Error ? e : new Error(String(e)) });
         }
       } finally {

--- a/packages/cli/test/cliAuthSession.test.ts
+++ b/packages/cli/test/cliAuthSession.test.ts
@@ -260,3 +260,27 @@ describe("withAuthLock", () => {
     expect(order).toEqual(["A:start", "A:end", "B"]); // B ran only after A completed
   });
 });
+
+// The incident's most likely root cause: a refresh response without a rotated token used to be
+// papered over with `|| auth.refreshToken`, persisting a token the server had almost certainly just
+// spent. The session then looked healthy for the rest of the access token's hour and failed every
+// refresh afterwards — exactly one success, then permanent death.
+describe("a refresh with no rotated token", () => {
+  it("does NOT persist the old refresh token as if it were fresh", async () => {
+    seed();
+    const before = JSON.parse(readFileSync(authPath(), "utf8")) as { refreshToken: string; accessToken?: string };
+    refreshResult = { data: { session: session({ refresh_token: undefined }) }, error: null };
+    const s = await authedSession();
+    expect(s).toBeNull(); // treated as a failed refresh…
+    const after = JSON.parse(readFileSync(authPath(), "utf8")) as { refreshToken: string; accessToken?: string };
+    expect(after.refreshToken).toBe(before.refreshToken); // …and the stored token is untouched
+    expect(after.accessToken).toBeUndefined(); // no half-written session either
+  });
+
+  it("still persists normally when the server does rotate", async () => {
+    seed();
+    refreshResult = { data: { session: session() }, error: null };
+    expect(await authedSession()).not.toBeNull();
+    expect((JSON.parse(readFileSync(authPath(), "utf8")) as { refreshToken: string }).refreshToken).toBe("rt-new");
+  });
+});

--- a/packages/cli/test/sessionResilience.test.ts
+++ b/packages/cli/test/sessionResilience.test.ts
@@ -13,6 +13,23 @@ import { LIVE_REFRESH_SKEW_S, refreshBackoffMs } from "../src/cliAuth";
 import { DEFAULT_ERROR_GRACE_MS, DEFAULT_POLL_TIMEOUT_MS, waitForActions } from "../src/wait";
 import type { ControlChannel } from "@inplan/core";
 
+/** Assert a wait is STILL RUNNING after `ms`, then stop it.
+ *
+ *  A bare `Promise.race` only abandons the caller's view: `waitForActions` keeps its interval alive,
+ *  and with a 1ms poll and an injected clock it spins at ~1kHz past the end of the test. Aborting
+ *  clears the interval deterministically, so the assertion costs one timer instead of thousands. */
+async function stillWaitingAfter(ms: number, run: (signal: AbortSignal) => Promise<unknown>): Promise<void> {
+  const ctl = new AbortController();
+  const wait = run(ctl.signal).then(
+    (r) => ({ settled: r }),
+    (e) => ({ rejected: e as Error }),
+  );
+  const outcome = await Promise.race([wait, new Promise((r) => setTimeout(() => r("pending"), ms))]);
+  expect(outcome).toBe("pending"); // it must not have finished on its own
+  ctl.abort();
+  await wait; // the abort rejection is the expected end; awaiting it proves the loop stopped
+}
+
 describe("refresh backoff", () => {
   it("grows exponentially instead of hammering a single-use token", () => {
     expect(refreshBackoffMs(1)).toBe(1_000);
@@ -175,11 +192,7 @@ describe("give-up budget vs refresh backoff", () => {
       presence: async () => true,
     } as unknown as ControlChannel;
     // No errorGraceMs: the shipped default must carry it past a full cooldown without giving up.
-    const result = await Promise.race([
-      waitForActions({ channel: ch, cursor: 0, pollMs: 1, now: () => (t += 1_000), watchEditor: false }),
-      new Promise((r) => setTimeout(() => r("still waiting"), 250)),
-    ]);
-    expect(result).toBe("still waiting");
+    await stillWaitingAfter(250, (signal) => waitForActions({ channel: ch, cursor: 0, pollMs: 1, now: () => (t += 1_000), watchEditor: false, signal }));
   });
 
   it("does not give up early just because the poll cadence is fast", async () => {
@@ -196,11 +209,9 @@ describe("give-up budget vs refresh backoff", () => {
       presence: async () => true,
     } as unknown as ControlChannel;
     // 300 ticks of 200ms advance 60s of fake time — under the 5-minute grace, so it must NOT give up.
-    const result = await Promise.race([
-      waitForActions({ channel: ch, cursor: 0, pollMs: 1, errorGraceMs: 5 * 60_000, now: () => (t += 200), watchEditor: false }),
-      new Promise((r) => setTimeout(() => r("still waiting"), 300)),
-    ]);
-    expect(result).toBe("still waiting");
+    await stillWaitingAfter(300, (signal) =>
+      waitForActions({ channel: ch, cursor: 0, pollMs: 1, errorGraceMs: 5 * 60_000, now: () => (t += 200), watchEditor: false, signal }),
+    );
   });
 });
 
@@ -230,6 +241,38 @@ describe("a hung poll", () => {
       watchEditor: false,
     });
     expect(result.failed?.message).toMatch(/timed out after 10ms/);
+  });
+
+  // Bounding only `readSince` would have MOVED the hang rather than removed it: `isSuperseded` and
+  // `presence` are awaited in the same tick and are equally unbounded on the Supabase channel.
+  // "Still waiting" is NOT the assertion here — a FROZEN wait is also still waiting, so that would
+  //  pass with the bug present. The discriminator is whether the tick recycles: a stalled probe that
+  //  pins `busy` lets `readSince` run exactly ONCE, ever.
+  const pollsDuring = async (ms: number, stall: "lock" | "presence") => {
+    let reads = 0;
+    const ch = {
+      append: async () => {},
+      readSince: async (cursor: number) => ((reads += 1), { entries: [], cursor }),
+      subscribe: () => () => {},
+      getCursor: async () => 0,
+      setCursor: async () => {},
+      claimLock: async () => {},
+      isSuperseded: stall === "lock" ? () => new Promise(() => {}) : async () => false,
+      presence: stall === "presence" ? () => new Promise(() => {}) : async () => true,
+    } as unknown as ControlChannel;
+    await stillWaitingAfter(ms, (signal) =>
+      waitForActions({ channel: ch, cursor: 0, pollMs: 1, pollTimeoutMs: 10, token: "lock-1", watchEditor: stall === "presence", signal }),
+    );
+    return reads;
+  };
+
+  it("keeps polling when the LOCK probe stalls, instead of freezing on it", async () => {
+    // A stalled lock read means "unknown", which must not END the wait — but must not freeze it.
+    expect(await pollsDuring(120, "lock")).toBeGreaterThan(1);
+  });
+
+  it("keeps polling when the PRESENCE probe stalls", async () => {
+    expect(await pollsDuring(120, "presence")).toBeGreaterThan(1);
   });
 
   it("does not fire the timeout for a poll that answers in time", async () => {

--- a/packages/cli/test/sessionResilience.test.ts
+++ b/packages/cli/test/sessionResilience.test.ts
@@ -10,7 +10,7 @@
 
 import { describe, expect, it, vi } from "vitest";
 import { LIVE_REFRESH_SKEW_S, refreshBackoffMs } from "../src/cliAuth";
-import { waitForActions } from "../src/wait";
+import { DEFAULT_ERROR_GRACE_MS, waitForActions } from "../src/wait";
 import type { ControlChannel } from "@inplan/core";
 
 describe("refresh backoff", () => {
@@ -155,10 +155,31 @@ describe("wait survives a failing poll", () => {
 // budget would read that single cooldown as hundreds of independent failures and abandon a wait
 // seconds into a backoff designed to outlast it — so the budget is expressed in time.
 describe("give-up budget vs refresh backoff", () => {
-  it("survives a full 60s refresh cooldown by default", () => {
-    const DEFAULT_GRACE_MS = 5 * 60_000;
-    expect(DEFAULT_GRACE_MS).toBeGreaterThan(refreshBackoffMs(1000)); // one max-length cooldown…
-    expect(DEFAULT_GRACE_MS / refreshBackoffMs(1000)).toBeGreaterThanOrEqual(5); // …and several more
+  it("survives a full 60s refresh cooldown on the REAL default", () => {
+    // Asserted against wait.ts's exported constant, not a copy: a local literal would keep passing
+    // while the shipped default drifted, which is the opposite of what this test is for.
+    expect(DEFAULT_ERROR_GRACE_MS).toBeGreaterThan(refreshBackoffMs(1000)); // one max-length cooldown…
+    expect(DEFAULT_ERROR_GRACE_MS / refreshBackoffMs(1000)).toBeGreaterThanOrEqual(5); // …and several more
+  });
+
+  it("applies that default when the caller passes no budget", async () => {
+    let t = 0;
+    const ch = {
+      append: async () => {},
+      readSince: async () => { throw new Error("cooling off"); },
+      subscribe: () => () => {},
+      getCursor: async () => 0,
+      setCursor: async () => {},
+      claimLock: async () => {},
+      isSuperseded: async () => false,
+      presence: async () => true,
+    } as unknown as ControlChannel;
+    // No errorGraceMs: the shipped default must carry it past a full cooldown without giving up.
+    const result = await Promise.race([
+      waitForActions({ channel: ch, cursor: 0, pollMs: 1, now: () => (t += 1_000), watchEditor: false }),
+      new Promise((r) => setTimeout(() => r("still waiting"), 250)),
+    ]);
+    expect(result).toBe("still waiting");
   });
 
   it("does not give up early just because the poll cadence is fast", async () => {

--- a/packages/cli/test/sessionResilience.test.ts
+++ b/packages/cli/test/sessionResilience.test.ts
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// A real session died mid-`wait` and took the process with it: the access token lasts exactly one
+// hour, the refresh was attempted 2 minutes before expiry, it failed, and the poll loop then retried
+// it every 200ms until the token expired — replaying a SINGLE-USE refresh token hundreds of times,
+// which is how a token family gets revoked. The final failure escaped `void tick()` as an unhandled
+// rejection, so Node printed a stack trace where the agent expects one line of JSON.
+//
+// These pin the four things that changed.
+
+import { describe, expect, it, vi } from "vitest";
+import { LIVE_REFRESH_SKEW_S, refreshBackoffMs } from "../src/cliAuth";
+import { waitForActions } from "../src/wait";
+import type { ControlChannel } from "@inplan/core";
+
+describe("refresh backoff", () => {
+  it("grows exponentially instead of hammering a single-use token", () => {
+    expect(refreshBackoffMs(1)).toBe(1_000);
+    expect(refreshBackoffMs(2)).toBe(2_000);
+    expect(refreshBackoffMs(3)).toBe(4_000);
+    expect(refreshBackoffMs(4)).toBe(8_000);
+  });
+
+  it("caps so a long outage still retries, but only about once a minute", () => {
+    expect(refreshBackoffMs(20)).toBe(60_000);
+    expect(refreshBackoffMs(1000)).toBe(60_000);
+  });
+
+  it("never returns a delay shorter than the 200ms poll — the whole point is to be slower", () => {
+    for (let f = 1; f <= 50; f++) expect(refreshBackoffMs(f)).toBeGreaterThan(200);
+  });
+
+  it("is monotonic, so consecutive failures can only slow down", () => {
+    for (let f = 1; f < 30; f++) expect(refreshBackoffMs(f + 1)).toBeGreaterThanOrEqual(refreshBackoffMs(f));
+  });
+
+  // The incident: ~120s of budget at a 200ms cadence is ~600 replays of one single-use token.
+  it("collapses a 2-minute failure window from hundreds of attempts to a handful", () => {
+    const window = 120_000;
+    let elapsed = 0;
+    let attempts = 0;
+    while (elapsed < window) {
+      attempts += 1;
+      elapsed += refreshBackoffMs(attempts);
+    }
+    expect(attempts).toBeLessThan(10);
+    expect(window / 200).toBeGreaterThan(500); // what it used to be
+  });
+});
+
+describe("proactive refresh margin", () => {
+  it("gives a long wait real retry budget instead of one shot at the cliff", () => {
+    expect(LIVE_REFRESH_SKEW_S).toBe(600);
+    // Enough room for the backoff to exhaust several attempts before the token actually expires.
+    let elapsed = 0;
+    let attempts = 0;
+    while (elapsed < LIVE_REFRESH_SKEW_S * 1000) {
+      attempts += 1;
+      elapsed += refreshBackoffMs(attempts);
+    }
+    expect(attempts).toBeGreaterThanOrEqual(9);
+  });
+});
+
+/** A channel whose reads reject, to drive the poll loop's failure path. */
+function failingChannel(err: Error, failAfter = 0): ControlChannel {
+  let reads = 0;
+  return {
+    append: async () => {},
+    readSince: async (cursor: number) => {
+      reads += 1;
+      if (reads > failAfter) throw err;
+      return { entries: [], cursor };
+    },
+    subscribe: () => () => {},
+    getCursor: async () => 0,
+    setCursor: async () => {},
+    claimLock: async () => {},
+    isSuperseded: async () => false,
+    presence: async () => true,
+  } as unknown as ControlChannel;
+}
+
+describe("wait survives a failing poll", () => {
+  it("ends with `failed` instead of dying of an unhandled rejection", async () => {
+    const err = new Error("inplan: not logged in (or session expired) — run `inplan login`");
+    const unhandled = vi.fn();
+    process.on("unhandledRejection", unhandled);
+    try {
+      const result = await waitForActions({
+        channel: failingChannel(err),
+        cursor: 0,
+        pollMs: 1,
+        maxConsecutiveErrors: 3,
+        watchEditor: false,
+      });
+      expect(result.failed?.message).toContain("session expired");
+      await new Promise((r) => setTimeout(r, 20)); // let any stray rejection surface
+      expect(unhandled).not.toHaveBeenCalled();
+    } finally {
+      process.off("unhandledRejection", unhandled);
+    }
+  });
+
+  it("tolerates a streak shorter than the threshold rather than giving up on a blip", async () => {
+    let reads = 0;
+    const ch = {
+      append: async () => {},
+      readSince: async (cursor: number) => {
+        reads += 1;
+        if (reads <= 2) throw new Error("transient 503");
+        return { entries: [{ seq: 1, actor: "user", type: "turn_ended", ts: "" }], cursor: 1 };
+      },
+      subscribe: () => () => {},
+      getCursor: async () => 0,
+      setCursor: async () => {},
+      claimLock: async () => {},
+      isSuperseded: async () => false,
+      presence: async () => true,
+    } as unknown as ControlChannel;
+
+    const result = await waitForActions({ channel: ch, cursor: 0, pollMs: 1, debounceMs: 1, maxConsecutiveErrors: 10, watchEditor: false });
+    expect(result.failed).toBeUndefined(); // recovered
+    expect(result.entries.length).toBe(1);
+  });
+
+  it("a recovery resets the streak, so scattered blips never accumulate into a give-up", async () => {
+    let reads = 0;
+    const ch = {
+      append: async () => {},
+      readSince: async (cursor: number) => {
+        reads += 1;
+        if (reads % 2 === 1 && reads < 12) throw new Error("flaky");
+        if (reads < 12) return { entries: [], cursor };
+        return { entries: [{ seq: 1, actor: "user", type: "turn_ended", ts: "" }], cursor: 1 };
+      },
+      subscribe: () => () => {},
+      getCursor: async () => 0,
+      setCursor: async () => {},
+      claimLock: async () => {},
+      isSuperseded: async () => false,
+      presence: async () => true,
+    } as unknown as ControlChannel;
+
+    // 6 failures total, but never 2 in a row — well past maxConsecutiveErrors if it didn't reset.
+    const result = await waitForActions({ channel: ch, cursor: 0, pollMs: 1, debounceMs: 1, maxConsecutiveErrors: 3, watchEditor: false });
+    expect(result.failed).toBeUndefined();
+  });
+});

--- a/packages/cli/test/sessionResilience.test.ts
+++ b/packages/cli/test/sessionResilience.test.ts
@@ -51,17 +51,25 @@ describe("refresh backoff", () => {
     for (let f = 1; f < 30; f++) expect(refreshBackoffMs(f + 1)).toBeGreaterThanOrEqual(refreshBackoffMs(f));
   });
 
-  // The incident: ~120s of budget at a 200ms cadence is ~600 replays of one single-use token.
+  // The incident: an unthrottled retry replays the token once per poll, so a 2-minute window is
+  // hundreds of replays. Both sides are DERIVED — the throttled count from the real schedule, the
+  // unthrottled from the real poll cadence — so the contrast can actually fail if either changes.
   it("collapses a 2-minute failure window from hundreds of attempts to a handful", () => {
-    const window = 120_000;
-    let elapsed = 0;
-    let attempts = 0;
-    while (elapsed < window) {
-      attempts += 1;
-      elapsed += refreshBackoffMs(attempts);
-    }
-    expect(attempts).toBeLessThan(10);
-    expect(window / 200).toBeGreaterThan(500); // what it used to be
+    const windowMs = 120_000;
+    const POLL_MS = 200; // the wait loop's cadence, which the old code retried on
+    const attemptsWith = (delay: (n: number) => number) => {
+      let elapsed = 0;
+      let n = 0;
+      while (elapsed < windowMs) {
+        n += 1;
+        elapsed += delay(n);
+      }
+      return n;
+    };
+    const throttled = attemptsWith(refreshBackoffMs);
+    const unthrottled = attemptsWith(() => POLL_MS);
+    expect(throttled).toBeLessThan(10);
+    expect(unthrottled / throttled).toBeGreaterThan(50); // orders of magnitude, not a tweak
   });
 });
 
@@ -294,5 +302,48 @@ describe("a hung poll", () => {
   it("the default bound is long enough for a real read but short of any human timescale", () => {
     expect(DEFAULT_POLL_TIMEOUT_MS).toBeGreaterThanOrEqual(10_000);
     expect(DEFAULT_POLL_TIMEOUT_MS).toBeLessThan(DEFAULT_ERROR_GRACE_MS);
+  });
+});
+
+// Both reviewers independently flagged this: `alive` starting at `false` meant a presence call that
+// THREW read as "the editor is gone". Harmless while presence only rejected on real errors; once the
+// poll gained a timeout, a single 30s stall could end a live session after one earlier success.
+describe("presence: unknown is not absent", () => {
+  const channelWithPresence = (presence: () => Promise<boolean>) =>
+    ({
+      append: async () => {},
+      readSince: async (cursor: number) => ({ entries: [], cursor }),
+      subscribe: () => () => {},
+      getCursor: async () => 0,
+      setCursor: async () => {},
+      claimLock: async () => {},
+      isSuperseded: async () => false,
+      presence,
+    }) as unknown as ControlChannel;
+
+  it("does not report editorGone when presence stalls after a successful read", async () => {
+    let calls = 0;
+    const ch = channelWithPresence(() => {
+      calls += 1;
+      return calls === 1 ? Promise.resolve(true) : new Promise(() => {}); // alive once, then stalls
+    });
+    await stillWaitingAfter(150, (signal) => waitForActions({ channel: ch, cursor: 0, pollMs: 1, pollTimeoutMs: 5, watchEditor: true, signal }));
+  });
+
+  it("does not report editorGone when presence throws after a successful read", async () => {
+    let calls = 0;
+    const ch = channelWithPresence(async () => {
+      calls += 1;
+      if (calls === 1) return true;
+      throw new Error("presence unreadable");
+    });
+    await stillWaitingAfter(80, (signal) => waitForActions({ channel: ch, cursor: 0, pollMs: 1, watchEditor: true, signal }));
+  });
+
+  it("STILL reports editorGone when presence deterministically answers false", async () => {
+    let calls = 0;
+    const ch = channelWithPresence(async () => ++calls === 1); // true once, then a real false
+    const r = await waitForActions({ channel: ch, cursor: 0, pollMs: 1, watchEditor: true });
+    expect(r.editorGone).toBe(true); // the real signal must survive the fix
   });
 });

--- a/packages/cli/test/sessionResilience.test.ts
+++ b/packages/cli/test/sessionResilience.test.ts
@@ -10,7 +10,7 @@
 
 import { describe, expect, it, vi } from "vitest";
 import { LIVE_REFRESH_SKEW_S, refreshBackoffMs } from "../src/cliAuth";
-import { DEFAULT_ERROR_GRACE_MS, waitForActions } from "../src/wait";
+import { DEFAULT_ERROR_GRACE_MS, DEFAULT_POLL_TIMEOUT_MS, waitForActions } from "../src/wait";
 import type { ControlChannel } from "@inplan/core";
 
 describe("refresh backoff", () => {
@@ -201,5 +201,55 @@ describe("give-up budget vs refresh backoff", () => {
       new Promise((r) => setTimeout(() => r("still waiting"), 300)),
     ]);
     expect(result).toBe("still waiting");
+  });
+});
+
+// A HUNG poll is not a failing one. `SupabaseControlChannel.readSince` has no client-side timeout, so
+// a stalled request left `busy` true forever: the interval kept firing and returning immediately, the
+// grace budget never advanced, and the wait neither progressed nor reported `failed`. It just stopped.
+describe("a hung poll", () => {
+  const neverSettles = () =>
+    ({
+      append: async () => {},
+      readSince: () => new Promise(() => {}), // never resolves, never rejects
+      subscribe: () => () => {},
+      getCursor: async () => 0,
+      setCursor: async () => {},
+      claimLock: async () => {},
+      isSuperseded: async () => false,
+      presence: async () => true,
+    }) as unknown as ControlChannel;
+
+  it("is abandoned and counted as a failure rather than stranding the loop", async () => {
+    const result = await waitForActions({
+      channel: neverSettles(),
+      cursor: 0,
+      pollMs: 1,
+      pollTimeoutMs: 10,
+      errorGraceMs: 0, // first timeout ends the wait
+      watchEditor: false,
+    });
+    expect(result.failed?.message).toMatch(/timed out after 10ms/);
+  });
+
+  it("does not fire the timeout for a poll that answers in time", async () => {
+    const ch = {
+      append: async () => {},
+      readSince: async (cursor: number) => ({ entries: [{ seq: 1, actor: "user", type: "turn_ended", ts: "" }], cursor: cursor + 1 }),
+      subscribe: () => () => {},
+      getCursor: async () => 0,
+      setCursor: async () => {},
+      claimLock: async () => {},
+      isSuperseded: async () => false,
+      presence: async () => true,
+    } as unknown as ControlChannel;
+    const result = await waitForActions({ channel: ch, cursor: 0, pollMs: 1, debounceMs: 1, pollTimeoutMs: 5_000, watchEditor: false });
+    expect(result.failed).toBeUndefined();
+    expect(result.entries.length).toBe(1);
+  });
+
+  it("the default bound is long enough for a real read but short of any human timescale", () => {
+    expect(DEFAULT_POLL_TIMEOUT_MS).toBeGreaterThanOrEqual(10_000);
+    expect(DEFAULT_POLL_TIMEOUT_MS).toBeLessThan(DEFAULT_ERROR_GRACE_MS);
   });
 });

--- a/packages/cli/test/sessionResilience.test.ts
+++ b/packages/cli/test/sessionResilience.test.ts
@@ -91,7 +91,7 @@ describe("wait survives a failing poll", () => {
         channel: failingChannel(err),
         cursor: 0,
         pollMs: 1,
-        maxConsecutiveErrors: 3,
+        errorGraceMs: 0, // give up on the first failure — deterministic, no wall-clock dependence
         watchEditor: false,
       });
       expect(result.failed?.message).toContain("session expired");
@@ -119,7 +119,7 @@ describe("wait survives a failing poll", () => {
       presence: async () => true,
     } as unknown as ControlChannel;
 
-    const result = await waitForActions({ channel: ch, cursor: 0, pollMs: 1, debounceMs: 1, maxConsecutiveErrors: 10, watchEditor: false });
+    const result = await waitForActions({ channel: ch, cursor: 0, pollMs: 1, debounceMs: 1, errorGraceMs: 60_000, watchEditor: false });
     expect(result.failed).toBeUndefined(); // recovered
     expect(result.entries.length).toBe(1);
   });
@@ -142,8 +142,43 @@ describe("wait survives a failing poll", () => {
       presence: async () => true,
     } as unknown as ControlChannel;
 
-    // 6 failures total, but never 2 in a row — well past maxConsecutiveErrors if it didn't reset.
-    const result = await waitForActions({ channel: ch, cursor: 0, pollMs: 1, debounceMs: 1, maxConsecutiveErrors: 3, watchEditor: false });
+    // A fake clock makes the reset observable: without it, the run that starts at t=0 would exceed
+    // the 150ms grace long before the channel recovers.
+    let t = 0;
+    const result = await waitForActions({ channel: ch, cursor: 0, pollMs: 1, debounceMs: 1, errorGraceMs: 150, now: () => (t += 100), watchEditor: false });
     expect(result.failed).toBeUndefined();
+  });
+});
+
+// The backoff and the give-up budget are two of this PR's own fixes, and they interact: a refresh
+// cooldown of up to 60s means EVERY poll in that window fails for one underlying reason. A tick-count
+// budget would read that single cooldown as hundreds of independent failures and abandon a wait
+// seconds into a backoff designed to outlast it — so the budget is expressed in time.
+describe("give-up budget vs refresh backoff", () => {
+  it("survives a full 60s refresh cooldown by default", () => {
+    const DEFAULT_GRACE_MS = 5 * 60_000;
+    expect(DEFAULT_GRACE_MS).toBeGreaterThan(refreshBackoffMs(1000)); // one max-length cooldown…
+    expect(DEFAULT_GRACE_MS / refreshBackoffMs(1000)).toBeGreaterThanOrEqual(5); // …and several more
+  });
+
+  it("does not give up early just because the poll cadence is fast", async () => {
+    // 200ms polls over a 60s cooldown = ~300 failing ticks. Time-based, that is one failure run.
+    let t = 0;
+    const ch = {
+      append: async () => {},
+      readSince: async () => { throw new Error("session refresh cooling off"); },
+      subscribe: () => () => {},
+      getCursor: async () => 0,
+      setCursor: async () => {},
+      claimLock: async () => {},
+      isSuperseded: async () => false,
+      presence: async () => true,
+    } as unknown as ControlChannel;
+    // 300 ticks of 200ms advance 60s of fake time — under the 5-minute grace, so it must NOT give up.
+    const result = await Promise.race([
+      waitForActions({ channel: ch, cursor: 0, pollMs: 1, errorGraceMs: 5 * 60_000, now: () => (t += 200), watchEditor: false }),
+      new Promise((r) => setTimeout(() => r("still waiting"), 300)),
+    ]);
+    expect(result).toBe("still waiting");
   });
 });


### PR DESCRIPTION
> **Stacked on #76** (base is `feat/local-agent-gating`, not `main`) — it reuses `exitAfterFlush` from that PR. Merge #76 first and this retargets to `main` cleanly. It touches `cliAuth.ts` and `wait.ts`, which #76 doesn't, so there's no overlap.

A live `wait --remote` died after almost exactly an hour and took the process with it:

```
Error: inplan: not logged in (or session expired) — run `inplan login`
    at need (cli.js:1005:19)
    at async Object.readSince (cli.js:1010:30)
    at async tick (cli.js:1511:37)
Node.js v24.16.0                       ← raw stack trace, exit 1, nothing on stdout
```

Four things had to line up. All four are fixed.

## 1. The refresh happened at the cliff

Access token TTL is exactly 3600s. `ACCESS_SKEW_S = 120`, so on an idle wait the first refresh attempt lands **58 minutes in**, with two minutes of room to recover.

Long-lived waits now refresh 10 minutes early (`LIVE_REFRESH_SKEW_S`). One-shot commands keep the small skew deliberately — they exit immediately, and widening it there would only rotate the single-use token more often than necessary.

## 2. A failed refresh was retried every 200ms

This is the one that turns a recoverable failure into a permanent one. `fresh()` clears `inflight` in a `.finally`, so the next poll tick starts another attempt — at `pollMs = 200`, that replays the **same single-use refresh token** hundreds of times a minute. GoTrue revokes the whole token family when a rotated refresh token is replayed, which is consistent with the session staying dead rather than recovering.

Failures now back off 1s → 2s → 4s … capped at 60s. A two-minute window goes from ~600 attempts to fewer than ten (pinned by test).

## 3. A response with no rotated token was papered over

```js
refreshToken: data.session.refresh_token || auth.refreshToken,   // before
```

If a refresh response ever lacks a rotated token, this persists the one the server just **spent**. The session then looks healthy for the rest of the access token's hour and fails every refresh afterwards — exactly one success, then permanent death, which is the shape this incident had.

Now treated as a failed refresh: the stored token is left untouched, so a server that genuinely doesn't rotate stays usable on the next attempt, and a spent token is never enshrined.

## 4. The crash itself

`tick` in `wait.ts` was `try`/`finally` with **no `catch`**, and there is no `unhandledRejection` handler anywhere in `packages/cli/src`. The rejection escaped `void tick()` and Node's default `--unhandled-rejections=throw` killed the process — a stack trace on stderr and **nothing on stdout**, where the agent expects one line of JSON.

`tick` now tolerates a streak of failures (a blip, a 5xx, an in-flight refresh), **resets the streak on any clean poll**, and ends the wait with `{"status":"wait_failed"}` + exit 6 once the streak stands. A process-level `unhandledRejection` backstop guarantees the agent's channel gets JSON no matter what else escapes.

## Verification

Beyond the suite passing, I re-removed the `catch` and re-ran the new tests: they reproduce the original failure — `Unhandled Rejection`, hung poll, 5s timeout — and pass only with it in place.

- `sessionResilience.test.ts` — backoff shape, cap, monotonicity, the ~600→<10 collapse, the retry budget the wider margin buys, the crash itself, and that scattered blips never accumulate into a give-up
- `cliAuthSession.test.ts` — a rotation-less response leaves `auth.json` untouched and writes no half-session; a normal rotation still persists

Full suite: 1080 passed, 2 skipped. Coverage 96%+ (gate ≥95%).

## Not addressed

Why the *first* refresh was rejected at 02:35:50 can't be determined locally — the stored token is opaque. That needs the Supabase auth logs for 01:37–02:38 to separate "invalid refresh token" from "reuse detected". Every change here is about making that failure survivable rather than fatal, which holds whichever it was.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/77?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CLI handling of repeated polling failures with clear guidance, structured error output, and a dedicated exit status.
  - Prevented temporary authentication service failures from unnecessarily invalidating active sessions.
  - Avoided overwriting valid credentials when refresh responses are incomplete.
  - Added capped exponential backoff for authentication refresh attempts.

- **Reliability**
  - CLI startup and runtime failures now produce consistent structured errors.
  - Polling recovers from brief error streaks and reports persistent failures cleanly.
  - Long-lived sessions refresh proactively to reduce interruptions.
  - Hung polling requests no longer block progress indefinitely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->