### PR TITLE
release: 0.1.27 — local-agent gating on cloud docs + session-refresh resilience

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5335,7 +5335,7 @@
     },
     "packages/cli": {
       "name": "@inplan/cli",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@hocuspocus/provider": "^2.15.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inplan/cli",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "private": true,
   "description": "inplan CLI: open / wait / signal orchestration over the document core.",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
Version bump only (`packages/cli/package.json` + lockfile). Merging this, then publishing a `v0.1.27` GitHub Release, triggers `release.yml` → npm publish via OIDC trusted publishing.

## What ships since 0.1.26

**#76 — the local agent on a cloud document is a Pro+ surface.**
`wait --remote` refuses to attach when it cannot serve the doc, and keeps "your plan doesn't include this" (exit 4) strictly apart from "we couldn't reach the server" (exit 5) — a transient outage must never be reported as a paywall. Free accounts get the reason plus an upgrade path instead of a connect command they can't run.

The agent indicator no longer reads "disconnected" while a turn-based agent is *working*: its CLI exits between turns, so live presence reported connected only while idle — inverted. And the connect instruction now installs `inplan@latest` unconditionally rather than only when the CLI is missing, which is exactly how an out-of-date CLI attached and silently lacked the code path the document needed.

**#77 — a failed token refresh no longer revokes the session or kills the wait.**
- refresh 10 min before expiry, not 2 — a failure now has a retry budget
- failures back off 1s→60s instead of replaying a single-use refresh token every 200ms (~600 replays in the incident window, which is how a token family gets revoked)
- a refresh response with no rotated token is a failure, not something to persist — persisting a *spent* token is what made one bad refresh permanent an hour later
- a poll that fails **or stalls** ends the wait with `{"status":"wait_failed"}` instead of an unhandled rejection that killed the process with a stack trace and no JSON
- every channel call in a poll is bounded, and timed-out requests don't stack
- an unknown presence is no longer read as an absent editor
- stdout is drained before any coded exit, so the agent actually receives the JSON those exit codes exist to carry

## Verification

Full suite green — 1091 unit/integration tests, typecheck clean, coverage ≥95% (gate). Both merged PRs were reviewed to zero open findings across seven rounds.

## Note for the release step

npm versions are immutable, so `0.1.27` must be unused — confirmed against the registry (latest published is `0.1.26`, no `v0.1.27` tag exists).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/78?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

