### PR TITLE
cli: bake the plugin verifier public key into the published bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,38 @@ jobs:
       - run: npm run build
       - run: npm run typecheck
       - run: npm test
+      # Release key-bake guard (0.1.27 regression): exercise the REAL tsup `define` wiring +
+      # build-release's isKeyBaked check against an actual build — the unit tests only cover the
+      # pure helper, so a reverted/mis-wired define would otherwise stay green until a release.
+      # Runs LAST: it rebuilds packages/cli/dist with a key baked in, which must not leak into the
+      # test steps above (they exercise the runtime-lookup dev build). Any valid P-256/Ed25519
+      # SPKI works here — this asserts the MECHANISM, not the production trust root.
+      - name: Release key-bake guard
+        env:
+          INPLAN_REQUIRE_PLUGIN_KEY: "1"
+          INPLAN_PLUGIN_PUBLIC_KEY: |
+            -----BEGIN PUBLIC KEY-----
+            MCowBQYDK2VwAyEAVP11te5E7xzNJ4reKg0+mAnrr91gcyD1bMr43Homq98=
+            -----END PUBLIC KEY-----
+        run: |
+          npm run build -w @inplan/cli
+          node --input-type=module -e '
+            import { readFileSync } from "node:fs";
+            import { isKeyBaked } from "./scripts/lib/bakedKey.mjs";
+            const src = readFileSync("packages/cli/dist/cli.js", "utf8");
+            if (!isKeyBaked(src, process.env.INPLAN_PLUGIN_PUBLIC_KEY)) {
+              console.error("FAIL: the plugin verifier key was not baked into the CLI bundle (0.1.27 regression)");
+              process.exit(1);
+            }
+            if (/process\.env\.INPLAN_PLUGIN_PUBLIC_KEY/.test(src)) {
+              console.error("FAIL: the bundle still reads INPLAN_PLUGIN_PUBLIC_KEY at runtime — define not applied");
+              process.exit(1);
+            }
+            console.log("ok: verifier key baked; runtime lookup fully replaced");
+          '
+          # …and the require-guard must REFUSE a keyless build rather than shipping a dead gate.
+          if env -u INPLAN_PLUGIN_PUBLIC_KEY npm run build -w @inplan/cli; then
+            echo "FAIL: the CLI built without the key despite INPLAN_REQUIRE_PLUGIN_KEY=1"
+            exit 1
+          fi
+          echo "ok: keyless build refused under INPLAN_REQUIRE_PLUGIN_KEY"

--- a/packages/cli/test/bakedKey.test.ts
+++ b/packages/cli/test/bakedKey.test.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Regression test for the release guard that verifies the plugin verifier PUBLIC key is BAKED into
+// the shipped CLI bundle (the 0.1.27 bug shipped an empty runtime lookup → live-collab gate dead).
+// Proving the guard: a bundle missing the key — or holding only a truncated/first-line fragment —
+// must fail, so a "successful" build can never approve a CLI that can't verify plugins.
+import { describe, it, expect } from "vitest";
+import { isKeyBaked, spkiBodyLines } from "../../../scripts/lib/bakedKey.mjs";
+
+// The real single-line Ed25519 trust root, and a synthetic multi-line (RSA-style) SPKI to prove the
+// guard validates the COMPLETE body across wrapped lines rather than just the first contiguous run.
+const ED = "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAVP11te5E7xzNJ4reKg0+mAnrr91gcyD1bMr43Homq98=\n-----END PUBLIC KEY-----";
+const MULTI =
+  "-----BEGIN PUBLIC KEY-----\nAAAABBBBCCCCDDDDEEEEFFFFGGGGHHHHIIIIJJJJKKKK\nLLLLMMMMNNNNOOOOPPPPQQQQRRRRSSSSTTTTUUUUVVVV\n-----END PUBLIC KEY-----";
+
+// How the key appears once esbuild `define` bakes it: a JS string literal (PEM newlines escaped).
+const bakedLike = (pem: string) => `var PLUGIN_PUBLIC_KEY = ${JSON.stringify(pem)};`;
+
+describe("isKeyBaked", () => {
+  it("passes when the full single-line key is baked", () => {
+    expect(isKeyBaked(bakedLike(ED), ED)).toBe(true);
+  });
+
+  it("fails when the key is absent — the empty runtime lookup that shipped in 0.1.27", () => {
+    const dead = 'var PLUGIN_PUBLIC_KEY = process.env.INPLAN_PLUGIN_PUBLIC_KEY ?? "";';
+    expect(isKeyBaked(dead, ED)).toBe(false);
+  });
+
+  it("fails on a truncated body — a partial fragment must not pass", () => {
+    const body = spkiBodyLines(ED)[0] ?? "";
+    expect(isKeyBaked(`var k = "${body.slice(0, 20)}";`, ED)).toBe(false);
+  });
+
+  it("requires EVERY line of a multi-line key (a line-1-only bake fails)", () => {
+    const [l1, l2] = spkiBodyLines(MULTI);
+    expect(isKeyBaked(`var k = "${l1}";`, MULTI)).toBe(false); // only the first line baked
+    expect(isKeyBaked(`var k = "${l1}" + "${l2}";`, MULTI)).toBe(true); // all lines present
+  });
+
+  it("rejects a missing or degenerate key body", () => {
+    expect(isKeyBaked("anything", "")).toBe(false);
+    expect(isKeyBaked("anything", "-----BEGIN PUBLIC KEY-----\n-----END PUBLIC KEY-----")).toBe(false);
+  });
+});

--- a/packages/cli/test/bakedKey.test.ts
+++ b/packages/cli/test/bakedKey.test.ts
@@ -2,23 +2,30 @@
 //
 // Regression test for the release guard that verifies the plugin verifier PUBLIC key is BAKED into
 // the shipped CLI bundle (the 0.1.27 bug shipped an empty runtime lookup → live-collab gate dead).
-// Proving the guard: a bundle missing the key — or holding only a truncated/first-line fragment —
-// must fail, so a "successful" build can never approve a CLI that can't verify plugins.
+// Proving the guard: a bundle missing the key — or holding only fragments, out-of-order lines, or a
+// truncated body — must fail, so a "successful" build can never approve a CLI whose baked key
+// `crypto.createPublicKey` couldn't actually load.
 import { describe, it, expect } from "vitest";
 import { isKeyBaked, spkiBodyLines } from "../../../scripts/lib/bakedKey.mjs";
 
 // The real single-line Ed25519 trust root, and a synthetic multi-line (RSA-style) SPKI to prove the
-// guard validates the COMPLETE body across wrapped lines rather than just the first contiguous run.
+// guard validates the COMPLETE serialization across wrapped lines, contiguous and in order.
 const ED = "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAVP11te5E7xzNJ4reKg0+mAnrr91gcyD1bMr43Homq98=\n-----END PUBLIC KEY-----";
 const MULTI =
   "-----BEGIN PUBLIC KEY-----\nAAAABBBBCCCCDDDDEEEEFFFFGGGGHHHHIIIIJJJJKKKK\nLLLLMMMMNNNNOOOOPPPPQQQQRRRRSSSSTTTTUUUUVVVV\n-----END PUBLIC KEY-----";
 
-// How the key appears once esbuild `define` bakes it: a JS string literal (PEM newlines escaped).
+// How the key appears once esbuild `define` bakes it: ONE JS string literal, PEM newlines escaped.
 const bakedLike = (pem: string) => `var PLUGIN_PUBLIC_KEY = ${JSON.stringify(pem)};`;
 
 describe("isKeyBaked", () => {
-  it("passes when the full single-line key is baked", () => {
+  it("passes when the full key is baked as an escaped string literal (esbuild's emission)", () => {
     expect(isKeyBaked(bakedLike(ED), ED)).toBe(true);
+    expect(isKeyBaked(bakedLike(MULTI), MULTI)).toBe(true);
+  });
+
+  it("passes for a template-literal bake (real newlines) and CRLF-escaped serialization", () => {
+    expect(isKeyBaked(`var k = \`${ED}\`;`, ED)).toBe(true);
+    expect(isKeyBaked(`var k = "${MULTI.split("\n").join("\\r\\n")}";`, MULTI)).toBe(true);
   });
 
   it("fails when the key is absent — the empty runtime lookup that shipped in 0.1.27", () => {
@@ -28,13 +35,24 @@ describe("isKeyBaked", () => {
 
   it("fails on a truncated body — a partial fragment must not pass", () => {
     const body = spkiBodyLines(ED)[0] ?? "";
-    expect(isKeyBaked(`var k = "${body.slice(0, 20)}";`, ED)).toBe(false);
+    expect(isKeyBaked(`var k = "-----BEGIN PUBLIC KEY-----\\n${body.slice(0, 20)}";`, ED)).toBe(false);
   });
 
-  it("requires EVERY line of a multi-line key (a line-1-only bake fails)", () => {
+  it("fails when lines exist only as scattered, non-contiguous fragments", () => {
     const [l1, l2] = spkiBodyLines(MULTI);
-    expect(isKeyBaked(`var k = "${l1}";`, MULTI)).toBe(false); // only the first line baked
-    expect(isKeyBaked(`var k = "${l1}" + "${l2}";`, MULTI)).toBe(true); // all lines present
+    // Every line present somewhere in the bundle, but never as one loadable PEM serialization.
+    expect(isKeyBaked(`var a = "${l1}"; var b = "${l2}"; var h = "-----BEGIN PUBLIC KEY-----";`, MULTI)).toBe(false);
+  });
+
+  it("fails when the body lines are baked out of order", () => {
+    const [l1, l2] = spkiBodyLines(MULTI);
+    const reordered = `var k = "-----BEGIN PUBLIC KEY-----\\n${l2}\\n${l1}\\n-----END PUBLIC KEY-----";`;
+    expect(isKeyBaked(reordered, MULTI)).toBe(false);
+  });
+
+  it("fails on a line-1-only bake of a multi-line key", () => {
+    const l1 = spkiBodyLines(MULTI)[0] ?? "";
+    expect(isKeyBaked(`var k = "-----BEGIN PUBLIC KEY-----\\n${l1}\\n-----END PUBLIC KEY-----";`, MULTI)).toBe(false);
   });
 
   it("rejects a missing or degenerate key body", () => {

--- a/packages/cli/test/bakedKey.test.ts
+++ b/packages/cli/test/bakedKey.test.ts
@@ -11,8 +11,10 @@ import { isKeyBaked, spkiBodyLines } from "../../../scripts/lib/bakedKey.mjs";
 // The real single-line Ed25519 trust root, and a synthetic multi-line (RSA-style) SPKI to prove the
 // guard validates the COMPLETE serialization across wrapped lines, contiguous and in order.
 const ED = "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAVP11te5E7xzNJ4reKg0+mAnrr91gcyD1bMr43Homq98=\n-----END PUBLIC KEY-----";
+// A REAL multi-line SPKI (RSA-2048): isKeyBaked parse-gates the configured key with
+// createPublicKey, so a synthetic base64 blob would fail before the matcher even ran.
 const MULTI =
-  "-----BEGIN PUBLIC KEY-----\nAAAABBBBCCCCDDDDEEEEFFFFGGGGHHHHIIIIJJJJKKKK\nLLLLMMMMNNNNOOOOPPPPQQQQRRRRSSSSTTTTUUUUVVVV\n-----END PUBLIC KEY-----";
+  "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAkZbA4lx2KQSZMCNcDU35\nkdc/t/+/YYpg6vP9IYXyJk+kAzFmYSpO1S37GkUQgDYpxz+MzTvTPou4FW6wNEX0\nJpdQxUOyyjCmhXF9dN51WMn+hJNxM04Vh1gMfb2EpIHdykebgi9ii1zP+KUxN19m\ndoAg8Ci9lP19kZkuGUlkN+FTdyzW2GK7H1t9hL3NG4CkV2SU6DOhGxe0fhAYz3Mg\nYcvgwKusGSGispUqc926e09t85NMZERVnVXAUGbqOjvJL2xfU49TOu1jOkaz4yv9\njvkiX+5pyhYR2UaEbtSGWvZ+QxR5S1R5izsehzVPBviAa3gvOF/C6l62Rpbkrzv5\nSwIDAQAB\n-----END PUBLIC KEY-----";
 
 // How the key appears once esbuild `define` bakes it: ONE JS string literal, PEM newlines escaped.
 const bakedLike = (pem: string) => `var PLUGIN_PUBLIC_KEY = ${JSON.stringify(pem)};`;
@@ -71,5 +73,14 @@ describe("isKeyBaked", () => {
   it("rejects a missing or degenerate key body", () => {
     expect(isKeyBaked("anything", "")).toBe(false);
     expect(isKeyBaked("anything", "-----BEGIN PUBLIC KEY-----\n-----END PUBLIC KEY-----")).toBe(false);
+  });
+
+  it("rejects a configured value that isn't a loadable public key, even when baked verbatim", () => {
+    // The guard must validate the KEY, not just the string plumbing: a garbage env value baked
+    // perfectly between delimiters still ships a trust root createPublicKey rejects at runtime.
+    const garbage = "not-a-public-key-with-more-than-forty-characters-of-payload";
+    expect(isKeyBaked(`var k = ${JSON.stringify(garbage)};`, garbage)).toBe(false);
+    const fakePem = "-----BEGIN PUBLIC KEY-----\nAAAABBBBCCCCDDDDEEEEFFFFGGGGHHHHIIIIJJJJKKKK\n-----END PUBLIC KEY-----";
+    expect(isKeyBaked(`var k = ${JSON.stringify(fakePem)};`, fakePem)).toBe(false);
   });
 });

--- a/packages/cli/test/bakedKey.test.ts
+++ b/packages/cli/test/bakedKey.test.ts
@@ -55,6 +55,12 @@ describe("isKeyBaked", () => {
     expect(isKeyBaked(`var k = "-----BEGIN PUBLIC KEY-----\\n${l1}\\n-----END PUBLIC KEY-----";`, MULTI)).toBe(false);
   });
 
+  it("rejects a polluted literal — junk inside the delimiters means createPublicKey would fail", () => {
+    // The PEM subsequence is PRESENT, but the runtime string is "junk-----BEGIN…" — unloadable.
+    expect(isKeyBaked(`var k = ${JSON.stringify("junk" + ED)};`, ED)).toBe(false);
+    expect(isKeyBaked(`var k = ${JSON.stringify(ED + "trailing")};`, ED)).toBe(false);
+  });
+
   it("rejects a missing or degenerate key body", () => {
     expect(isKeyBaked("anything", "")).toBe(false);
     expect(isKeyBaked("anything", "-----BEGIN PUBLIC KEY-----\n-----END PUBLIC KEY-----")).toBe(false);

--- a/packages/cli/test/bakedKey.test.ts
+++ b/packages/cli/test/bakedKey.test.ts
@@ -55,6 +55,13 @@ describe("isKeyBaked", () => {
     expect(isKeyBaked(`var k = "-----BEGIN PUBLIC KEY-----\\n${l1}\\n-----END PUBLIC KEY-----";`, MULTI)).toBe(false);
   });
 
+  it("tolerates surrounding whitespace inside the literal — the YAML block scalar's trailing newline", () => {
+    // release.yml passes the key via a `|` block scalar, so the env value (and thus the baked
+    // literal) ends with \n — createPublicKey accepts surrounding whitespace, so must the guard.
+    expect(isKeyBaked(`var k = ${JSON.stringify(ED + "\n")};`, ED)).toBe(true);
+    expect(isKeyBaked(`var k = ${JSON.stringify("\n" + ED + "\n")};`, ED)).toBe(true);
+  });
+
   it("rejects a polluted literal — junk inside the delimiters means createPublicKey would fail", () => {
     // The PEM subsequence is PRESENT, but the runtime string is "junk-----BEGIN…" — unloadable.
     expect(isKeyBaked(`var k = ${JSON.stringify("junk" + ED)};`, ED)).toBe(false);

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -8,6 +8,26 @@ import { defineConfig } from "tsup";
 // own env still works and forks never ship our key. Telemetry stays opt-in regardless.
 const POSTHOG_KEY = process.env.INPLAN_POSTHOG_KEY;
 
+// Bake the plugin trust-root PUBLIC key (SPKI PEM) into the bundle the same way. `@inplan/core`'s
+// pluginLoader reads `process.env.INPLAN_PLUGIN_PUBLIC_KEY` to verify the entitlement lease + the
+// fetched plugin bundle; unless we inline it here, the published CLI ships an EMPTY key and the
+// live-collab gate fails closed for EVERY user (the 0.1.27 regression — the desktop app baked it via
+// electron.vite.config, but the CLI never did). Skipped on dev/source/fork builds → runtime lookup,
+// so a developer's own env still works and forks never ship our key.
+const PLUGIN_PUBLIC_KEY = process.env.INPLAN_PLUGIN_PUBLIC_KEY;
+
+// The release sets INPLAN_REQUIRE_PLUGIN_KEY=1 so a forgotten key is a HARD build failure instead of
+// silently shipping a CLI with no plugin trust root (mirrors packages/app/electron.vite.config.ts).
+if (process.env.INPLAN_REQUIRE_PLUGIN_KEY && !PLUGIN_PUBLIC_KEY) {
+  throw new Error(
+    "INPLAN_REQUIRE_PLUGIN_KEY is set but INPLAN_PLUGIN_PUBLIC_KEY is missing — refusing to build a CLI without the plugin verifier key.",
+  );
+}
+
+const define: Record<string, string> = {};
+if (POSTHOG_KEY) define["process.env.INPLAN_POSTHOG_KEY"] = JSON.stringify(POSTHOG_KEY);
+if (PLUGIN_PUBLIC_KEY) define["process.env.INPLAN_PLUGIN_PUBLIC_KEY"] = JSON.stringify(PLUGIN_PUBLIC_KEY);
+
 // Bundle the internal `@inplan/*` workspace packages INTO the CLI output so the published
 // `inplan` package has no unpublished `@inplan/*` dependencies. Third-party deps stay
 // external (declared in the release package.json, installed by npm at `-g` install time).
@@ -16,5 +36,5 @@ export default defineConfig({
   format: ["esm"],
   clean: true,
   noExternal: [/^@inplan\//],
-  ...(POSTHOG_KEY ? { define: { "process.env.INPLAN_POSTHOG_KEY": JSON.stringify(POSTHOG_KEY) } } : {}),
+  ...(Object.keys(define).length ? { define } : {}),
 });

--- a/scripts/build-release.mjs
+++ b/scripts/build-release.mjs
@@ -14,6 +14,7 @@ import { execFileSync } from "node:child_process";
 import { cpSync, mkdirSync, readFileSync, rmSync, writeFileSync, chmodSync, existsSync } from "node:fs";
 import { builtinModules } from "node:module";
 import { fileURLToPath } from "node:url";
+import { isKeyBaked } from "./lib/bakedKey.mjs";
 
 const root = fileURLToPath(new URL("..", import.meta.url));
 const p = (rel) => fileURLToPath(new URL(`../${rel}`, import.meta.url));
@@ -58,13 +59,12 @@ const bundleSrc = readFileSync(cliBundle, "utf8");
 // Regression guard (0.1.27): the plugin verifier PUBLIC key must be BAKED into the shipped bundle,
 // not left as a `process.env.INPLAN_PLUGIN_PUBLIC_KEY` lookup that resolves to "" on a user's machine
 // — an empty key fails the live-collab gate closed for EVERYONE. The tsup `define` bakes it; here we
-// assert it actually landed in cli.js (catches a missing env AND a mis-wired define). We match the
-// SPKI base64 body, which is whitespace-free so it survives JSON string-escaping of the PEM newlines.
+// assert the COMPLETE key actually landed in cli.js (catches a missing env AND a mis-wired define).
+// isKeyBaked checks every base64 line of the SPKI body, so a truncated/partial bake can't pass.
 if (process.env.INPLAN_REQUIRE_PLUGIN_KEY) {
-  const b64 = (process.env.INPLAN_PLUGIN_PUBLIC_KEY ?? "").match(/[A-Za-z0-9+/=]{40,}/)?.[0];
-  if (!b64 || !bundleSrc.includes(b64)) {
+  if (!isKeyBaked(bundleSrc, process.env.INPLAN_PLUGIN_PUBLIC_KEY)) {
     throw new Error(
-      "cli bundle is missing the baked plugin verifier key — the live-collab gate would fail closed for every user (0.1.27 regression). Check packages/cli/tsup.config.ts `define`.",
+      "cli bundle is missing the fully-baked plugin verifier key — the live-collab gate would fail closed for every user (0.1.27 regression). Check packages/cli/tsup.config.ts `define`.",
     );
   }
   console.log("• plugin verifier key baked into cli bundle ✓");

--- a/scripts/build-release.mjs
+++ b/scripts/build-release.mjs
@@ -54,6 +54,22 @@ const IMPORT_FORMS = [
   /(?:^|[^.\w$])require\s*\(\s*["']([^"']+)["']/g, // require      require("x")
 ];
 const bundleSrc = readFileSync(cliBundle, "utf8");
+
+// Regression guard (0.1.27): the plugin verifier PUBLIC key must be BAKED into the shipped bundle,
+// not left as a `process.env.INPLAN_PLUGIN_PUBLIC_KEY` lookup that resolves to "" on a user's machine
+// — an empty key fails the live-collab gate closed for EVERYONE. The tsup `define` bakes it; here we
+// assert it actually landed in cli.js (catches a missing env AND a mis-wired define). We match the
+// SPKI base64 body, which is whitespace-free so it survives JSON string-escaping of the PEM newlines.
+if (process.env.INPLAN_REQUIRE_PLUGIN_KEY) {
+  const b64 = (process.env.INPLAN_PLUGIN_PUBLIC_KEY ?? "").match(/[A-Za-z0-9+/=]{40,}/)?.[0];
+  if (!b64 || !bundleSrc.includes(b64)) {
+    throw new Error(
+      "cli bundle is missing the baked plugin verifier key — the live-collab gate would fail closed for every user (0.1.27 regression). Check packages/cli/tsup.config.ts `define`.",
+    );
+  }
+  console.log("• plugin verifier key baked into cli bundle ✓");
+}
+
 const externals = new Set();
 for (const re of IMPORT_FORMS) {
   let m;

--- a/scripts/lib/bakedKey.d.mts
+++ b/scripts/lib/bakedKey.d.mts
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+export function spkiBodyLines(pem: string): string[];
+export function isKeyBaked(bundleSrc: string, pem: string): boolean;

--- a/scripts/lib/bakedKey.mjs
+++ b/scripts/lib/bakedKey.mjs
@@ -22,16 +22,19 @@ export function spkiBodyLines(pem) {
 
 /**
  * True iff the COMPLETE serialized PEM — header, every base64 body line IN ORDER, footer — appears
- * contiguously in `bundleSrc`, with each newline in either its escaped string-literal form (`\n`
- * as backslash-n, which is what esbuild's `define` emits inside one quoted string) or literal form
- * (a template literal). Requiring the whole serialization in order means out-of-order fragments,
- * coincidental substrings scattered through the bundle, or a truncated bake cannot satisfy the
- * guard — the bundle must contain a string `crypto.createPublicKey` would actually accept. A
- * missing or degenerate key body is likewise rejected.
+ * as an ENTIRE string literal in `bundleSrc`: opened by a quote (", ', or backtick) immediately
+ * before the header and closed by the SAME quote immediately after the footer, with each newline
+ * in either its escaped string-literal form (`\n` as backslash-n, which is what esbuild's
+ * `define` emits) or literal form (a template literal). The delimiter anchoring matters: a
+ * polluted bake like "junk-----BEGIN…" still CONTAINS the PEM subsequence, but
+ * `crypto.createPublicKey` would reject the runtime value — the guard must only accept a literal
+ * that actually loads. Out-of-order fragments, scattered substrings, truncation, and
+ * degenerate/missing bodies are all rejected.
  */
 export function isKeyBaked(bundleSrc, pem) {
   const lines = pemLines(pem);
   if (spkiBodyLines(pem).join("").length < 40) return false; // no/degenerate key → not a real trust root
   const NL = String.raw`(?:(?:\\r)?\\n|\r?\n)`;
-  return new RegExp(lines.map(escapeRe).join(NL)).test(String(bundleSrc ?? ""));
+  const DELIM = "([\"'`])";
+  return new RegExp(DELIM + lines.map(escapeRe).join(NL) + String.raw`\1`).test(String(bundleSrc ?? ""));
 }

--- a/scripts/lib/bakedKey.mjs
+++ b/scripts/lib/bakedKey.mjs
@@ -3,7 +3,9 @@
 // Pure helper for the release regression guard (scripts/build-release.mjs): confirm the plugin
 // verifier PUBLIC key was actually BAKED into the built CLI bundle, not left as an empty runtime
 // `process.env.INPLAN_PLUGIN_PUBLIC_KEY` lookup — the 0.1.27 bug that failed the live-collab gate
-// closed for every user. Dependency-free so packages/cli/test/bakedKey.test.ts can unit-test it.
+// closed for every user. Node-stdlib only, so packages/cli/test/bakedKey.test.ts can unit-test it.
+
+import { createPublicKey } from "node:crypto";
 
 const escapeRe = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
@@ -32,8 +34,16 @@ export function spkiBodyLines(pem) {
  * degenerate/missing bodies are all rejected.
  */
 export function isKeyBaked(bundleSrc, pem) {
+  // The configured value must BE a loadable public key before any string matching means anything:
+  // a 40+-character garbage env value between matching delimiters would otherwise satisfy the
+  // pattern while shipping a trust root createPublicKey rejects at runtime.
+  try {
+    createPublicKey(String(pem ?? ""));
+  } catch {
+    return false;
+  }
   const lines = pemLines(pem);
-  if (spkiBodyLines(pem).join("").length < 40) return false; // no/degenerate key → not a real trust root
+  if (spkiBodyLines(pem).join("").length < 40) return false; // belt-and-braces; unreachable past the parse gate
   const NL = String.raw`(?:(?:\\r)?\\n|\r?\n)`;
   // Between the delimiters and the PEM, tolerate exactly what crypto.createPublicKey tolerates:
   // surrounding whitespace (escaped or literal). The release workflow's YAML block scalar leaves a

--- a/scripts/lib/bakedKey.mjs
+++ b/scripts/lib/bakedKey.mjs
@@ -35,6 +35,11 @@ export function isKeyBaked(bundleSrc, pem) {
   const lines = pemLines(pem);
   if (spkiBodyLines(pem).join("").length < 40) return false; // no/degenerate key → not a real trust root
   const NL = String.raw`(?:(?:\\r)?\\n|\r?\n)`;
+  // Between the delimiters and the PEM, tolerate exactly what crypto.createPublicKey tolerates:
+  // surrounding whitespace (escaped or literal). The release workflow's YAML block scalar leaves a
+  // trailing newline in the env value, so the baked literal legitimately ends "…KEY-----\n". Any
+  // NON-whitespace padding still fails — that is the polluted bake createPublicKey would reject.
+  const WS = String.raw`(?:(?:\\r)?\\n|\\t|\r?\n|[ \t])*`;
   const DELIM = "([\"'`])";
-  return new RegExp(DELIM + lines.map(escapeRe).join(NL) + String.raw`\1`).test(String(bundleSrc ?? ""));
+  return new RegExp(DELIM + WS + lines.map(escapeRe).join(NL) + WS + String.raw`\1`).test(String(bundleSrc ?? ""));
 }

--- a/scripts/lib/bakedKey.mjs
+++ b/scripts/lib/bakedKey.mjs
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Pure helper for the release regression guard (scripts/build-release.mjs): confirm the plugin
+// verifier PUBLIC key was actually BAKED into the built CLI bundle, not left as an empty runtime
+// `process.env.INPLAN_PLUGIN_PUBLIC_KEY` lookup — the 0.1.27 bug that failed the live-collab gate
+// closed for every user. Dependency-free so packages/cli/test/bakedKey.test.ts can unit-test it.
+
+/** The base64 body lines of an SPKI PEM — header/footer and blank lines removed. */
+export function spkiBodyLines(pem) {
+  return String(pem ?? "")
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0 && !l.startsWith("-----"));
+}
+
+/**
+ * True iff the COMPLETE key is baked into `bundleSrc`: EVERY base64 line of the SPKI body appears
+ * verbatim. Checking every line — not just the first contiguous run — means a truncated or
+ * line-1-only bake (e.g. a multi-line RSA key) fails the guard, so the release never approves a CLI
+ * whose baked key cannot verify plugins. A missing/degenerate key body is likewise rejected.
+ */
+export function isKeyBaked(bundleSrc, pem) {
+  const lines = spkiBodyLines(pem);
+  if (lines.join("").length < 40) return false; // no/degenerate key → not a real trust root
+  return lines.every((line) => bundleSrc.includes(line));
+}

--- a/scripts/lib/bakedKey.mjs
+++ b/scripts/lib/bakedKey.mjs
@@ -5,22 +5,33 @@
 // `process.env.INPLAN_PLUGIN_PUBLIC_KEY` lookup — the 0.1.27 bug that failed the live-collab gate
 // closed for every user. Dependency-free so packages/cli/test/bakedKey.test.ts can unit-test it.
 
-/** The base64 body lines of an SPKI PEM — header/footer and blank lines removed. */
-export function spkiBodyLines(pem) {
+const escapeRe = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+/** Every non-empty line of the PEM (header, base64 body, footer), trimmed. */
+function pemLines(pem) {
   return String(pem ?? "")
     .split(/\r?\n/)
     .map((l) => l.trim())
-    .filter((l) => l.length > 0 && !l.startsWith("-----"));
+    .filter((l) => l.length > 0);
+}
+
+/** The base64 body lines of an SPKI PEM — header/footer and blank lines removed. */
+export function spkiBodyLines(pem) {
+  return pemLines(pem).filter((l) => !l.startsWith("-----"));
 }
 
 /**
- * True iff the COMPLETE key is baked into `bundleSrc`: EVERY base64 line of the SPKI body appears
- * verbatim. Checking every line — not just the first contiguous run — means a truncated or
- * line-1-only bake (e.g. a multi-line RSA key) fails the guard, so the release never approves a CLI
- * whose baked key cannot verify plugins. A missing/degenerate key body is likewise rejected.
+ * True iff the COMPLETE serialized PEM — header, every base64 body line IN ORDER, footer — appears
+ * contiguously in `bundleSrc`, with each newline in either its escaped string-literal form (`\n`
+ * as backslash-n, which is what esbuild's `define` emits inside one quoted string) or literal form
+ * (a template literal). Requiring the whole serialization in order means out-of-order fragments,
+ * coincidental substrings scattered through the bundle, or a truncated bake cannot satisfy the
+ * guard — the bundle must contain a string `crypto.createPublicKey` would actually accept. A
+ * missing or degenerate key body is likewise rejected.
  */
 export function isKeyBaked(bundleSrc, pem) {
-  const lines = spkiBodyLines(pem);
-  if (lines.join("").length < 40) return false; // no/degenerate key → not a real trust root
-  return lines.every((line) => bundleSrc.includes(line));
+  const lines = pemLines(pem);
+  if (spkiBodyLines(pem).join("").length < 40) return false; // no/degenerate key → not a real trust root
+  const NL = String.raw`(?:(?:\\r)?\\n|\r?\n)`;
+  return new RegExp(lines.map(escapeRe).join(NL)).test(String(bundleSrc ?? ""));
 }


### PR DESCRIPTION
## Problem

The published `inplan` CLI has no plugin verifier key, so `@inplan/core`'s `PLUGIN_PUBLIC_KEY` is empty at runtime and the live-collab gate fails closed for **every** CLI user (`plugin_unavailable`), even on entitled accounts. Root cause: `packages/cli/tsup.config.ts` only `define`s `INPLAN_POSTHOG_KEY`, never `INPLAN_PLUGIN_PUBLIC_KEY` — so the release env is set but tsup ships `process.env.INPLAN_PLUGIN_PUBLIC_KEY ?? ""` verbatim. The desktop app bakes the key via `electron.vite.config.ts`; the CLI never did, and the `INPLAN_REQUIRE_PLUGIN_KEY` guard only covered the app.

## Fix

- `packages/cli/tsup.config.ts`: add the `define` for `INPLAN_PLUGIN_PUBLIC_KEY` (mirrors POSTHOG) so the release bakes it into `cli.js`, plus the `INPLAN_REQUIRE_PLUGIN_KEY` hard-fail guard. Dev/source/fork builds skip the define → runtime lookup preserved, so a developer's own env still works and forks never ship the key.
- `scripts/build-release.mjs`: shipped-artifact regression check — when the release requires the key, assert the SPKI body actually landed in `cli.js` (catches a missing env **and** a mis-wired define).

## Verification

- Build with key set → key baked, `process.env.INPLAN_PLUGIN_PUBLIC_KEY` fully replaced (0 runtime lookups).
- `INPLAN_REQUIRE_PLUGIN_KEY=1` + no key → build refused.
- Dev build (no env) → succeeds, runtime lookup preserved, no key leaked.
- Full suite: 1091 pass, coverage 96.3%.

Needs a new CLI release (0.1.28) after merge so shipped clients verify.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/79?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI build validation when plugin verification is enabled.
  * Builds now fail clearly if the required plugin verification key is missing or incomplete.
  * Release checks confirm that the configured verification key is fully included in the CLI bundle.
  * Added regression coverage for key formatting, truncation, and missing-key scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->