### PR TITLE
login: cloud-rendezvous handoff — works for coding agents and cross-machine CLIs

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -752,17 +752,36 @@ async function pendingLoginExit(): Promise<void> {
     process.stderr.write(`inplan login: ${e instanceof Error ? e.message : String(e)}\n`);
     return;
   }
-  // Quote arguments that need it: the skill tells the agent to re-run `resume` VERBATIM, so an
-  // argument carrying a space or shell metacharacter (`inplan message doc "did X this turn"`,
-  // `--model "Opus 4.8"`) must survive re-parsing as ONE argument, not shatter into several.
-  const quoted = (a: string): string => (/^[A-Za-z0-9_@%+=:,.\/-]+$/.test(a) ? a : shellQuote(a));
+  // Quote arguments that need it FOR THE ACTIVE SHELL: the skill tells the agent to re-run
+  // `resume` VERBATIM, so an argument carrying a space or metacharacter must survive re-parsing
+  // as ONE argument. POSIX single-quoting is wrong on Windows (cmd/PowerShell treat ' as data) —
+  // there, wrap in double quotes with embedded quotes doubled, which both shells accept.
+  const quoted = (a: string): string => {
+    if (/^[A-Za-z0-9_@%+=:,.\/-]+$/.test(a)) return a;
+    return process.platform === "win32" ? `"${a.replaceAll('"', '""')}"` : shellQuote(a);
+  };
+  // Credential-bearing flags must NOT round-trip through stdout/agent logs: a partial
+  // `--refresh <token>` login that fell through to the browser path would otherwise serialize a
+  // bearer credential into the printed resume line. The browser sign-in replaces them anyway.
+  const argsSansCredentials: string[] = [];
+  const skipValueOf = new Set(["--refresh", "--anon", "--url"]);
+  const argv = process.argv.slice(2);
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]!;
+    if (skipValueOf.has(a)) {
+      i++; // drop the flag AND its value
+      continue;
+    }
+    if ([...skipValueOf].some((f) => a.startsWith(`${f}=`))) continue;
+    argsSansCredentials.push(a);
+  }
   // The executable half must also be re-runnable from THIS environment: a bare `inplan` only
   // exists for global installs. When the entry script was invoked under another name (npx cache,
   // a repo checkout's dist/cli.js), rebuild the invocation from the running node + entry script.
   const entry = process.argv[1] ?? "";
   const invokedAsInplan = entry.split(/[\\/]/).pop()?.replace(/\.(cmd|ps1)$/i, "") === "inplan";
   const argv0 = invokedAsInplan ? ["inplan"] : [quoted(process.execPath), quoted(entry)];
-  const resume = [...argv0, ...process.argv.slice(2).map(quoted)].join(" ");
+  const resume = [...argv0, ...argsSansCredentials.map(quoted)].join(" ");
   process.stderr.write(
     "inplan: sign-in required.\n" +
       `  ACTION (human): open this URL in a browser and sign in:\n    ${url}\n` +

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -28,7 +28,7 @@ import {
 import { agentAuthorFor } from "./agentAuthor";
 import { gitProvenance } from "./provenance";
 import { authedSession, clearAuth, currentUser, liveRemoteBackend, loadAuth, remoteBackend, saveAuth, type AuthFile } from "./cliAuth";
-import { LoginSessionExpiredError, createLoginSession, loadPendingLogin, pollLoginSession, rendezvousLogin } from "./cliLogin";
+import { LoginSessionExpiredError, createLoginSession, loadPendingLogin, pollLoginSession, rendezvousLogin, type PendingLogin } from "./cliLogin";
 import { resolveIdentity, setManualProfile, writeLocalProfile } from "./cliProfile";
 import { checkForUpdate, selfUpdate, UPDATE_PKG, warnIfOutdated } from "./update";
 import { runningEditorPid } from "./editorProcess";
@@ -567,6 +567,13 @@ async function doLogin(args: string[]): Promise<void> {
   // Browser handoff (cloud rendezvous). No partial-credential mode: anything short of the full
   // non-interactive set above falls through here, which is the intended UX.
   //
+  // Explicit opt-outs first — BEFORE resuming or minting any session: an unattended run must use
+  // the non-interactive credential path above, never wait on a human (even on a stale sidecar),
+  // and never leave a dangling rendezvous session nobody will complete.
+  if (loginOptOut(args)) {
+    process.stderr.write("inplan login: non-interactive environment — pass --url/--anon/--refresh (or the matching INPLAN_* env vars).\n");
+    process.exit(1);
+  }
   // A previous invocation may have already minted a session and exited pending (the coding-agent
   // loop) — finish THAT login rather than minting a fresh URL the human never asked for.
   const pending = loadPendingLogin();
@@ -590,7 +597,10 @@ async function doLogin(args: string[]): Promise<void> {
   // session, hand over the URL + resume command, and get out of the way.
   if (!canInteractiveLogin(args) || isKnownAgentEnv()) {
     await pendingLoginExit();
-    return;
+    // pendingLoginExit only returns when the session could not be minted (offline / hub down):
+    // no credentials were stored, so this login FAILED — exit 1 like every other failure path
+    // (returning here would exit 0 and a script branching on the code would think it signed in).
+    process.exit(1);
   }
   try {
     const auth = await defaultRendezvousLogin();
@@ -649,14 +659,20 @@ export async function ensureLoggedIn(
   args: string[],
   login: () => Promise<AuthFile> = defaultRendezvousLogin,
   pendingExit: () => Promise<void> = pendingLoginExit,
+  pollPending: (p: PendingLogin) => Promise<AuthFile> = (p) => pollLoginSession(p, { onNudge: printLoginNudge }),
 ): Promise<boolean> {
   if (loadAuth()) return true; // credentials present → remoteBackend refreshes (expiry handled there)
+
+  // Explicit opt-outs FIRST — before resuming a sidecar or minting a session: both flags mean
+  // "never wait on a human", and a stale login-pending.json (e.g. a cached CI home dir) must not
+  // stall an unattended run for the whole poll window.
+  if (loginOptOut(args)) return false;
 
   const pending = loadPendingLogin();
   if (pending) {
     try {
       process.stderr.write(`inplan: waiting for the pending browser sign-in to finish…\n  ${pending.url}\n`);
-      saveAuth(await pollLoginSession(pending, { onNudge: printLoginNudge }));
+      saveAuth(await pollPending(pending));
       await persistCloudIdentity();
       return true;
     } catch (e) {
@@ -681,11 +697,15 @@ export async function ensureLoggedIn(
     }
   }
 
-  // Explicit opt-outs: an unattended run must not dangle a session nobody will ever complete.
-  if (hasFlag(args, "no-login") || process.env.CI) return false;
-
   await pendingExit();
   return false; // pendingLoginExit never returns in prod; injected test doubles do
+}
+
+/** The shared login opt-out — "never block on a human, never mint a session nobody will claim" —
+ *  applied identically by BOTH entry points (`inplan login` and auto-login) before any path that
+ *  resumes or creates a rendezvous session. */
+function loginOptOut(args: string[]): boolean {
+  return hasFlag(args, "no-login") || Boolean(process.env.CI);
 }
 
 /** The real browser handoff used by auto-login and `inplan login` (interactive-human path). */
@@ -732,7 +752,10 @@ async function pendingLoginExit(): Promise<void> {
     process.stderr.write(`inplan login: ${e instanceof Error ? e.message : String(e)}\n`);
     return;
   }
-  const resume = ["inplan", ...process.argv.slice(2)].join(" ");
+  // Quote arguments that need it: the skill tells the agent to re-run `resume` VERBATIM, so an
+  // argument carrying a space or shell metacharacter (`inplan message doc "did X this turn"`,
+  // `--model "Opus 4.8"`) must survive re-parsing as ONE argument, not shatter into several.
+  const resume = ["inplan", ...process.argv.slice(2).map((a) => (/^[A-Za-z0-9_@%+=:,.\/-]+$/.test(a) ? a : shellQuote(a)))].join(" ");
   process.stderr.write(
     "inplan: sign-in required.\n" +
       `  ACTION (human): open this URL in a browser and sign in:\n    ${url}\n` +

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -28,7 +28,7 @@ import {
 import { agentAuthorFor } from "./agentAuthor";
 import { gitProvenance } from "./provenance";
 import { authedSession, clearAuth, currentUser, liveRemoteBackend, loadAuth, remoteBackend, saveAuth, type AuthFile } from "./cliAuth";
-import { browserLogin } from "./cliLogin";
+import { LoginSessionExpiredError, createLoginSession, loadPendingLogin, pollLoginSession, rendezvousLogin } from "./cliLogin";
 import { resolveIdentity, setManualProfile, writeLocalProfile } from "./cliProfile";
 import { checkForUpdate, selfUpdate, UPDATE_PKG, warnIfOutdated } from "./update";
 import { runningEditorPid } from "./editorProcess";
@@ -564,10 +564,36 @@ async function doLogin(args: string[]): Promise<void> {
     return;
   }
 
-  // Interactive browser handoff. No partial-credential mode: anything short of the full
-  // non-interactive set above falls through to the browser, which is the intended UX.
+  // Browser handoff (cloud rendezvous). No partial-credential mode: anything short of the full
+  // non-interactive set above falls through here, which is the intended UX.
+  //
+  // A previous invocation may have already minted a session and exited pending (the coding-agent
+  // loop) — finish THAT login rather than minting a fresh URL the human never asked for.
+  const pending = loadPendingLogin();
+  if (pending) {
+    try {
+      process.stderr.write(`inplan: waiting for the pending browser sign-in to finish…\n  ${pending.url}\n`);
+      const auth = await pollLoginSession(pending, { onNudge: printLoginNudge });
+      saveAuth(auth);
+      await persistCloudIdentity();
+      output({ status: "logged_in", url: auth.url, ...(auth.email ? { email: auth.email } : {}) });
+      return;
+    } catch (e) {
+      if (!(e instanceof LoginSessionExpiredError)) {
+        process.stderr.write(`inplan login: ${e instanceof Error ? e.message : String(e)}\n`);
+        process.exit(1);
+      }
+      /* expired → fall through to a fresh flow */
+    }
+  }
+  // A coding agent (or any pipe) only reads our output when the process exits — start the
+  // session, hand over the URL + resume command, and get out of the way.
+  if (!canInteractiveLogin(args) || isKnownAgentEnv()) {
+    await pendingLoginExit();
+    return;
+  }
   try {
-    const auth = await defaultBrowserLogin();
+    const auth = await defaultRendezvousLogin();
     saveAuth(auth);
     await persistCloudIdentity();
     output({ status: "logged_in", url: auth.url, ...(auth.email ? { email: auth.email } : {}) });
@@ -605,32 +631,119 @@ export function canInteractiveLogin(args: string[]): boolean {
 
 /**
  * Ensure a cloud session exists before a foreground cloud command runs. When there are
- * no stored credentials *and* we're interactive, run the browser login inline (so the
- * connect instruction is just `inplan wait --remote <doc>` — no separate `inplan login`).
- * Returns false when we can't/shouldn't auto-login (headless, --no-login, or the handoff
- * failed); the caller prints the actionable "run `inplan login`" guidance and exits.
+ * no stored credentials:
+ *  - a pending rendezvous a previous invocation started is RESUMED (blocks until the human
+ *    finishes signing in — the second half of the coding-agent loop);
+ *  - an interactive human gets the inline browser login (so the connect instruction is just
+ *    `inplan wait --remote <doc>` — no separate `inplan login`);
+ *  - a non-interactive caller (a coding agent, a pipe) gets a fresh session + the URL and
+ *    resume command, and this process EXITS with EXIT_LOGIN_PENDING — agents only read our
+ *    output once we exit, so blocking here would hide the URL until the login had already
+ *    timed out. `--no-login` and CI keep the old contract: return false, caller errors.
  *
  * Scoped to the *missing credentials* case (loadAuth === null) on purpose: an expired
  * session still falls through to the existing refresh path + its message, so we never
  * pop a browser on every routine expiry. `login` is injectable for tests.
  */
-export async function ensureLoggedIn(args: string[], login: () => Promise<AuthFile> = defaultBrowserLogin): Promise<boolean> {
+export async function ensureLoggedIn(
+  args: string[],
+  login: () => Promise<AuthFile> = defaultRendezvousLogin,
+  pendingExit: () => Promise<void> = pendingLoginExit,
+): Promise<boolean> {
   if (loadAuth()) return true; // credentials present → remoteBackend refreshes (expiry handled there)
-  if (!canInteractiveLogin(args)) return false;
-  try {
-    process.stderr.write("inplan: not signed in — opening your browser to sign in…\n");
-    saveAuth(await login());
-    await persistCloudIdentity();
-    return true;
-  } catch (e) {
-    process.stderr.write(`inplan login: ${e instanceof Error ? e.message : String(e)}\n`);
-    return false;
+
+  const pending = loadPendingLogin();
+  if (pending) {
+    try {
+      process.stderr.write(`inplan: waiting for the pending browser sign-in to finish…\n  ${pending.url}\n`);
+      saveAuth(await pollLoginSession(pending, { onNudge: printLoginNudge }));
+      await persistCloudIdentity();
+      return true;
+    } catch (e) {
+      if (!(e instanceof LoginSessionExpiredError)) {
+        // Foreground timeout / transport failure — the sidecar survives, the next run resumes.
+        process.stderr.write(`inplan login: ${e instanceof Error ? e.message : String(e)}\n`);
+        return false;
+      }
+      /* the session expired → fall through and start a fresh flow */
+    }
   }
+
+  if (canInteractiveLogin(args) && !isKnownAgentEnv()) {
+    try {
+      process.stderr.write("inplan: not signed in — opening your browser to sign in…\n");
+      saveAuth(await login());
+      await persistCloudIdentity();
+      return true;
+    } catch (e) {
+      process.stderr.write(`inplan login: ${e instanceof Error ? e.message : String(e)}\n`);
+      return false;
+    }
+  }
+
+  // Explicit opt-outs: an unattended run must not dangle a session nobody will ever complete.
+  if (hasFlag(args, "no-login") || process.env.CI) return false;
+
+  await pendingExit();
+  return false; // pendingLoginExit never returns in prod; injected test doubles do
 }
 
-/** The real browser handoff used by auto-login (mirrors `doLogin`'s interactive path). */
-function defaultBrowserLogin(): Promise<AuthFile> {
-  return browserLogin({ onUrl: (u) => process.stderr.write(`Opening your browser to sign in:\n  ${u}\nIf it didn't open, paste that URL into your browser.\n`) });
+/** The real browser handoff used by auto-login and `inplan login` (interactive-human path). */
+function defaultRendezvousLogin(): Promise<AuthFile> {
+  return rendezvousLogin({
+    onUrl: (u) => process.stderr.write(`Opening your browser to sign in:\n  ${u}\nIf it didn't open, paste that URL into your browser.\n`),
+    onNudge: printLoginNudge,
+  });
+}
+
+/** The page never acked `opened` — the browser likely didn't launch (open() is fire-and-forget
+ *  and a spawn "success" proves nothing); the human has to open the printed URL by hand. */
+function printLoginNudge(): void {
+  process.stderr.write("inplan: still waiting — the browser may not have opened. Open the sign-in URL above manually to continue.\n");
+}
+
+/**
+ * Rung 2 of the login detection ladder (docs: cli-login-rendezvous plan): env markers that exist
+ * ONLY inside a coding agent's tool shell, never in a human's terminal. Deliberately narrow —
+ * e.g. Cursor sets CURSOR_* in its integrated terminal where a real human types, so it does NOT
+ * belong here. A match routes login to the pending/exit path even on a PTY (some agent harnesses
+ * allocate one for streaming); misdetection is safe either way because both paths converge on the
+ * same resumable session.
+ */
+export function isKnownAgentEnv(env: NodeJS.ProcessEnv = process.env): boolean {
+  return Boolean(env.CLAUDECODE) || Object.keys(env).some((k) => k.startsWith("CLAUDE_CODE_"));
+}
+
+/**
+ * Start a rendezvous session for a NON-interactive caller and exit. The printed block is written
+ * FOR the coding agent reading it: the URL to relay, plus the exact command to re-run — which is
+ * simply the command that just ran, because ensureLoggedIn resumes the pending sidecar. The JSON
+ * line carries the same fields for parsers, and the distinct exit code lets wrappers branch.
+ */
+async function pendingLoginExit(): Promise<void> {
+  let url: string;
+  let expiresInSec: number;
+  try {
+    const pending = await createLoginSession();
+    url = pending.url;
+    expiresInSec = Math.max(0, Math.floor((pending.expiresAt - Date.now()) / 1000));
+  } catch (e) {
+    // Couldn't even mint a session (offline / server down) — fall back to the old guidance.
+    process.stderr.write(`inplan login: ${e instanceof Error ? e.message : String(e)}\n`);
+    return;
+  }
+  const resume = ["inplan", ...process.argv.slice(2)].join(" ");
+  process.stderr.write(
+    "inplan: sign-in required.\n" +
+      `  ACTION (human): open this URL in a browser and sign in:\n    ${url}\n` +
+      "  NEXT STEP (coding agent): show that URL to the human, then immediately RE-RUN the\n" +
+      `  command you just ran (\`${resume}\`) — it waits for the sign-in to finish, then continues.\n` +
+      `  The link expires in ${Math.max(1, Math.round(expiresInSec / 60))} minutes.\n`,
+  );
+  output({ status: "login_required", url, resume, expiresInSec });
+  exitAfterFlush(EXIT_LOGIN_PENDING);
+  // exitAfterFlush resolves asynchronously (stdout drain) — park forever so no caller code runs.
+  await new Promise<never>(() => {});
 }
 
 /** Where the staleness check parks its verdict, so it costs one registry hit per TTL, not per turn. */
@@ -652,6 +765,10 @@ export const EXIT_UPGRADE_REQUIRED = 4;
 export const EXIT_PLUGIN_UNAVAILABLE = 5;
 /** A wait that gave up after repeated poll failures (usually an expired session). */
 export const EXIT_WAIT_FAILED = 6;
+/** Sign-in required but this caller is non-interactive: a rendezvous session was created and its
+ *  URL printed (text + a `login_required` JSON line). Relay the URL to the human and RE-RUN the
+ *  same command — it resumes the pending session and blocks until the sign-in completes. */
+export const EXIT_LOGIN_PENDING = 7;
 
 /**
  * Explain, to a human and to the coding agent reading our JSON, why we can't serve this cloud doc.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -28,7 +28,7 @@ import {
 import { agentAuthorFor } from "./agentAuthor";
 import { gitProvenance } from "./provenance";
 import { authedSession, clearAuth, currentUser, liveRemoteBackend, loadAuth, remoteBackend, saveAuth, type AuthFile } from "./cliAuth";
-import { LoginSessionExpiredError, createLoginSession, loadPendingLogin, pollLoginSession, rendezvousLogin, type PendingLogin } from "./cliLogin";
+import { LoginSessionExpiredError, clearPendingLogin, createLoginSession, loadPendingLogin, pollLoginSession, rendezvousLogin, type PendingLogin } from "./cliLogin";
 import { resolveIdentity, setManualProfile, writeLocalProfile } from "./cliProfile";
 import { checkForUpdate, selfUpdate, UPDATE_PKG, warnIfOutdated } from "./update";
 import { runningEditorPid } from "./editorProcess";
@@ -539,9 +539,10 @@ async function waitCycle(backend: WaitBackend, explicitCursor: number | null, co
 
 /**
  * Sign in to the cloud. Two paths:
- *  - Interactive (default): `inplan login` opens the web app's /cli-auth page in the browser
- *    and receives the project url/anon + refresh token back over a one-shot 127.0.0.1 listener
- *    (see cliLogin.ts). This is what a human runs.
+ *  - Interactive (default): `inplan login` runs the cloud-rendezvous handoff (cliLogin.ts) —
+ *    open /cli-auth?session=…#pub=…, the page seals the credentials to our ephemeral key and
+ *    posts them to the session, we poll and decrypt. Non-interactive callers get a pending
+ *    sidecar + EXIT_LOGIN_PENDING instead, and the next invocation resumes it.
  *  - Non-interactive: when `--url`/`--anon`/`--refresh` (or the matching env vars) are all
  *    supplied, store them directly — for scripts and the desktop app, which already hold a
  *    session. Flags win over env so a shell can pre-seed the deployment and pass only `--refresh`.
@@ -574,34 +575,37 @@ async function doLogin(args: string[]): Promise<void> {
     process.stderr.write("inplan login: non-interactive environment — pass --url/--anon/--refresh (or the matching INPLAN_* env vars).\n");
     process.exit(1);
   }
-  // A previous invocation may have already minted a session and exited pending (the coding-agent
-  // loop) — finish THAT login rather than minting a fresh URL the human never asked for.
-  const pending = loadPendingLogin();
-  if (pending) {
-    try {
-      process.stderr.write(`inplan: waiting for the pending browser sign-in to finish…\n  ${pending.url}\n`);
-      const auth = await pollLoginSession(pending, { onNudge: printLoginNudge });
-      saveAuth(auth);
-      await persistCloudIdentity();
-      output({ status: "logged_in", url: auth.url, ...(auth.email ? { email: auth.email } : {}) });
-      return;
-    } catch (e) {
-      if (!(e instanceof LoginSessionExpiredError)) {
-        process.stderr.write(`inplan login: ${e instanceof Error ? e.message : String(e)}\n`);
-        process.exit(1);
-      }
-      /* expired → fall through to a fresh flow */
-    }
-  }
-  // A coding agent (or any pipe) only reads our output when the process exits — start the
-  // session, hand over the URL + resume command, and get out of the way.
+  // Non-interactive callers (coding agents, pipes): resume a pending session a previous
+  // invocation minted — the agent loop's second half — or mint one and exit pending.
   if (!canInteractiveLogin(args) || isKnownAgentEnv()) {
+    const pending = loadPendingLogin();
+    if (pending) {
+      try {
+        process.stderr.write(`inplan: waiting for the pending browser sign-in to finish…\n  ${pending.url}\n`);
+        const auth = await pollLoginSession(pending, { onNudge: printLoginNudge });
+        saveAuth(auth);
+        await persistCloudIdentity();
+        output({ status: "logged_in", url: auth.url, ...(auth.email ? { email: auth.email } : {}) });
+        return;
+      } catch (e) {
+        if (!(e instanceof LoginSessionExpiredError)) {
+          process.stderr.write(`inplan login: ${e instanceof Error ? e.message : String(e)}\n`);
+          process.exit(1);
+        }
+        /* expired → fall through to a fresh pending session */
+      }
+    }
     await pendingLoginExit();
     // pendingLoginExit only returns when the session could not be minted (offline / hub down):
     // no credentials were stored, so this login FAILED — exit 1 like every other failure path
     // (returning here would exit 0 and a script branching on the code would think it signed in).
     process.exit(1);
   }
+  // An interactive human explicitly running `inplan login` means "sign me in NOW": don't block
+  // for minutes on a leftover-but-still-valid pending session from an aborted agent flow they may
+  // never have seen — drop it and mint fresh. (Auto-login's ensureLoggedIn still resumes first,
+  // which is the right default for the agent loop's re-run.)
+  clearPendingLogin();
   try {
     const auth = await defaultRendezvousLogin();
     saveAuth(auth);
@@ -769,7 +773,10 @@ async function pendingLoginExit(): Promise<void> {
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i]!;
     if (skipValueOf.has(a)) {
-      i++; // drop the flag AND its value
+      // Drop the flag AND its value — but only when the next token IS a value. A valueless
+      // `--refresh` (empty $TOKEN expansion) followed by another option must not swallow that
+      // option: `--refresh --remote doc` minus `--remote` would resume against a local path.
+      if (i + 1 < argv.length && !argv[i + 1]!.startsWith("-")) i++;
       continue;
     }
     if ([...skipValueOf].some((f) => a.startsWith(`${f}=`))) continue;

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -577,8 +577,18 @@ async function doLogin(args: string[]): Promise<void> {
   }
   // Non-interactive callers (coding agents, pipes): resume a pending session a previous
   // invocation minted — the agent loop's second half — or mint one and exit pending.
-  if (!canInteractiveLogin(args) || isKnownAgentEnv()) {
-    const pending = loadPendingLogin();
+  // A human at a TTY who set INPLAN_NO_BROWSER is still INTERACTIVE — they just don't want a
+  // popup. Route them to the inline flow with the auto-open disabled (URL printed, poll inline)
+  // instead of the agent's pending-exit, which would block on a stale sidecar or exit 7 with
+  // nothing polling.
+  const noBrowserHuman =
+    !canInteractiveLogin(args) &&
+    Boolean(process.env.INPLAN_NO_BROWSER) &&
+    Boolean(process.stdin.isTTY && process.stdout.isTTY) &&
+    !process.env.CI &&
+    !isKnownAgentEnv();
+  if ((!canInteractiveLogin(args) && !noBrowserHuman) || isKnownAgentEnv()) {
+    const pending = await loadPendingLogin();
     if (pending) {
       try {
         process.stderr.write(`inplan: waiting for the pending browser sign-in to finish…\n  ${pending.url}\n`);
@@ -607,7 +617,13 @@ async function doLogin(args: string[]): Promise<void> {
   // which is the right default for the agent loop's re-run.)
   clearPendingLogin();
   try {
-    const auth = await defaultRendezvousLogin();
+    const auth = noBrowserHuman
+      ? await rendezvousLogin({
+          onUrl: (u) => process.stderr.write(`Open this URL in your browser to sign in:\n  ${u}\n`),
+          onNudge: printLoginNudge,
+          open: () => {}, // INPLAN_NO_BROWSER: never launch one — the printed URL is the flow
+        })
+      : await defaultRendezvousLogin();
     saveAuth(auth);
     await persistCloudIdentity();
     output({ status: "logged_in", url: auth.url, ...(auth.email ? { email: auth.email } : {}) });
@@ -672,7 +688,7 @@ export async function ensureLoggedIn(
   // stall an unattended run for the whole poll window.
   if (loginOptOut(args)) return false;
 
-  const pending = loadPendingLogin();
+  const pending = await loadPendingLogin();
   if (pending) {
     try {
       process.stderr.write(`inplan: waiting for the pending browser sign-in to finish…\n  ${pending.url}\n`);
@@ -773,10 +789,12 @@ async function pendingLoginExit(): Promise<void> {
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i]!;
     if (skipValueOf.has(a)) {
-      // Drop the flag AND its value — but only when the next token IS a value. A valueless
-      // `--refresh` (empty $TOKEN expansion) followed by another option must not swallow that
-      // option: `--refresh --remote doc` minus `--remote` would resume against a local path.
-      if (i + 1 < argv.length && !argv[i + 1]!.startsWith("-")) i++;
+      // Drop the flag AND its value — but only when the next token IS a value. Options in this
+      // CLI are `--`-prefixed (getFlag's boundary), so a token starting with a SINGLE hyphen is
+      // a legitimate credential value (tokens can begin with '-') and must be dropped with its
+      // flag; only another `--option` means the flag was valueless (empty $TOKEN expansion) and
+      // that option must survive.
+      if (i + 1 < argv.length && !argv[i + 1]!.startsWith("--")) i++;
       continue;
     }
     if ([...skipValueOf].some((f) => a.startsWith(`${f}=`))) continue;

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -755,7 +755,14 @@ async function pendingLoginExit(): Promise<void> {
   // Quote arguments that need it: the skill tells the agent to re-run `resume` VERBATIM, so an
   // argument carrying a space or shell metacharacter (`inplan message doc "did X this turn"`,
   // `--model "Opus 4.8"`) must survive re-parsing as ONE argument, not shatter into several.
-  const resume = ["inplan", ...process.argv.slice(2).map((a) => (/^[A-Za-z0-9_@%+=:,.\/-]+$/.test(a) ? a : shellQuote(a)))].join(" ");
+  const quoted = (a: string): string => (/^[A-Za-z0-9_@%+=:,.\/-]+$/.test(a) ? a : shellQuote(a));
+  // The executable half must also be re-runnable from THIS environment: a bare `inplan` only
+  // exists for global installs. When the entry script was invoked under another name (npx cache,
+  // a repo checkout's dist/cli.js), rebuild the invocation from the running node + entry script.
+  const entry = process.argv[1] ?? "";
+  const invokedAsInplan = entry.split(/[\\/]/).pop()?.replace(/\.(cmd|ps1)$/i, "") === "inplan";
+  const argv0 = invokedAsInplan ? ["inplan"] : [quoted(process.execPath), quoted(entry)];
+  const resume = [...argv0, ...process.argv.slice(2).map(quoted)].join(" ");
   process.stderr.write(
     "inplan: sign-in required.\n" +
       `  ACTION (human): open this URL in a browser and sign in:\n    ${url}\n` +

--- a/packages/cli/src/cliLogin.ts
+++ b/packages/cli/src/cliLogin.ts
@@ -1,47 +1,209 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //
-// Interactive `inplan login`: the browser handoff. The CLI can't safely prompt for a
-// password (and OAuth providers reject headless flows), so login is delegated to the web
-// app's /cli-auth page, exactly as the desktop app does. We spin up a one-shot
-// 127.0.0.1 listener, open the browser at /cli-auth?port=<port>&state=<nonce>, and the page
-// POSTs the project url/anon + the freshly-minted refresh token back over the loopback once a
-// session exists. The token only ever crosses localhost; `state` is echoed back so a stray
-// local request can't inject a session.
+// `inplan login` — the cloud-rendezvous browser handoff. The CLI can't safely prompt for a
+// password (and OAuth providers reject headless flows), so login is delegated to the web app's
+// /cli-auth page. Historically the page POSTed the credentials to a one-shot 127.0.0.1 listener;
+// that breaks exactly where agent workflows live — a coding agent only reads output when the
+// process exits, and a CLI on a remote box can never receive a loopback POST from the human's
+// browser on another machine. So the handoff now rides a short-lived CLOUD session instead
+// (the collab server's /api/v1/cli-login routes):
+//
+//   1. Generate an ephemeral ECDH P-256 keypair; create a session; persist a pending-login
+//      sidecar (0600) so a LATER invocation can finish what this one starts.
+//   2. Send the human to /cli-auth?session=<id>&pub=<publicKey>. On load the page acks
+//      `opened` (the cross-machine-safe "the browser really opened" signal — no ack within
+//      30 s ⇒ tell the human to open the URL manually). After sign-in the page seals
+//      {url, anon, refresh, email} to our public key (ECDH → HKDF-SHA256 → AES-256-GCM)
+//      and posts the ciphertext to the session.
+//   3. Poll the session; on completion decrypt locally (the server only ever stores bytes it
+//      cannot read), persist the credentials, delete the sidecar. Sessions are single-use and
+//      expire server-side in ~10 minutes.
 
-import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
-import type { AddressInfo } from "node:net";
 import { spawn } from "node:child_process";
-import { randomBytes } from "node:crypto";
+import { webcrypto } from "node:crypto";
+import { chmodSync, existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
 import type { AuthFile } from "./cliAuth";
+import { resolveHubUrl } from "./pluginGate";
+
+const subtle = webcrypto.subtle;
 
 /** The web app origin that hosts /cli-auth. Overridable for self-hosted / dev. */
 const DEFAULT_WEB_ORIGIN = process.env.INPLAN_WEB_URL || "https://inplan.ai";
+/** HKDF domain separation — MUST match the /cli-auth page's sealer exactly. */
+const HKDF_INFO = "inplan cli-login v1";
 const DEFAULT_TIMEOUT_MS = 3 * 60_000;
-const MAX_BODY_BYTES = 64 * 1024; // a refresh token is small; cap to refuse junk.
+const POLL_MS = 2_000;
+/** No `opened` ack by this long ⇒ the browser likely never opened — nudge the human. */
+const NUDGE_MS = 30_000;
 
-export interface BrowserLoginOptions {
-  /** Origin hosting /cli-auth (default https://inplan.ai or $INPLAN_WEB_URL). */
-  webOrigin?: string;
-  /** How long to wait for the browser handoff before giving up. */
-  timeoutMs?: number;
-  /** Launch the system browser at `url`. Overridable in tests. Default: OS opener. */
-  open?: (url: string) => void;
-  /** Notified with the handoff URL so the caller can print a manual fallback. */
-  onUrl?: (url: string) => void;
+/** The collab server's HTTP base (same resolution as the plugin gate: ws(s) → http(s)). */
+export function loginApiBase(): string {
+  return resolveHubUrl().replace(/^ws/, "http").replace(/\/+$/, "");
 }
 
-/** The JSON the /cli-auth page POSTs back over the loopback once signed in. */
-interface Handoff {
-  state: string;
+export interface RendezvousDeps {
+  fetchImpl?: typeof fetch;
+  /** Launch the system browser at `url`. Overridable in tests. Default: OS opener. */
+  open?: (url: string) => void;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export interface RendezvousLoginOptions extends RendezvousDeps {
+  webOrigin?: string;
+  apiBase?: string;
+  /** How long the foreground command waits before giving up (the session itself lives longer,
+   *  so a follow-up invocation can still resume it). */
+  timeoutMs?: number;
+  /** Notified with the handoff URL so the caller can print a manual fallback. */
+  onUrl?: (url: string) => void;
+  /** Fired once if the page hasn't acked `opened` within NUDGE_MS — "open the URL manually". */
+  onNudge?: () => void;
+}
+
+/** A login this process started (or a previous one left behind): everything a later invocation
+ *  needs to finish the handoff. The private key never leaves this machine. */
+export interface PendingLogin {
+  sessionId: string;
+  /** Our ephemeral ECDH private key (PKCS#8, base64) — decrypts the sealed handoff. */
+  privateKeyPkcs8: string;
   url: string;
-  anon: string;
-  refresh: string;
-  email?: string;
+  apiBase: string;
+  expiresAt: number; // epoch ms
+}
+
+/** `~/.inplan/login-pending.json` — `INPLAN_HOME` overrides the base dir (tests). */
+export function pendingLoginPath(): string {
+  const base = process.env.INPLAN_HOME || join(homedir(), ".inplan");
+  return join(base, "login-pending.json");
+}
+
+export function clearPendingLogin(): void {
+  try {
+    unlinkSync(pendingLoginPath());
+  } catch {
+    /* already gone */
+  }
+}
+
+/** The pending login a previous invocation left behind, if it can still complete. An expired or
+ *  unreadable sidecar is cleared and reads as absent. */
+export function loadPendingLogin(now: number = Date.now()): PendingLogin | null {
+  const path = pendingLoginPath();
+  if (!existsSync(path)) return null;
+  try {
+    const p = JSON.parse(readFileSync(path, "utf8")) as PendingLogin;
+    if (
+      typeof p.sessionId !== "string" ||
+      typeof p.privateKeyPkcs8 !== "string" ||
+      typeof p.url !== "string" ||
+      typeof p.apiBase !== "string" ||
+      typeof p.expiresAt !== "number" ||
+      p.expiresAt <= now
+    ) {
+      clearPendingLogin();
+      return null;
+    }
+    return p;
+  } catch {
+    clearPendingLogin();
+    return null;
+  }
+}
+
+/** Create a rendezvous session + the sidecar that lets ANY later invocation finish it. */
+export async function createLoginSession(opts: RendezvousLoginOptions = {}): Promise<PendingLogin> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const now = opts.now ?? Date.now;
+  const apiBase = opts.apiBase ?? loginApiBase();
+  const webOrigin = (opts.webOrigin ?? DEFAULT_WEB_ORIGIN).replace(/\/$/, "");
+
+  const keys = await subtle.generateKey({ name: "ECDH", namedCurve: "P-256" }, true, ["deriveBits"]);
+  const pub = Buffer.from(await subtle.exportKey("spki", keys.publicKey)).toString("base64");
+  const priv = Buffer.from(await subtle.exportKey("pkcs8", keys.privateKey)).toString("base64");
+
+  const res = await fetchImpl(`${apiBase}/api/v1/cli-login`, { method: "POST" });
+  if (!res.ok) throw new Error(`could not start a sign-in session (HTTP ${res.status})`);
+  const { sessionId, expiresInSec } = (await res.json()) as { sessionId: string; expiresInSec: number };
+  if (typeof sessionId !== "string" || !sessionId) throw new Error("could not start a sign-in session (bad response)");
+
+  const pending: PendingLogin = {
+    sessionId,
+    privateKeyPkcs8: priv,
+    url: `${webOrigin}/cli-auth?session=${encodeURIComponent(sessionId)}&pub=${encodeURIComponent(pub)}`,
+    apiBase,
+    expiresAt: now() + (typeof expiresInSec === "number" ? expiresInSec : 600) * 1000,
+  };
+  const path = pendingLoginPath();
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(pending, null, 2), { mode: 0o600 });
+  chmodSync(path, 0o600); // writeFileSync mode is ignored when the file pre-existed
+  return pending;
+}
+
+/** Distinguishes "this session can never complete" (sidecar cleared; start fresh) from a
+ *  foreground timeout (sidecar kept; a later invocation resumes). */
+export class LoginSessionExpiredError extends Error {}
+
+/**
+ * Poll `pending` until the page posts the sealed handoff, then decrypt + return the credentials
+ * (the sidecar is deleted on success — sessions are single-use). Throws LoginSessionExpiredError
+ * when the session is gone server-side (also clears the sidecar), or a plain Error on foreground
+ * timeout (the sidecar survives so the NEXT invocation picks the login up — the coding-agent loop).
+ */
+export async function pollLoginSession(pending: PendingLogin, opts: RendezvousLoginOptions = {}): Promise<AuthFile> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const now = opts.now ?? Date.now;
+  const sleep = opts.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  const deadline = now() + (opts.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+  const nudgeAt = now() + NUDGE_MS;
+  let nudged = false;
+
+  while (true) {
+    if (now() >= pending.expiresAt) {
+      clearPendingLogin();
+      throw new LoginSessionExpiredError("the sign-in link expired — run the command again for a fresh one");
+    }
+    if (now() >= deadline) throw new Error("login timed out — no response from the browser");
+
+    const res = await fetchImpl(`${pending.apiBase}/api/v1/cli-login/${encodeURIComponent(pending.sessionId)}`, { method: "GET" });
+    if (res.status === 404) {
+      // Unknown/expired/already-claimed server-side — this pending login can never complete.
+      clearPendingLogin();
+      throw new LoginSessionExpiredError("the sign-in link expired — run the command again for a fresh one");
+    }
+    if (res.ok) {
+      const body = (await res.json()) as { status?: string; epk?: string; iv?: string; ct?: string };
+      if (body.status === "completed" && body.epk && body.iv && body.ct) {
+        const auth = await unsealHandoff(pending.privateKeyPkcs8, { epk: body.epk, iv: body.iv, ct: body.ct });
+        clearPendingLogin();
+        return auth;
+      }
+      // Still pending after the nudge window with the page never even loading? Tell the human —
+      // open() is fire-and-forget (a spawn "success" doesn't mean a browser appeared), so the
+      // page's own `opened` ack is the only trustworthy signal, and it works cross-machine.
+      if (!nudged && body.status === "pending" && now() >= nudgeAt) {
+        nudged = true;
+        opts.onNudge?.();
+      }
+    }
+    await sleep(POLL_MS);
+  }
+}
+
+/** The one-command human flow: create a session, open the browser, poll to completion inline. */
+export async function rendezvousLogin(opts: RendezvousLoginOptions = {}): Promise<AuthFile> {
+  const pending = await createLoginSession(opts);
+  opts.onUrl?.(pending.url);
+  (opts.open ?? openInBrowser)(pending.url);
+  return pollLoginSession(pending, opts);
 }
 
 /** Best-effort: open `url` in the OS browser. Errors are swallowed — the URL is also
- *  printed so the user can open it by hand. */
-function openInBrowser(url: string): void {
+ *  printed so the user can open it by hand (and the 30 s no-`opened` nudge re-prompts). */
+export function openInBrowser(url: string): void {
   const cmd = process.platform === "darwin" ? "open" : process.platform === "win32" ? "cmd" : "xdg-open";
   const args = process.platform === "win32" ? ["/c", "start", "", url] : [url];
   try {
@@ -55,103 +217,26 @@ function openInBrowser(url: string): void {
   }
 }
 
-function isHandoff(v: unknown): v is Handoff {
-  if (typeof v !== "object" || v === null) return false;
-  const o = v as Record<string, unknown>;
-  return (
-    typeof o.state === "string" &&
-    typeof o.url === "string" &&
-    typeof o.anon === "string" &&
-    typeof o.refresh === "string" &&
-    (o.email === undefined || typeof o.email === "string")
+/** Decrypt the page's sealed handoff: ECDH(P-256) → HKDF-SHA256(salt=∅, info=HKDF_INFO) →
+ *  AES-256-GCM — the exact inverse of the page's `sealCliLogin`. */
+async function unsealHandoff(privateKeyPkcs8: string, sealed: { epk: string; iv: string; ct: string }): Promise<AuthFile> {
+  const privateKey = await subtle.importKey("pkcs8", Buffer.from(privateKeyPkcs8, "base64"), { name: "ECDH", namedCurve: "P-256" }, false, [
+    "deriveBits",
+  ]);
+  const epk = await subtle.importKey("spki", Buffer.from(sealed.epk, "base64"), { name: "ECDH", namedCurve: "P-256" }, false, []);
+  const shared = await subtle.deriveBits({ name: "ECDH", public: epk }, privateKey, 256);
+  const hkdfKey = await subtle.importKey("raw", shared, "HKDF", false, ["deriveKey"]);
+  const aes = await subtle.deriveKey(
+    { name: "HKDF", hash: "SHA-256", salt: new Uint8Array(0), info: new TextEncoder().encode(HKDF_INFO) },
+    hkdfKey,
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["decrypt"],
   );
-}
-
-/**
- * Run the browser login handoff and resolve with the credentials to persist. Rejects on
- * timeout or if the listener fails. The caller is responsible for `saveAuth` + identity.
- */
-export function browserLogin(opts: BrowserLoginOptions = {}): Promise<AuthFile> {
-  const webOrigin = (opts.webOrigin ?? DEFAULT_WEB_ORIGIN).replace(/\/$/, "");
-  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  const open = opts.open ?? openInBrowser;
-  const state = randomBytes(16).toString("hex");
-
-  return new Promise<AuthFile>((resolve, reject) => {
-    let settled = false;
-    const finish = (fn: () => void) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      server.close();
-      fn();
-    };
-
-    // CORS: the page lives on an https origin and fetches this http://127.0.0.1 listener, so a
-    // JSON POST is preflighted. Echo the caller's Origin (the page) and allow the JSON content-type.
-    const cors = (req: IncomingMessage, res: ServerResponse) => {
-      res.setHeader("Access-Control-Allow-Origin", req.headers.origin || webOrigin);
-      res.setHeader("Vary", "Origin");
-      res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
-      res.setHeader("Access-Control-Allow-Headers", "content-type");
-    };
-
-    const server = createServer((req, res) => {
-      const url = req.url ?? "";
-      if (req.method === "OPTIONS" && url.startsWith("/cb")) {
-        cors(req, res);
-        res.writeHead(204).end();
-        return;
-      }
-      if (req.method !== "POST" || !url.startsWith("/cb")) {
-        res.writeHead(404).end();
-        return;
-      }
-      cors(req, res);
-      let body = "";
-      let tooBig = false;
-      req.on("data", (chunk: Buffer) => {
-        body += chunk.toString("utf8");
-        if (body.length > MAX_BODY_BYTES) {
-          tooBig = true;
-          req.destroy();
-        }
-      });
-      req.on("end", () => {
-        if (tooBig) {
-          res.writeHead(413).end();
-          return;
-        }
-        let parsed: unknown;
-        try {
-          parsed = JSON.parse(body);
-        } catch {
-          res.writeHead(400).end();
-          return;
-        }
-        if (!isHandoff(parsed) || parsed.state !== state) {
-          // Not our handoff (mismatched/missing state) — reject but keep listening; a stray
-          // local request must not end the real flow.
-          res.writeHead(403).end();
-          return;
-        }
-        // Acknowledge so the page can show "you can close this tab", then finish.
-        res.writeHead(200, { "content-type": "text/plain" }).end("inplan: signed in — you can close this tab.");
-        const { url: projUrl, anon, refresh, email } = parsed;
-        finish(() => resolve({ url: projUrl, anonKey: anon, refreshToken: refresh, ...(email ? { email } : {}) }));
-      });
-    });
-
-    server.on("error", (err) => finish(() => reject(err)));
-
-    const timer = setTimeout(() => finish(() => reject(new Error("login timed out — no response from the browser"))), timeoutMs);
-    if (typeof timer.unref === "function") timer.unref();
-
-    server.listen(0, "127.0.0.1", () => {
-      const { port } = server.address() as AddressInfo;
-      const target = `${webOrigin}/cli-auth?port=${port}&state=${state}`;
-      opts.onUrl?.(target);
-      open(target);
-    });
-  });
+  const pt = await subtle.decrypt({ name: "AES-GCM", iv: Buffer.from(sealed.iv, "base64") }, aes, Buffer.from(sealed.ct, "base64"));
+  const parsed = JSON.parse(new TextDecoder().decode(pt)) as { url?: string; anon?: string; refresh?: string; email?: string };
+  if (typeof parsed.url !== "string" || typeof parsed.anon !== "string" || typeof parsed.refresh !== "string") {
+    throw new Error("sign-in handoff was malformed");
+  }
+  return { url: parsed.url, anonKey: parsed.anon, refreshToken: parsed.refresh, ...(parsed.email ? { email: parsed.email } : {}) };
 }

--- a/packages/cli/src/cliLogin.ts
+++ b/packages/cli/src/cliLogin.ts
@@ -155,8 +155,20 @@ export async function createLoginSession(opts: RendezvousLoginOptions = {}): Pro
   };
   const path = pendingLoginPath();
   mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, JSON.stringify(pending, null, 2), { mode: 0o600 });
-  chmodSync(path, 0o600); // writeFileSync mode is ignored when the file pre-existed
+  // EXCLUSIVE create: two concurrent commands must not each mint a session with the second
+  // overwriting the first (whose printed URL would then be unresumable — its private key gone).
+  // The loser adopts the winner's still-valid pending login instead; a stale/corrupt leftover is
+  // cleared and the write retried once.
+  try {
+    writeFileSync(path, JSON.stringify(pending, null, 2), { mode: 0o600, flag: "wx" });
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code !== "EEXIST") throw e;
+    const winner = loadPendingLogin(now());
+    if (winner) return winner;
+    // The existing sidecar was expired/corrupt (loadPendingLogin cleared it) — take the slot.
+    writeFileSync(path, JSON.stringify(pending, null, 2), { mode: 0o600, flag: "wx" });
+  }
+  chmodSync(path, 0o600); // belt-and-braces: mode can be masked by umask
   return pending;
 }
 
@@ -192,7 +204,9 @@ export async function pollLoginSession(pending: PendingLogin, opts: RendezvousLo
         // The poll credential rides a header (never a URL, so never an access log) — see
         // PendingLogin.pollToken: the session id alone must not read or destroy the handoff.
         headers: { "x-inplan-poll-token": pending.pollToken },
-        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+        // Capped to the REMAINING deadline: an in-flight request must not let the foreground
+        // wait overrun its budget by a whole request-timeout.
+        signal: AbortSignal.timeout(Math.max(1, Math.min(REQUEST_TIMEOUT_MS, deadline - now()))),
       });
     } catch {
       // Transient transport failure (DNS blip, dropped connection, a stalled request cut by the
@@ -209,7 +223,17 @@ export async function pollLoginSession(pending: PendingLogin, opts: RendezvousLo
     if (res.ok) {
       const body = (await res.json()) as { status?: string; epk?: string; iv?: string; ct?: string };
       if (body.status === "completed" && body.epk && body.iv && body.ct) {
-        const auth = await unsealHandoff(pending.privateKeyPkcs8, { epk: body.epk, iv: body.iv, ct: body.ct });
+        let auth: AuthFile;
+        try {
+          auth = await unsealHandoff(pending.privateKeyPkcs8, { epk: body.epk, iv: body.iv, ct: body.ct });
+        } catch {
+          // The handoff can't be decrypted (wrong key / corrupt ciphertext) — and the claim-once
+          // GET already consumed the row, so this session can NEVER complete. Clear the sidecar
+          // and report it like an expiry, so the caller starts a FRESH session instead of
+          // treating a permanently-dead login as a transient failure to retry.
+          clearPendingLogin();
+          throw new LoginSessionExpiredError("the sign-in handoff could not be read — run the command again for a fresh link");
+        }
         clearPendingLogin();
         return auth;
       }

--- a/packages/cli/src/cliLogin.ts
+++ b/packages/cli/src/cliLogin.ts
@@ -37,6 +37,9 @@ const DEFAULT_TIMEOUT_MS = 3 * 60_000;
 const POLL_MS = 2_000;
 /** No `opened` ack by this long ⇒ the browser likely never opened — nudge the human. */
 const NUDGE_MS = 30_000;
+/** Per-request bound: a stalled TCP connection must not hang the CLI silently (create) or stop
+ *  the poll loop's deadline from ever being re-checked (poll). */
+const REQUEST_TIMEOUT_MS = 15_000;
 
 /** The collab server's HTTP base (same resolution as the plugin gate: ws(s) → http(s)). */
 export function loginApiBase(): string {
@@ -124,7 +127,7 @@ export async function createLoginSession(opts: RendezvousLoginOptions = {}): Pro
   const pub = Buffer.from(await subtle.exportKey("spki", keys.publicKey)).toString("base64");
   const priv = Buffer.from(await subtle.exportKey("pkcs8", keys.privateKey)).toString("base64");
 
-  const res = await fetchImpl(`${apiBase}/api/v1/cli-login`, { method: "POST" });
+  const res = await fetchImpl(`${apiBase}/api/v1/cli-login`, { method: "POST", signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) });
   if (!res.ok) throw new Error(`could not start a sign-in session (HTTP ${res.status})`);
   const { sessionId, expiresInSec } = (await res.json()) as { sessionId: string; expiresInSec: number };
   if (typeof sessionId !== "string" || !sessionId) throw new Error("could not start a sign-in session (bad response)");
@@ -132,9 +135,15 @@ export async function createLoginSession(opts: RendezvousLoginOptions = {}): Pro
   const pending: PendingLogin = {
     sessionId,
     privateKeyPkcs8: priv,
-    url: `${webOrigin}/cli-auth?session=${encodeURIComponent(sessionId)}&pub=${encodeURIComponent(pub)}`,
+    // `pub` rides the URL FRAGMENT so it never reaches server access logs (a log reader holding
+    // session + pub could complete the session for their own account); the page reads it from
+    // location.hash. Public key or not, keep the whole capability out of logs.
+    url: `${webOrigin}/cli-auth?session=${encodeURIComponent(sessionId)}#pub=${encodeURIComponent(pub)}`,
     apiBase,
-    expiresAt: now() + (typeof expiresInSec === "number" ? expiresInSec : 600) * 1000,
+    // Guard against a bogus server TTL: NaN/Infinity/negative would make expiresAt a past
+    // timestamp — or one that NEVER expires (NaN compares false forever), leaving a dead sidecar
+    // that every later invocation resumes until the server 404s.
+    expiresAt: now() + (Number.isFinite(expiresInSec) && expiresInSec > 0 ? expiresInSec : 600) * 1000,
   };
   const path = pendingLoginPath();
   mkdirSync(dirname(path), { recursive: true });
@@ -168,7 +177,19 @@ export async function pollLoginSession(pending: PendingLogin, opts: RendezvousLo
     }
     if (now() >= deadline) throw new Error("login timed out — no response from the browser");
 
-    const res = await fetchImpl(`${pending.apiBase}/api/v1/cli-login/${encodeURIComponent(pending.sessionId)}`, { method: "GET" });
+    let res: Awaited<ReturnType<typeof fetchImpl>>;
+    try {
+      res = await fetchImpl(`${pending.apiBase}/api/v1/cli-login/${encodeURIComponent(pending.sessionId)}`, {
+        method: "GET",
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
+    } catch {
+      // Transient transport failure (DNS blip, dropped connection, a stalled request cut by the
+      // per-request timeout): retry like a 5xx — the session is still valid, and the foreground
+      // deadline above bounds the total wait. Only a 404 (below) ends the session for good.
+      await sleep(POLL_MS);
+      continue;
+    }
     if (res.status === 404) {
       // Unknown/expired/already-claimed server-side — this pending login can never complete.
       clearPendingLogin();

--- a/packages/cli/src/cliLogin.ts
+++ b/packages/cli/src/cliLogin.ts
@@ -72,6 +72,10 @@ export interface PendingLogin {
   sessionId: string;
   /** Our ephemeral ECDH private key (PKCS#8, base64) — decrypts the sealed handoff. */
   privateKeyPkcs8: string;
+  /** The CLI-only poll credential (returned once at create; the server stores only its hash).
+   *  Polling requires it, so the browser-facing session id in the URL is not a claim capability
+   *  — a leaked URL can neither read nor destroy the handoff. Sent via an unlogged header. */
+  pollToken: string;
   url: string;
   apiBase: string;
   expiresAt: number; // epoch ms
@@ -101,6 +105,7 @@ export function loadPendingLogin(now: number = Date.now()): PendingLogin | null 
     if (
       typeof p.sessionId !== "string" ||
       typeof p.privateKeyPkcs8 !== "string" ||
+      typeof p.pollToken !== "string" ||
       typeof p.url !== "string" ||
       typeof p.apiBase !== "string" ||
       typeof p.expiresAt !== "number" ||
@@ -129,12 +134,15 @@ export async function createLoginSession(opts: RendezvousLoginOptions = {}): Pro
 
   const res = await fetchImpl(`${apiBase}/api/v1/cli-login`, { method: "POST", signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) });
   if (!res.ok) throw new Error(`could not start a sign-in session (HTTP ${res.status})`);
-  const { sessionId, expiresInSec } = (await res.json()) as { sessionId: string; expiresInSec: number };
-  if (typeof sessionId !== "string" || !sessionId) throw new Error("could not start a sign-in session (bad response)");
+  const { sessionId, pollToken, expiresInSec } = (await res.json()) as { sessionId: string; pollToken: string; expiresInSec: number };
+  if (typeof sessionId !== "string" || !sessionId || typeof pollToken !== "string" || !pollToken) {
+    throw new Error("could not start a sign-in session (bad response)");
+  }
 
   const pending: PendingLogin = {
     sessionId,
     privateKeyPkcs8: priv,
+    pollToken,
     // `pub` rides the URL FRAGMENT so it never reaches server access logs (a log reader holding
     // session + pub could complete the session for their own account); the page reads it from
     // location.hash. Public key or not, keep the whole capability out of logs.
@@ -181,6 +189,9 @@ export async function pollLoginSession(pending: PendingLogin, opts: RendezvousLo
     try {
       res = await fetchImpl(`${pending.apiBase}/api/v1/cli-login/${encodeURIComponent(pending.sessionId)}`, {
         method: "GET",
+        // The poll credential rides a header (never a URL, so never an access log) — see
+        // PendingLogin.pollToken: the session id alone must not read or destroy the handoff.
+        headers: { "x-inplan-poll-token": pending.pollToken },
         signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
       });
     } catch {

--- a/packages/cli/src/cliLogin.ts
+++ b/packages/cli/src/cliLogin.ts
@@ -25,7 +25,7 @@ import { chmodSync, existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSy
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import type { AuthFile } from "./cliAuth";
-import { resolveHubUrl } from "./pluginGate";
+import { hubHttpBase } from "./pluginGate";
 
 const subtle = webcrypto.subtle;
 
@@ -41,9 +41,10 @@ const NUDGE_MS = 30_000;
  *  the poll loop's deadline from ever being re-checked (poll). */
 const REQUEST_TIMEOUT_MS = 15_000;
 
-/** The collab server's HTTP base (same resolution as the plugin gate: ws(s) → http(s)). */
+/** The collab server's HTTP base — pluginGate's single ws(s)→http(s) mapping, so the login and
+ *  the plugin gate can never derive different endpoints from the same hub URL. */
 export function loginApiBase(): string {
-  return resolveHubUrl().replace(/^ws/, "http").replace(/\/+$/, "");
+  return hubHttpBase();
 }
 
 export interface RendezvousDeps {
@@ -93,6 +94,20 @@ export function clearPendingLogin(): void {
   } catch {
     /* already gone */
   }
+}
+
+/** Remove the sidecar ONLY if it still belongs to `sessionId`. A delayed poll of an OLD session
+ *  (expired, claimed, undecryptable) must never erase a NEWER pending login that replaced it —
+ *  that would make the replacement's printed URL impossible to resume. */
+function clearPendingLoginFor(sessionId: string): void {
+  const path = pendingLoginPath();
+  try {
+    const p = JSON.parse(readFileSync(path, "utf8")) as { sessionId?: unknown };
+    if (p.sessionId !== sessionId) return; // a newer login owns the slot now — leave it alone
+  } catch {
+    /* unreadable/absent → nothing to protect */
+  }
+  clearPendingLogin();
 }
 
 /** The pending login a previous invocation left behind, if it can still complete. An expired or
@@ -192,7 +207,7 @@ export async function pollLoginSession(pending: PendingLogin, opts: RendezvousLo
 
   while (true) {
     if (now() >= pending.expiresAt) {
-      clearPendingLogin();
+      clearPendingLoginFor(pending.sessionId);
       throw new LoginSessionExpiredError("the sign-in link expired — run the command again for a fresh one");
     }
     if (now() >= deadline) throw new Error("login timed out — no response from the browser");
@@ -217,11 +232,19 @@ export async function pollLoginSession(pending: PendingLogin, opts: RendezvousLo
     }
     if (res.status === 404) {
       // Unknown/expired/already-claimed server-side — this pending login can never complete.
-      clearPendingLogin();
+      clearPendingLoginFor(pending.sessionId);
       throw new LoginSessionExpiredError("the sign-in link expired — run the command again for a fresh one");
     }
     if (res.ok) {
-      const body = (await res.json()) as { status?: string; epk?: string; iv?: string; ct?: string };
+      let body: { status?: string; epk?: string; iv?: string; ct?: string };
+      try {
+        body = (await res.json()) as { status?: string; epk?: string; iv?: string; ct?: string };
+      } catch {
+        // A 200 with an empty/non-JSON body (proxy hiccup, captive portal) is as transient as a
+        // dropped connection — retry within the deadline instead of killing a valid session's wait.
+        await sleep(POLL_MS);
+        continue;
+      }
       if (body.status === "completed" && body.epk && body.iv && body.ct) {
         let auth: AuthFile;
         try {
@@ -231,10 +254,10 @@ export async function pollLoginSession(pending: PendingLogin, opts: RendezvousLo
           // GET already consumed the row, so this session can NEVER complete. Clear the sidecar
           // and report it like an expiry, so the caller starts a FRESH session instead of
           // treating a permanently-dead login as a transient failure to retry.
-          clearPendingLogin();
+          clearPendingLoginFor(pending.sessionId);
           throw new LoginSessionExpiredError("the sign-in handoff could not be read — run the command again for a fresh link");
         }
-        clearPendingLogin();
+        clearPendingLoginFor(pending.sessionId);
         return auth;
       }
       // Still pending after the nudge window with the page never even loading? Tell the human —

--- a/packages/cli/src/cliLogin.ts
+++ b/packages/cli/src/cliLogin.ts
@@ -21,7 +21,7 @@
 
 import { spawn } from "node:child_process";
 import { webcrypto } from "node:crypto";
-import { chmodSync, existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmdirSync, unlinkSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import type { AuthFile } from "./cliAuth";
@@ -96,18 +96,54 @@ export function clearPendingLogin(): void {
   }
 }
 
+/** Serialize sidecar ownership (read-check-delete-create) with a tiny advisory lock: an atomic
+ *  mkdir held for microseconds. Without it, a delayed poll's owner-check and unlink could
+ *  interleave with a fresh login's write and erase the newcomer. A lock outliving the spin
+ *  budget is stolen — a crashed holder must not brick logins forever. */
+function withSidecarLock<T>(fn: () => T): T {
+  const lock = pendingLoginPath() + ".lock";
+  const deadline = Date.now() + 2000;
+  for (;;) {
+    try {
+      mkdirSync(lock, { recursive: false });
+      break;
+    } catch {
+      if (Date.now() > deadline) {
+        try {
+          rmdirSync(lock); // steal a stale lock left by a crashed process
+        } catch {
+          /* already released */
+        }
+      }
+      /* busy-spin: the critical sections are file-touch sized */
+    }
+  }
+  try {
+    return fn();
+  } finally {
+    try {
+      rmdirSync(lock);
+    } catch {
+      /* already released */
+    }
+  }
+}
+
 /** Remove the sidecar ONLY if it still belongs to `sessionId`. A delayed poll of an OLD session
  *  (expired, claimed, undecryptable) must never erase a NEWER pending login that replaced it —
- *  that would make the replacement's printed URL impossible to resume. */
+ *  that would make the replacement's printed URL impossible to resume. Owner-check + unlink run
+ *  as one critical section, so the check can't go stale before the delete. */
 function clearPendingLoginFor(sessionId: string): void {
-  const path = pendingLoginPath();
-  try {
-    const p = JSON.parse(readFileSync(path, "utf8")) as { sessionId?: unknown };
-    if (p.sessionId !== sessionId) return; // a newer login owns the slot now — leave it alone
-  } catch {
-    /* unreadable/absent → nothing to protect */
-  }
-  clearPendingLogin();
+  withSidecarLock(() => {
+    const path = pendingLoginPath();
+    try {
+      const p = JSON.parse(readFileSync(path, "utf8")) as { sessionId?: unknown };
+      if (p.sessionId !== sessionId) return; // a newer login owns the slot now — leave it alone
+    } catch {
+      /* unreadable/absent → nothing to protect */
+    }
+    clearPendingLogin();
+  });
 }
 
 /** The pending login a previous invocation left behind, if it can still complete. An expired or
@@ -170,21 +206,17 @@ export async function createLoginSession(opts: RendezvousLoginOptions = {}): Pro
   };
   const path = pendingLoginPath();
   mkdirSync(dirname(path), { recursive: true });
-  // EXCLUSIVE create: two concurrent commands must not each mint a session with the second
+  // EXCLUSIVE ownership: two concurrent commands must not each mint a session with the second
   // overwriting the first (whose printed URL would then be unresumable — its private key gone).
-  // The loser adopts the winner's still-valid pending login instead; a stale/corrupt leftover is
-  // cleared and the write retried once.
-  try {
-    writeFileSync(path, JSON.stringify(pending, null, 2), { mode: 0o600, flag: "wx" });
-  } catch (e) {
-    if ((e as NodeJS.ErrnoException).code !== "EEXIST") throw e;
+  // Inside the lock: adopt a still-valid winner, otherwise take the slot — one critical section,
+  // so there is no second write race to lose.
+  return withSidecarLock(() => {
     const winner = loadPendingLogin(now());
     if (winner) return winner;
-    // The existing sidecar was expired/corrupt (loadPendingLogin cleared it) — take the slot.
-    writeFileSync(path, JSON.stringify(pending, null, 2), { mode: 0o600, flag: "wx" });
-  }
-  chmodSync(path, 0o600); // belt-and-braces: mode can be masked by umask
-  return pending;
+    writeFileSync(path, JSON.stringify(pending, null, 2), { mode: 0o600 });
+    chmodSync(path, 0o600); // belt-and-braces: mode can be masked by umask
+    return pending;
+  });
 }
 
 /** Distinguishes "this session can never complete" (sidecar cleared; start fresh) from a
@@ -204,8 +236,16 @@ export async function pollLoginSession(pending: PendingLogin, opts: RendezvousLo
   const deadline = now() + (opts.timeoutMs ?? DEFAULT_TIMEOUT_MS);
   const nudgeAt = now() + NUDGE_MS;
   let nudged = false;
+  let sawOpened = false;
 
   while (true) {
+    // The nudge is a TIMER, not a response property: if the page hasn't acked `opened` by the
+    // window — including when the hub is unreachable or answering 5xx/garbage, exactly when the
+    // human is most likely staring at a browser that never opened — say so once.
+    if (!nudged && !sawOpened && now() >= nudgeAt) {
+      nudged = true;
+      opts.onNudge?.();
+    }
     if (now() >= pending.expiresAt) {
       clearPendingLoginFor(pending.sessionId);
       throw new LoginSessionExpiredError("the sign-in link expired — run the command again for a fresh one");
@@ -260,13 +300,7 @@ export async function pollLoginSession(pending: PendingLogin, opts: RendezvousLo
         clearPendingLoginFor(pending.sessionId);
         return auth;
       }
-      // Still pending after the nudge window with the page never even loading? Tell the human —
-      // open() is fire-and-forget (a spawn "success" doesn't mean a browser appeared), so the
-      // page's own `opened` ack is the only trustworthy signal, and it works cross-machine.
-      if (!nudged && body.status === "pending" && now() >= nudgeAt) {
-        nudged = true;
-        opts.onNudge?.();
-      }
+      if (body.status === "opened" || body.status === "completed") sawOpened = true;
     }
     await sleep(POLL_MS);
   }

--- a/packages/cli/src/cliLogin.ts
+++ b/packages/cli/src/cliLogin.ts
@@ -21,7 +21,7 @@
 
 import { spawn } from "node:child_process";
 import { webcrypto } from "node:crypto";
-import { chmodSync, existsSync, mkdirSync, readFileSync, rmdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmdirSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import type { AuthFile } from "./cliAuth";
@@ -100,26 +100,36 @@ export function clearPendingLogin(): void {
  *  mkdir held for microseconds. Without it, a delayed poll's owner-check and unlink could
  *  interleave with a fresh login's write and erase the newcomer. A lock outliving the spin
  *  budget is stolen — a crashed holder must not brick logins forever. */
-function withSidecarLock<T>(fn: () => T): T {
+const LOCK_WAIT_MS = 2000;
+const LOCK_RETRY_MS = 25;
+/** A lock this old belongs to a dead process — the real critical sections are file-touch sized. */
+const LOCK_STALE_MS = 5000;
+
+async function withSidecarLock<T>(fn: () => T | Promise<T>): Promise<T> {
   const lock = pendingLoginPath() + ".lock";
-  const deadline = Date.now() + 2000;
+  const deadline = Date.now() + LOCK_WAIT_MS;
   for (;;) {
     try {
       mkdirSync(lock, { recursive: false });
       break;
-    } catch {
-      if (Date.now() > deadline) {
-        try {
-          rmdirSync(lock); // steal a stale lock left by a crashed process
-        } catch {
-          /* already released */
-        }
+    } catch (e) {
+      // Only contention is retryable — an unwritable path or a pre-existing regular file would
+      // otherwise spin forever with no way out.
+      if ((e as NodeJS.ErrnoException).code !== "EEXIST") throw e;
+      // Steal only a lock that is provably STALE (holder long dead), never one that is merely
+      // slower than our patience — stealing a live lock would re-open the very race this
+      // serializes. Our own wait is bounded separately.
+      try {
+        if (Date.now() - statSync(lock).mtimeMs > LOCK_STALE_MS) rmdirSync(lock);
+      } catch {
+        /* the holder released it between our checks — loop and retry */
       }
-      /* busy-spin: the critical sections are file-touch sized */
+      if (Date.now() > deadline) throw new Error("could not acquire the login lock — another inplan process is holding it");
+      await new Promise((r) => setTimeout(r, LOCK_RETRY_MS)); // yield, don't burn a core
     }
   }
   try {
-    return fn();
+    return await fn();
   } finally {
     try {
       rmdirSync(lock);
@@ -133,8 +143,8 @@ function withSidecarLock<T>(fn: () => T): T {
  *  (expired, claimed, undecryptable) must never erase a NEWER pending login that replaced it —
  *  that would make the replacement's printed URL impossible to resume. Owner-check + unlink run
  *  as one critical section, so the check can't go stale before the delete. */
-function clearPendingLoginFor(sessionId: string): void {
-  withSidecarLock(() => {
+async function clearPendingLoginFor(sessionId: string): Promise<void> {
+  await withSidecarLock(() => {
     const path = pendingLoginPath();
     try {
       const p = JSON.parse(readFileSync(path, "utf8")) as { sessionId?: unknown };
@@ -146,9 +156,8 @@ function clearPendingLoginFor(sessionId: string): void {
   });
 }
 
-/** The pending login a previous invocation left behind, if it can still complete. An expired or
- *  unreadable sidecar is cleared and reads as absent. */
-export function loadPendingLogin(now: number = Date.now()): PendingLogin | null {
+/** Lock-free read + cleanup — ONLY for use inside withSidecarLock (the lock is not re-entrant). */
+function loadPendingLoginLocked(now: number): PendingLogin | null {
   const path = pendingLoginPath();
   if (!existsSync(path)) return null;
   try {
@@ -172,10 +181,23 @@ export function loadPendingLogin(now: number = Date.now()): PendingLogin | null 
   }
 }
 
+/** The pending login a previous invocation left behind, if it can still complete. An expired or
+ *  unreadable sidecar is cleared and reads as absent — the read and that cleanup run under the
+ *  sidecar lock, so a delayed reader of an OLD sidecar can never delete a fresh replacement that
+ *  landed in between. */
+export function loadPendingLogin(now: number = Date.now()): Promise<PendingLogin | null> {
+  return withSidecarLock(() => loadPendingLoginLocked(now));
+}
+
 /** Create a rendezvous session + the sidecar that lets ANY later invocation finish it. */
 export async function createLoginSession(opts: RendezvousLoginOptions = {}): Promise<PendingLogin> {
   const fetchImpl = opts.fetchImpl ?? fetch;
   const now = opts.now ?? Date.now;
+  // Adopt an existing valid pending login BEFORE minting anything: the common repeat-invocation
+  // path must not burn a keypair + a server session row just to throw them away in the locked
+  // adoption check below (which stays, for the true concurrent race).
+  const existing = await loadPendingLogin(now());
+  if (existing) return existing;
   const apiBase = opts.apiBase ?? loginApiBase();
   const webOrigin = (opts.webOrigin ?? DEFAULT_WEB_ORIGIN).replace(/\/$/, "");
 
@@ -211,7 +233,7 @@ export async function createLoginSession(opts: RendezvousLoginOptions = {}): Pro
   // Inside the lock: adopt a still-valid winner, otherwise take the slot — one critical section,
   // so there is no second write race to lose.
   return withSidecarLock(() => {
-    const winner = loadPendingLogin(now());
+    const winner = loadPendingLoginLocked(now());
     if (winner) return winner;
     writeFileSync(path, JSON.stringify(pending, null, 2), { mode: 0o600 });
     chmodSync(path, 0o600); // belt-and-braces: mode can be masked by umask
@@ -247,7 +269,7 @@ export async function pollLoginSession(pending: PendingLogin, opts: RendezvousLo
       opts.onNudge?.();
     }
     if (now() >= pending.expiresAt) {
-      clearPendingLoginFor(pending.sessionId);
+      await clearPendingLoginFor(pending.sessionId);
       throw new LoginSessionExpiredError("the sign-in link expired — run the command again for a fresh one");
     }
     if (now() >= deadline) throw new Error("login timed out — no response from the browser");
@@ -272,7 +294,7 @@ export async function pollLoginSession(pending: PendingLogin, opts: RendezvousLo
     }
     if (res.status === 404) {
       // Unknown/expired/already-claimed server-side — this pending login can never complete.
-      clearPendingLoginFor(pending.sessionId);
+      await clearPendingLoginFor(pending.sessionId);
       throw new LoginSessionExpiredError("the sign-in link expired — run the command again for a fresh one");
     }
     if (res.ok) {
@@ -294,10 +316,10 @@ export async function pollLoginSession(pending: PendingLogin, opts: RendezvousLo
           // GET already consumed the row, so this session can NEVER complete. Clear the sidecar
           // and report it like an expiry, so the caller starts a FRESH session instead of
           // treating a permanently-dead login as a transient failure to retry.
-          clearPendingLoginFor(pending.sessionId);
+          await clearPendingLoginFor(pending.sessionId);
           throw new LoginSessionExpiredError("the sign-in handoff could not be read — run the command again for a fresh link");
         }
-        clearPendingLoginFor(pending.sessionId);
+        await clearPendingLoginFor(pending.sessionId);
         return auth;
       }
       if (body.status === "opened" || body.status === "completed") sawOpened = true;

--- a/packages/cli/src/pluginGate.ts
+++ b/packages/cli/src/pluginGate.ts
@@ -22,8 +22,12 @@ export const DEFAULT_HUB_URL = "wss://inplan-collab.fly.dev";
  *  and this HTTP-base derivation — so the badge, the edits, and the entitlement probe can never
  *  target different hubs. `INPLAN_PLUGIN_URL` wins, then legacy `INPLAN_COLLAB_URL`, then the default. */
 export const resolveHubUrl = (): string => process.env.INPLAN_PLUGIN_URL || process.env.INPLAN_COLLAB_URL || DEFAULT_HUB_URL;
+
+/** The hub's HTTP(S) base — the ONE place the ws(s)→http(s) mapping lives, shared by the plugin
+ *  gate and the login rendezvous so the two derivations can never drift. */
+export const hubHttpBase = (): string => resolveHubUrl().replace(/^ws/, "http").replace(/\/+$/, "");
 /** Plugin server HTTP base (ws→http), shared with the desktop app's entitlement check. */
-const PLUGIN_HTTP = resolveHubUrl().replace(/^ws/, "http");
+const PLUGIN_HTTP = hubHttpBase();
 /** The same cache root the app uses, so a bundle fetched by either side is reused (and re-verified). */
 const defaultCacheDir = (): string => join(process.env.INPLAN_HOME || join(homedir(), ".inplan"), "plugin-cache");
 

--- a/packages/cli/test/cliLogin.test.ts
+++ b/packages/cli/test/cliLogin.test.ts
@@ -96,7 +96,7 @@ describe("createLoginSession", () => {
     expect(pending.url).toMatch(new RegExp(`^https://web\\.test/cli-auth\\?session=${SESSION}#pub=`)); // pub in the FRAGMENT — never in server logs
     expect(pending.expiresAt).toBe(600_000);
     expect(existsSync(pendingLoginPath())).toBe(true);
-    expect(loadPendingLogin(c.now())).toEqual(pending);
+    expect(await loadPendingLogin(c.now())).toEqual(pending);
   });
 
   it("throws on a server error and leaves no sidecar", async () => {
@@ -166,7 +166,7 @@ describe("pollLoginSession", () => {
     const { fetchImpl } = fakeServer(Array.from({ length: 200 }, () => () => ({ status: "pending" })));
     await expect(pollLoginSession(pending, { fetchImpl, now: c.now, sleep: c.sleep, timeoutMs: 10_000 })).rejects.toThrow(/timed out/);
     expect(existsSync(pendingLoginPath())).toBe(true);
-    expect(loadPendingLogin(c.now())).toEqual(pending);
+    expect(await loadPendingLogin(c.now())).toEqual(pending);
   });
 
   it("server-side 404 (expired/claimed) throws LoginSessionExpiredError and clears the sidecar", async () => {
@@ -261,7 +261,7 @@ describe("loadPendingLogin", () => {
     const c = clock();
     const { fetchImpl } = fakeServer([]);
     await createLoginSession({ ...OPTS, fetchImpl, now: c.now });
-    expect(loadPendingLogin(600_001)).toBeNull();
+    expect(await loadPendingLogin(600_001)).toBeNull();
     expect(existsSync(pendingLoginPath())).toBe(false);
   });
 
@@ -270,7 +270,7 @@ describe("loadPendingLogin", () => {
     const { fetchImpl } = fakeServer([]);
     const pending = await createLoginSession({ ...OPTS, fetchImpl, now: c.now });
     writeFileSync(pendingLoginPath(), JSON.stringify({ ...pending, privateKeyPkcs8: 42 }));
-    expect(loadPendingLogin(c.now())).toBeNull();
+    expect(await loadPendingLogin(c.now())).toBeNull();
     expect(existsSync(pendingLoginPath())).toBe(false);
   });
 });

--- a/packages/cli/test/cliLogin.test.ts
+++ b/packages/cli/test/cliLogin.test.ts
@@ -65,15 +65,17 @@ const res = (status: number, json: unknown) => ({ ok: status >= 200 && status < 
  *  (an exhausted script answers 404, the server's "unknown or expired session"). */
 function fakeServer(polls: Array<() => Promise<unknown> | unknown>, expiresInSec = 600) {
   const seen: string[] = [];
-  const fetchImpl = (async (input: unknown, init?: { method?: string }) => {
+  const polledTokens: string[] = [];
+  const fetchImpl = (async (input: unknown, init?: { method?: string; headers?: Record<string, string> }) => {
     const url = String(input);
     seen.push(`${init?.method ?? "GET"} ${url}`);
-    if (init?.method === "POST" && url.endsWith("/api/v1/cli-login")) return res(200, { sessionId: SESSION, expiresInSec });
+    if (init?.method !== "POST") polledTokens.push(init?.headers?.["x-inplan-poll-token"] ?? "");
+    if (init?.method === "POST" && url.endsWith("/api/v1/cli-login")) return res(200, { sessionId: SESSION, pollToken: "poll-tok", expiresInSec });
     const next = polls.shift();
     if (!next) return res(404, { error: "unknown or expired session" });
     return res(200, await next());
   }) as unknown as typeof fetch;
-  return { fetchImpl, seen };
+  return { fetchImpl, seen, polledTokens };
 }
 
 /** Deterministic clock: sleep() advances it, so poll cadence and deadlines are exact. */
@@ -117,6 +119,17 @@ describe("pollLoginSession", () => {
     const auth = await pollLoginSession(pending, { fetchImpl, now: c.now, sleep: c.sleep });
     expect(auth).toEqual({ url: payload.url, anonKey: payload.anon, refreshToken: payload.refresh, email: payload.email });
     expect(existsSync(pendingLoginPath())).toBe(false); // single-use — a resume must not replay it
+  });
+
+  it("every poll carries the CLI-only token in the unlogged header (the URL alone can't claim)", async () => {
+    const c = clock();
+    const { fetchImpl: createFetch } = fakeServer([]);
+    const pending = await createLoginSession({ ...OPTS, fetchImpl: createFetch, now: c.now });
+    expect(pending.pollToken).toBe("poll-tok");
+    const pub = pubOf(pending.url);
+    const srv = fakeServer([() => ({ status: "opened" }), async () => ({ status: "completed", ...(await sealLikeThePage(pub, payload)) })]);
+    await pollLoginSession(pending, { fetchImpl: srv.fetchImpl, now: c.now, sleep: c.sleep });
+    expect(srv.polledTokens).toEqual(["poll-tok", "poll-tok"]);
   });
 
   it("nudges exactly once when the page never acked `opened` within 30 s", async () => {
@@ -195,7 +208,7 @@ describe("pollLoginSession — resilience", () => {
     let calls = 0;
     const fetchImpl = (async (input: unknown, init?: { method?: string }) => {
       const url = String(input);
-      if (init?.method === "POST") return res(200, { sessionId: SESSION, expiresInSec: 600 });
+      if (init?.method === "POST") return res(200, { sessionId: SESSION, pollToken: "poll-tok", expiresInSec: 600 });
       calls++;
       if (calls <= 2) throw new TypeError("fetch failed"); // DNS blip / dropped connection
       return res(200, { status: "completed", ...(await sealLikeThePage(pub, payload)) });
@@ -256,6 +269,6 @@ describe("pending sidecar shape", () => {
     const { fetchImpl } = fakeServer([]);
     const pending: PendingLogin = await createLoginSession({ ...OPTS, fetchImpl, now: clock().now });
     expect(JSON.stringify(pending)).not.toContain("refresh-token");
-    expect(Object.keys(pending).sort()).toEqual(["apiBase", "expiresAt", "privateKeyPkcs8", "sessionId", "url"]);
+    expect(Object.keys(pending).sort()).toEqual(["apiBase", "expiresAt", "pollToken", "privateKeyPkcs8", "sessionId", "url"]);
   });
 });

--- a/packages/cli/test/cliLogin.test.ts
+++ b/packages/cli/test/cliLogin.test.ts
@@ -88,9 +88,10 @@ const OPTS = { apiBase: "http://hub.test", webOrigin: "https://web.test" };
 
 describe("createLoginSession", () => {
   it("mints a session, builds the /cli-auth URL, and persists a resumable sidecar", async () => {
-    const { fetchImpl } = fakeServer([]);
+    const { fetchImpl, seen } = fakeServer([]);
     const c = clock();
     const pending = await createLoginSession({ ...OPTS, fetchImpl, now: c.now });
+    expect(seen).toEqual(["POST http://hub.test/api/v1/cli-login"]); // exactly one create, right route
     expect(pending.sessionId).toBe(SESSION);
     expect(pending.url).toMatch(new RegExp(`^https://web\\.test/cli-auth\\?session=${SESSION}#pub=`)); // pub in the FRAGMENT — never in server logs
     expect(pending.expiresAt).toBe(600_000);
@@ -188,14 +189,17 @@ describe("pollLoginSession", () => {
     expect(existsSync(pendingLoginPath())).toBe(false);
   });
 
-  it("rejects a handoff sealed to the WRONG key (the crypto actually guards the payload)", async () => {
+  it("a handoff sealed to the WRONG key is terminal: sidecar cleared, expiry-class error", async () => {
     const c = clock();
     const { fetchImpl: createFetch } = fakeServer([]);
     const pending = await createLoginSession({ ...OPTS, fetchImpl: createFetch, now: c.now });
     const kp = await subtle.generateKey({ name: "ECDH", namedCurve: "P-256" }, false, ["deriveBits"]);
     const otherPub = Buffer.from(await subtle.exportKey("spki", kp.publicKey)).toString("base64");
     const { fetchImpl } = fakeServer([async () => ({ status: "completed", ...(await sealLikeThePage(otherPub, payload)) })]);
-    await expect(pollLoginSession(pending, { fetchImpl, now: c.now, sleep: c.sleep })).rejects.toThrow();
+    // The claim-once GET consumed the row, so this session can never complete — it must read as
+    // an expiry (start fresh), not as a transient failure the caller would keep resuming.
+    await expect(pollLoginSession(pending, { fetchImpl, now: c.now, sleep: c.sleep })).rejects.toThrow(LoginSessionExpiredError);
+    expect(existsSync(pendingLoginPath())).toBe(false);
   });
 });
 
@@ -225,6 +229,30 @@ describe("pollLoginSession — resilience", () => {
       const pending = await createLoginSession({ ...OPTS, fetchImpl, now: c.now });
       expect(pending.expiresAt).toBe(c.now() + 600_000); // default TTL, still expirable
     }
+  });
+});
+
+describe("createLoginSession — concurrency", () => {
+  it("a second concurrent create adopts the existing pending login instead of clobbering it", async () => {
+    const c = clock();
+    const { fetchImpl } = fakeServer([]);
+    const first = await createLoginSession({ ...OPTS, fetchImpl, now: c.now });
+    // Second invocation while the first is still valid: same session comes back — the first
+    // command's printed URL stays resumable (its private key was NOT overwritten).
+    const second = await createLoginSession({ ...OPTS, fetchImpl, now: c.now });
+    expect(second).toEqual(first);
+  });
+
+  it("a stale leftover sidecar is replaced, not adopted", async () => {
+    const c = clock();
+    const { fetchImpl } = fakeServer([]);
+    const first = await createLoginSession({ ...OPTS, fetchImpl, now: c.now });
+    c.set(700_000); // past the first session's expiry
+    const { fetchImpl: freshFetch } = fakeServer([]);
+    const second = await createLoginSession({ ...OPTS, fetchImpl: freshFetch, now: c.now });
+    expect(second.sessionId).toBe(SESSION);
+    expect(second.expiresAt).toBe(700_000 + 600_000);
+    expect(second).not.toEqual(first);
   });
 });
 

--- a/packages/cli/test/cliLogin.test.ts
+++ b/packages/cli/test/cliLogin.test.ts
@@ -1,103 +1,229 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //
-// Covers the interactive browser login handoff: the one-shot loopback listener accepts the
-// /cli-auth page's POST (matching state), rejects a mismatched state, and times out cleanly.
-// The "browser" is simulated by a fetch from the injected `open` callback — no real browser.
+// The rendezvous login (cliLogin.ts): a cloud session brokers the browser handoff so it works
+// where the old loopback couldn't — coding agents and cross-machine CLIs. These tests drive the
+// full client flow against a scripted fetch: create → poll → sealed completion → credentials,
+// the 30 s "browser never opened" nudge, foreground timeout vs session expiry (sidecar survives
+// the former, is cleared by the latter), and the sealing round-trip (the test seals exactly the
+// way the /cli-auth page does, so parameter drift between the two halves fails here).
 
-import { describe, expect, it } from "vitest";
-import { browserLogin } from "../src/cliLogin";
+import { webcrypto } from "node:crypto";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  LoginSessionExpiredError,
+  createLoginSession,
+  loadPendingLogin,
+  pendingLoginPath,
+  pollLoginSession,
+  rendezvousLogin,
+  type PendingLogin,
+} from "../src/cliLogin";
 
-/** Parse port + state out of the handoff URL the CLI would open. */
-function parse(url: string): { port: string; state: string } {
-  const u = new URL(url);
-  return { port: u.searchParams.get("port")!, state: u.searchParams.get("state")! };
+const subtle = webcrypto.subtle;
+const SESSION = "11111111-2222-4333-8444-555555555555";
+const payload = { url: "https://proj.supabase.co", anon: "anon-key", refresh: "refresh-token", email: "a@b.co" };
+
+let home: string;
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "inplan-login-"));
+  process.env.INPLAN_HOME = home;
+});
+afterEach(() => {
+  delete process.env.INPLAN_HOME;
+  rmSync(home, { recursive: true, force: true });
+});
+
+/** Seal `payload` to the CLI's public key EXACTLY the way the /cli-auth page does
+ *  (ECDH P-256 → HKDF-SHA256(salt=∅, info="inplan cli-login v1") → AES-256-GCM). */
+async function sealLikeThePage(pubB64: string, data: unknown): Promise<{ epk: string; iv: string; ct: string }> {
+  const cliPub = await subtle.importKey("spki", Buffer.from(pubB64, "base64"), { name: "ECDH", namedCurve: "P-256" }, false, []);
+  const eph = await subtle.generateKey({ name: "ECDH", namedCurve: "P-256" }, false, ["deriveBits"]);
+  const shared = await subtle.deriveBits({ name: "ECDH", public: cliPub }, eph.privateKey, 256);
+  const hkdfKey = await subtle.importKey("raw", shared, "HKDF", false, ["deriveKey"]);
+  const aes = await subtle.deriveKey(
+    { name: "HKDF", hash: "SHA-256", salt: new Uint8Array(0), info: new TextEncoder().encode("inplan cli-login v1") },
+    hkdfKey,
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["encrypt"],
+  );
+  const iv = webcrypto.getRandomValues(new Uint8Array(12));
+  const ct = await subtle.encrypt({ name: "AES-GCM", iv }, aes, new TextEncoder().encode(JSON.stringify(data)));
+  const epk = await subtle.exportKey("spki", eph.publicKey);
+  return { epk: Buffer.from(epk).toString("base64"), iv: Buffer.from(iv).toString("base64"), ct: Buffer.from(ct).toString("base64") };
 }
 
-/** POST a JSON body to the loopback /cb the way the web page does. */
-async function postCb(port: string, body: unknown): Promise<number> {
-  const r = await fetch(`http://127.0.0.1:${port}/cb`, {
-    method: "POST",
-    headers: { "content-type": "application/json", origin: "https://inplan.ai" },
-    body: JSON.stringify(body),
-  });
-  return r.status;
+const res = (status: number, json: unknown) => ({ ok: status >= 200 && status < 300, status, json: async () => json });
+
+/** A scripted server: POST create returns SESSION; each GET poll shifts the next scripted reply
+ *  (an exhausted script answers 404, the server's "unknown or expired session"). */
+function fakeServer(polls: Array<() => Promise<unknown> | unknown>, expiresInSec = 600) {
+  const seen: string[] = [];
+  const fetchImpl = (async (input: unknown, init?: { method?: string }) => {
+    const url = String(input);
+    seen.push(`${init?.method ?? "GET"} ${url}`);
+    if (init?.method === "POST" && url.endsWith("/api/v1/cli-login")) return res(200, { sessionId: SESSION, expiresInSec });
+    const next = polls.shift();
+    if (!next) return res(404, { error: "unknown or expired session" });
+    return res(200, await next());
+  }) as unknown as typeof fetch;
+  return { fetchImpl, seen };
 }
 
-describe("browserLogin", () => {
-  it("resolves with the credentials the page hands back over the loopback", async () => {
-    const auth = await browserLogin({
-      timeoutMs: 5000,
-      open: (url) => {
-        const { port, state } = parse(url);
-        void postCb(port, { state, url: "https://proj.supabase.co", anon: "anon-key", refresh: "rt-123", email: "a@b.com" });
-      },
-    });
-    expect(auth).toEqual({ url: "https://proj.supabase.co", anonKey: "anon-key", refreshToken: "rt-123", email: "a@b.com" });
+/** Deterministic clock: sleep() advances it, so poll cadence and deadlines are exact. */
+function clock() {
+  let t = 0;
+  return { now: () => t, sleep: async (ms: number) => void (t += ms), set: (v: number) => void (t = v) };
+}
+
+const OPTS = { apiBase: "http://hub.test", webOrigin: "https://web.test" };
+
+describe("createLoginSession", () => {
+  it("mints a session, builds the /cli-auth URL, and persists a resumable sidecar", async () => {
+    const { fetchImpl } = fakeServer([]);
+    const c = clock();
+    const pending = await createLoginSession({ ...OPTS, fetchImpl, now: c.now });
+    expect(pending.sessionId).toBe(SESSION);
+    expect(pending.url).toMatch(new RegExp(`^https://web\\.test/cli-auth\\?session=${SESSION}&pub=`));
+    expect(pending.expiresAt).toBe(600_000);
+    expect(existsSync(pendingLoginPath())).toBe(true);
+    expect(loadPendingLogin(c.now())).toEqual(pending);
   });
 
-  it("opens /cli-auth on the configured web origin with a port and a state nonce", async () => {
-    let seen = "";
-    const auth = await browserLogin({
-      timeoutMs: 5000,
-      webOrigin: "https://example.test/",
-      open: (url) => {
-        seen = url;
-        const { port, state } = parse(url);
-        void postCb(port, { state, url: "u", anon: "a", refresh: "r" });
-      },
-    });
-    expect(seen).toMatch(/^https:\/\/example\.test\/cli-auth\?port=\d+&state=[0-9a-f]{32}$/);
-    expect(auth.refreshToken).toBe("r"); // email is optional
-    expect(auth.email).toBeUndefined();
+  it("throws on a server error and leaves no sidecar", async () => {
+    const fetchImpl = (async () => res(503, { error: "nope" })) as unknown as typeof fetch;
+    await expect(createLoginSession({ ...OPTS, fetchImpl })).rejects.toThrow(/HTTP 503/);
+    expect(existsSync(pendingLoginPath())).toBe(false);
+  });
+});
+
+describe("pollLoginSession", () => {
+  it("completes: pending → opened → sealed handoff → credentials, sidecar cleared", async () => {
+    const c = clock();
+    const { fetchImpl: createFetch } = fakeServer([]);
+    const pending = await createLoginSession({ ...OPTS, fetchImpl: createFetch, now: c.now });
+    const pub = new URL(pending.url).searchParams.get("pub")!;
+    const { fetchImpl } = fakeServer([
+      () => ({ status: "pending" }),
+      () => ({ status: "opened" }),
+      async () => ({ status: "completed", ...(await sealLikeThePage(pub, payload)) }),
+    ]);
+    const auth = await pollLoginSession(pending, { fetchImpl, now: c.now, sleep: c.sleep });
+    expect(auth).toEqual({ url: payload.url, anonKey: payload.anon, refreshToken: payload.refresh, email: payload.email });
+    expect(existsSync(pendingLoginPath())).toBe(false); // single-use — a resume must not replay it
   });
 
-  it("ignores a mismatched-state POST and keeps waiting for the real one", async () => {
-    const auth = await browserLogin({
-      timeoutMs: 5000,
-      open: (url) => {
-        const { port, state } = parse(url);
-        void (async () => {
-          const bad = await postCb(port, { state: "wrong", url: "u", anon: "a", refresh: "evil" });
-          expect(bad).toBe(403);
-          // The real handoff still completes.
-          await postCb(port, { state, url: "u", anon: "a", refresh: "good" });
-        })();
-      },
-    });
-    expect(auth.refreshToken).toBe("good");
+  it("nudges exactly once when the page never acked `opened` within 30 s", async () => {
+    const c = clock();
+    const { fetchImpl: createFetch } = fakeServer([]);
+    const pending = await createLoginSession({ ...OPTS, fetchImpl: createFetch, now: c.now });
+    const pub = new URL(pending.url).searchParams.get("pub")!;
+    const polls: Array<() => Promise<unknown> | unknown> = Array.from({ length: 20 }, () => () => ({ status: "pending" }));
+    polls.push(async () => ({ status: "completed", ...(await sealLikeThePage(pub, payload)) }));
+    const { fetchImpl } = fakeServer(polls);
+    const onNudge = vi.fn();
+    await pollLoginSession(pending, { fetchImpl, now: c.now, sleep: c.sleep, onNudge });
+    expect(onNudge).toHaveBeenCalledTimes(1);
   });
 
-  it("rejects a malformed (non-JSON) body with 400 and keeps waiting", async () => {
-    const auth = await browserLogin({
-      timeoutMs: 5000,
-      open: (url) => {
-        const { port, state } = parse(url);
-        void (async () => {
-          const r = await fetch(`http://127.0.0.1:${port}/cb`, { method: "POST", headers: { "content-type": "application/json" }, body: "not json" });
-          expect(r.status).toBe(400);
-          await postCb(port, { state, url: "u", anon: "a", refresh: "ok" });
-        })();
-      },
-    });
-    expect(auth.refreshToken).toBe("ok");
+  it("does NOT nudge when the page acked `opened` promptly (slow sign-in, browser fine)", async () => {
+    const c = clock();
+    const { fetchImpl: createFetch } = fakeServer([]);
+    const pending = await createLoginSession({ ...OPTS, fetchImpl: createFetch, now: c.now });
+    const pub = new URL(pending.url).searchParams.get("pub")!;
+    const polls: Array<() => Promise<unknown> | unknown> = Array.from({ length: 20 }, () => () => ({ status: "opened" }));
+    polls.push(async () => ({ status: "completed", ...(await sealLikeThePage(pub, payload)) }));
+    const { fetchImpl } = fakeServer(polls);
+    const onNudge = vi.fn();
+    await pollLoginSession(pending, { fetchImpl, now: c.now, sleep: c.sleep, onNudge });
+    expect(onNudge).not.toHaveBeenCalled();
   });
 
-  it("rejects a non-string email (bad type guard) with 403 and keeps waiting", async () => {
-    const auth = await browserLogin({
-      timeoutMs: 5000,
-      open: (url) => {
-        const { port, state } = parse(url);
-        void (async () => {
-          const bad = await postCb(port, { state, url: "u", anon: "a", refresh: "r", email: {} });
-          expect(bad).toBe(403);
-          await postCb(port, { state, url: "u", anon: "a", refresh: "ok" });
-        })();
-      },
-    });
-    expect(auth.refreshToken).toBe("ok");
+  it("foreground timeout keeps the sidecar (the NEXT invocation resumes the login)", async () => {
+    const c = clock();
+    const { fetchImpl: createFetch } = fakeServer([]);
+    const pending = await createLoginSession({ ...OPTS, fetchImpl: createFetch, now: c.now });
+    const { fetchImpl } = fakeServer(Array.from({ length: 200 }, () => () => ({ status: "pending" })));
+    await expect(pollLoginSession(pending, { fetchImpl, now: c.now, sleep: c.sleep, timeoutMs: 10_000 })).rejects.toThrow(/timed out/);
+    expect(existsSync(pendingLoginPath())).toBe(true);
+    expect(loadPendingLogin(c.now())).toEqual(pending);
   });
 
-  it("times out when the browser never responds", async () => {
-    await expect(browserLogin({ timeoutMs: 150, open: () => {} })).rejects.toThrow(/timed out/);
+  it("server-side 404 (expired/claimed) throws LoginSessionExpiredError and clears the sidecar", async () => {
+    const c = clock();
+    const { fetchImpl: createFetch } = fakeServer([]);
+    const pending = await createLoginSession({ ...OPTS, fetchImpl: createFetch, now: c.now });
+    const { fetchImpl } = fakeServer([]); // no scripted polls → 404
+    await expect(pollLoginSession(pending, { fetchImpl, now: c.now, sleep: c.sleep })).rejects.toThrow(LoginSessionExpiredError);
+    expect(existsSync(pendingLoginPath())).toBe(false);
+  });
+
+  it("local expiry throws LoginSessionExpiredError before ever fetching", async () => {
+    const c = clock();
+    const { fetchImpl: createFetch } = fakeServer([]);
+    const pending = await createLoginSession({ ...OPTS, fetchImpl: createFetch, now: c.now });
+    c.set(700_000); // past expiresAt
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+    await expect(pollLoginSession(pending, { fetchImpl, now: c.now, sleep: c.sleep })).rejects.toThrow(LoginSessionExpiredError);
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(existsSync(pendingLoginPath())).toBe(false);
+  });
+
+  it("rejects a handoff sealed to the WRONG key (the crypto actually guards the payload)", async () => {
+    const c = clock();
+    const { fetchImpl: createFetch } = fakeServer([]);
+    const pending = await createLoginSession({ ...OPTS, fetchImpl: createFetch, now: c.now });
+    const kp = await subtle.generateKey({ name: "ECDH", namedCurve: "P-256" }, false, ["deriveBits"]);
+    const otherPub = Buffer.from(await subtle.exportKey("spki", kp.publicKey)).toString("base64");
+    const { fetchImpl } = fakeServer([async () => ({ status: "completed", ...(await sealLikeThePage(otherPub, payload)) })]);
+    await expect(pollLoginSession(pending, { fetchImpl, now: c.now, sleep: c.sleep })).rejects.toThrow();
+  });
+});
+
+describe("loadPendingLogin", () => {
+  it("returns null (and clears) an expired sidecar", async () => {
+    const c = clock();
+    const { fetchImpl } = fakeServer([]);
+    await createLoginSession({ ...OPTS, fetchImpl, now: c.now });
+    expect(loadPendingLogin(600_001)).toBeNull();
+    expect(existsSync(pendingLoginPath())).toBe(false);
+  });
+
+  it("returns null for a malformed sidecar", async () => {
+    const c = clock();
+    const { fetchImpl } = fakeServer([]);
+    const pending = await createLoginSession({ ...OPTS, fetchImpl, now: c.now });
+    writeFileSync(pendingLoginPath(), JSON.stringify({ ...pending, privateKeyPkcs8: 42 }));
+    expect(loadPendingLogin(c.now())).toBeNull();
+    expect(existsSync(pendingLoginPath())).toBe(false);
+  });
+});
+
+describe("rendezvousLogin", () => {
+  it("opens the browser at the session URL, reports it, and completes inline", async () => {
+    const c = clock();
+    let pub = "";
+    const { fetchImpl } = fakeServer([
+      () => ({ status: "opened" }),
+      async () => ({ status: "completed", ...(await sealLikeThePage(pub, payload)) }),
+    ]);
+    const open = vi.fn((u: string) => void (pub = new URL(u).searchParams.get("pub")!));
+    const onUrl = vi.fn();
+    const auth = await rendezvousLogin({ ...OPTS, fetchImpl, now: c.now, sleep: c.sleep, open, onUrl });
+    expect(open).toHaveBeenCalledTimes(1);
+    expect(onUrl).toHaveBeenCalledWith(expect.stringContaining("https://web.test/cli-auth?session="));
+    expect(auth.refreshToken).toBe(payload.refresh);
+  });
+});
+
+describe("pending sidecar shape", () => {
+  it("never stores credentials — only the session + the private key that unlocks the handoff", async () => {
+    const { fetchImpl } = fakeServer([]);
+    const pending: PendingLogin = await createLoginSession({ ...OPTS, fetchImpl, now: clock().now });
+    expect(JSON.stringify(pending)).not.toContain("refresh-token");
+    expect(Object.keys(pending).sort()).toEqual(["apiBase", "expiresAt", "privateKeyPkcs8", "sessionId", "url"]);
   });
 });

--- a/packages/cli/test/cliLogin.test.ts
+++ b/packages/cli/test/cliLogin.test.ts
@@ -26,6 +26,9 @@ const subtle = webcrypto.subtle;
 const SESSION = "11111111-2222-4333-8444-555555555555";
 const payload = { url: "https://proj.supabase.co", anon: "anon-key", refresh: "refresh-token", email: "a@b.co" };
 
+/** The CLI public key rides the URL fragment (never server logs) — parse it the way the page does. */
+const pubOf = (url: string) => decodeURIComponent(url.split("#pub=")[1]!);
+
 let home: string;
 beforeEach(() => {
   home = mkdtempSync(join(tmpdir(), "inplan-login-"));
@@ -87,7 +90,7 @@ describe("createLoginSession", () => {
     const c = clock();
     const pending = await createLoginSession({ ...OPTS, fetchImpl, now: c.now });
     expect(pending.sessionId).toBe(SESSION);
-    expect(pending.url).toMatch(new RegExp(`^https://web\\.test/cli-auth\\?session=${SESSION}&pub=`));
+    expect(pending.url).toMatch(new RegExp(`^https://web\\.test/cli-auth\\?session=${SESSION}#pub=`)); // pub in the FRAGMENT — never in server logs
     expect(pending.expiresAt).toBe(600_000);
     expect(existsSync(pendingLoginPath())).toBe(true);
     expect(loadPendingLogin(c.now())).toEqual(pending);
@@ -105,7 +108,7 @@ describe("pollLoginSession", () => {
     const c = clock();
     const { fetchImpl: createFetch } = fakeServer([]);
     const pending = await createLoginSession({ ...OPTS, fetchImpl: createFetch, now: c.now });
-    const pub = new URL(pending.url).searchParams.get("pub")!;
+    const pub = pubOf(pending.url);
     const { fetchImpl } = fakeServer([
       () => ({ status: "pending" }),
       () => ({ status: "opened" }),
@@ -120,7 +123,7 @@ describe("pollLoginSession", () => {
     const c = clock();
     const { fetchImpl: createFetch } = fakeServer([]);
     const pending = await createLoginSession({ ...OPTS, fetchImpl: createFetch, now: c.now });
-    const pub = new URL(pending.url).searchParams.get("pub")!;
+    const pub = pubOf(pending.url);
     const polls: Array<() => Promise<unknown> | unknown> = Array.from({ length: 20 }, () => () => ({ status: "pending" }));
     polls.push(async () => ({ status: "completed", ...(await sealLikeThePage(pub, payload)) }));
     const { fetchImpl } = fakeServer(polls);
@@ -133,7 +136,7 @@ describe("pollLoginSession", () => {
     const c = clock();
     const { fetchImpl: createFetch } = fakeServer([]);
     const pending = await createLoginSession({ ...OPTS, fetchImpl: createFetch, now: c.now });
-    const pub = new URL(pending.url).searchParams.get("pub")!;
+    const pub = pubOf(pending.url);
     const polls: Array<() => Promise<unknown> | unknown> = Array.from({ length: 20 }, () => () => ({ status: "opened" }));
     polls.push(async () => ({ status: "completed", ...(await sealLikeThePage(pub, payload)) }));
     const { fetchImpl } = fakeServer(polls);
@@ -183,6 +186,35 @@ describe("pollLoginSession", () => {
   });
 });
 
+describe("pollLoginSession — resilience", () => {
+  it("tolerates transient transport failures (retries like a 5xx; the deadline bounds the wait)", async () => {
+    const c = clock();
+    const { fetchImpl: createFetch } = fakeServer([]);
+    const pending = await createLoginSession({ ...OPTS, fetchImpl: createFetch, now: c.now });
+    const pub = pubOf(pending.url);
+    let calls = 0;
+    const fetchImpl = (async (input: unknown, init?: { method?: string }) => {
+      const url = String(input);
+      if (init?.method === "POST") return res(200, { sessionId: SESSION, expiresInSec: 600 });
+      calls++;
+      if (calls <= 2) throw new TypeError("fetch failed"); // DNS blip / dropped connection
+      return res(200, { status: "completed", ...(await sealLikeThePage(pub, payload)) });
+    }) as unknown as typeof fetch;
+    const auth = await pollLoginSession(pending, { fetchImpl, now: c.now, sleep: c.sleep });
+    expect(auth.refreshToken).toBe(payload.refresh);
+    expect(calls).toBe(3); // two failures retried, third answered
+  });
+
+  it("normalizes a bogus server TTL (NaN/negative) instead of minting a never-expiring sidecar", async () => {
+    const c = clock();
+    for (const bad of [Number.NaN, -5] as number[]) {
+      const { fetchImpl } = fakeServer([], bad);
+      const pending = await createLoginSession({ ...OPTS, fetchImpl, now: c.now });
+      expect(pending.expiresAt).toBe(c.now() + 600_000); // default TTL, still expirable
+    }
+  });
+});
+
 describe("loadPendingLogin", () => {
   it("returns null (and clears) an expired sidecar", async () => {
     const c = clock();
@@ -210,7 +242,7 @@ describe("rendezvousLogin", () => {
       () => ({ status: "opened" }),
       async () => ({ status: "completed", ...(await sealLikeThePage(pub, payload)) }),
     ]);
-    const open = vi.fn((u: string) => void (pub = new URL(u).searchParams.get("pub")!));
+    const open = vi.fn((u: string) => void (pub = pubOf(u)));
     const onUrl = vi.fn();
     const auth = await rendezvousLogin({ ...OPTS, fetchImpl, now: c.now, sleep: c.sleep, open, onUrl });
     expect(open).toHaveBeenCalledTimes(1);

--- a/packages/cli/test/ensureLogin.test.ts
+++ b/packages/cli/test/ensureLogin.test.ts
@@ -51,6 +51,7 @@ async function writeSidecar(): Promise<void> {
     JSON.stringify({
       sessionId: SIDE_SESSION,
       privateKeyPkcs8: "AAAA",
+      pollToken: "poll-tok",
       url: `https://web.test/cli-auth?session=${SIDE_SESSION}#pub=y`,
       apiBase: "http://127.0.0.1:1",
       expiresAt: Date.now() + 600_000,

--- a/packages/cli/test/ensureLogin.test.ts
+++ b/packages/cli/test/ensureLogin.test.ts
@@ -39,6 +39,25 @@ function setTTY(value: boolean): void {
 // after login fails fast (and swallows) rather than hitting the network in a unit test.
 const FAST_FAIL_AUTH: AuthFile = { url: "http://127.0.0.1:1", anonKey: "anon", refreshToken: "r" };
 
+const SIDE_SESSION = "11111111-2222-4333-8444-555555555555";
+/** Drop a valid pending-login sidecar into INPLAN_HOME so ensureLoggedIn's resume path engages. */
+async function writeSidecar(): Promise<void> {
+  const { mkdirSync, writeFileSync } = await import("node:fs");
+  const { dirname } = await import("node:path");
+  const { pendingLoginPath } = await import("../src/cliLogin");
+  mkdirSync(dirname(pendingLoginPath()), { recursive: true });
+  writeFileSync(
+    pendingLoginPath(),
+    JSON.stringify({
+      sessionId: SIDE_SESSION,
+      privateKeyPkcs8: "AAAA",
+      url: `https://web.test/cli-auth?session=${SIDE_SESSION}#pub=y`,
+      apiBase: "http://127.0.0.1:1",
+      expiresAt: Date.now() + 600_000,
+    }),
+  );
+}
+
 beforeEach(() => {
   home = mkdtempSync(join(tmpdir(), "inplan-ensure-"));
   process.env.INPLAN_HOME = home;
@@ -55,6 +74,13 @@ beforeEach(() => {
 afterEach(() => {
   delete process.env.INPLAN_HOME;
   rmSync(home, { recursive: true, force: true });
+  // Delete everything a test BODY may have assigned (CI leaks into every later test in the worker
+  // otherwise — ensureLoggedIn branches on it), THEN restore the genuinely-scrubbed originals.
+  delete process.env.CI;
+  delete process.env.INPLAN_NO_BROWSER;
+  for (const k of Object.keys(process.env)) {
+    if (k === "CLAUDECODE" || k.startsWith("CLAUDE_CODE_")) delete process.env[k];
+  }
   for (const [k, v] of scrubbedAgentEnv) process.env[k] = v;
   scrubbedAgentEnv.clear();
   for (const stream of ["stdin", "stdout"] as const) {
@@ -149,29 +175,58 @@ describe("ensureLoggedIn", () => {
     expect(pendingExit).not.toHaveBeenCalled();
   });
 
-  it("resumes a pending sidecar before anything else (the agent loop's second half)", async () => {
+  it("resumes a pending sidecar and signs in when the human completes it (agent loop, half 2)", async () => {
     setTTY(true); // even interactive: the pending session the human may already have opened wins
-    const { mkdirSync, writeFileSync } = await import("node:fs");
-    const { dirname } = await import("node:path");
-    const { pendingLoginPath } = await import("../src/cliLogin");
-    const sidecar = {
-      sessionId: "11111111-2222-4333-8444-555555555555",
-      privateKeyPkcs8: "AAAA",
-      url: "https://web.test/cli-auth?session=x&pub=y",
-      apiBase: "http://127.0.0.1:1", // refuses instantly — proves the resume path ran (fetch throws)
-      expiresAt: Date.now() + 600_000,
-    };
-    mkdirSync(dirname(pendingLoginPath()), { recursive: true });
-    writeFileSync(pendingLoginPath(), JSON.stringify(sidecar));
+    await writeSidecar();
     const login = vi.fn();
     const pendingExit = vi.fn(async () => {});
-    // The resume attempt fails on transport (unreachable) → false, but neither a fresh browser
-    // login nor a fresh pending session was started, and the sidecar survives for the next run.
-    expect(await ensureLoggedIn([], login, pendingExit)).toBe(false);
+    const pollPending = vi.fn(async (p: { sessionId: string }) => (void p, FAST_FAIL_AUTH));
+    expect(await ensureLoggedIn([], login, pendingExit, pollPending)).toBe(true);
+    expect(pollPending).toHaveBeenCalledOnce();
+    expect(pollPending.mock.calls[0]![0]).toMatchObject({ sessionId: SIDE_SESSION });
     expect(login).not.toHaveBeenCalled();
     expect(pendingExit).not.toHaveBeenCalled();
-    const { existsSync } = await import("node:fs");
-    expect(existsSync(pendingLoginPath())).toBe(true);
+    expect(loadAuth()).toEqual(FAST_FAIL_AUTH);
+  });
+
+  it("a transient resume failure returns false without starting any fresh flow", async () => {
+    setTTY(true);
+    await writeSidecar();
+    const login = vi.fn();
+    const pendingExit = vi.fn(async () => {});
+    const pollPending = vi.fn(async () => {
+      throw new Error("login timed out — no response from the browser");
+    });
+    // Timeout/transport → false; neither a fresh browser login nor a fresh pending session was
+    // started (pollLoginSession keeps the sidecar in this case, so the next run resumes it).
+    expect(await ensureLoggedIn([], login, pendingExit, pollPending)).toBe(false);
+    expect(login).not.toHaveBeenCalled();
+    expect(pendingExit).not.toHaveBeenCalled();
+  });
+
+  it("an EXPIRED pending session falls through to a fresh flow", async () => {
+    setTTY(true);
+    await writeSidecar();
+    const { LoginSessionExpiredError } = await import("../src/cliLogin");
+    const login = vi.fn(async () => FAST_FAIL_AUTH);
+    const pollPending = vi.fn(async () => {
+      throw new LoginSessionExpiredError("expired");
+    });
+    expect(await ensureLoggedIn([], login, vi.fn(async () => {}), pollPending)).toBe(true);
+    expect(login).toHaveBeenCalledOnce(); // interactive human → fresh inline login
+  });
+
+  it("the opt-outs run BEFORE the sidecar resume — a stale sidecar must not stall CI", async () => {
+    setTTY(true);
+    process.env.CI = "true";
+    await writeSidecar();
+    const login = vi.fn();
+    const pendingExit = vi.fn(async () => {});
+    const pollPending = vi.fn();
+    expect(await ensureLoggedIn([], login, pendingExit, pollPending)).toBe(false);
+    expect(pollPending).not.toHaveBeenCalled(); // never waits on a human, not even a pending one
+    expect(login).not.toHaveBeenCalled();
+    expect(pendingExit).not.toHaveBeenCalled();
   });
 
   it("runs the login handoff and persists credentials when interactive with none stored", async () => {

--- a/packages/cli/test/ensureLogin.test.ts
+++ b/packages/cli/test/ensureLogin.test.ts
@@ -18,11 +18,14 @@ vi.mock("../src/cliAuth", async (importOriginal) => ({
   currentUser: vi.fn(async () => null),
 }));
 
-import { canInteractiveLogin, ensureLoggedIn } from "../src/cli";
+import { canInteractiveLogin, ensureLoggedIn, isKnownAgentEnv } from "../src/cli";
 import { loadAuth, saveAuth, type AuthFile } from "../src/cliAuth";
 
 let home: string;
 const ttyDescriptors: Record<string, PropertyDescriptor | undefined> = {};
+// These tests may themselves run inside a coding agent's shell (CLAUDECODE/CLAUDE_CODE_* set),
+// which would trip the detection ladder's env rung — scrub and restore around each test.
+const scrubbedAgentEnv = new Map<string, string>();
 
 /** Force stdin/stdout's isTTY (a getter on the streams) so "interactive" is deterministic. */
 function setTTY(value: boolean): void {
@@ -41,11 +44,19 @@ beforeEach(() => {
   process.env.INPLAN_HOME = home;
   delete process.env.CI;
   delete process.env.INPLAN_NO_BROWSER;
+  for (const k of Object.keys(process.env)) {
+    if (k === "CLAUDECODE" || k.startsWith("CLAUDE_CODE_")) {
+      scrubbedAgentEnv.set(k, process.env[k]!);
+      delete process.env[k];
+    }
+  }
 });
 
 afterEach(() => {
   delete process.env.INPLAN_HOME;
   rmSync(home, { recursive: true, force: true });
+  for (const [k, v] of scrubbedAgentEnv) process.env[k] = v;
+  scrubbedAgentEnv.clear();
   for (const stream of ["stdin", "stdout"] as const) {
     if (ttyDescriptors[stream]) {
       Object.defineProperty(process[stream], "isTTY", ttyDescriptors[stream]!);
@@ -99,27 +110,68 @@ describe("ensureLoggedIn", () => {
     expect(login).not.toHaveBeenCalled();
   });
 
-  it("does NOT open a browser when headless (no TTY) — the caller errors instead", async () => {
+  it("headless (no TTY): no browser — routes to the pending-login exit for the agent loop", async () => {
     setTTY(false);
     const login = vi.fn();
-    expect(await ensureLoggedIn([], login)).toBe(false);
+    const pendingExit = vi.fn(async () => {});
+    expect(await ensureLoggedIn([], login, pendingExit)).toBe(false);
     expect(login).not.toHaveBeenCalled();
+    expect(pendingExit).toHaveBeenCalledOnce();
     expect(loadAuth()).toBeNull();
   });
 
-  it("does NOT open a browser under --no-login even when interactive", async () => {
+  it("routes to the pending exit even on a TTY when a coding-agent env marker is present", async () => {
     setTTY(true);
+    process.env.CLAUDECODE = "1";
     const login = vi.fn();
-    expect(await ensureLoggedIn(["--no-login"], login)).toBe(false);
+    const pendingExit = vi.fn(async () => {});
+    expect(await ensureLoggedIn([], login, pendingExit)).toBe(false);
     expect(login).not.toHaveBeenCalled();
+    expect(pendingExit).toHaveBeenCalledOnce();
   });
 
-  it("does NOT open a browser under CI even when interactive", async () => {
+  it("--no-login: no browser AND no pending session (explicit opt-out keeps the old contract)", async () => {
+    setTTY(true);
+    const login = vi.fn();
+    const pendingExit = vi.fn(async () => {});
+    expect(await ensureLoggedIn(["--no-login"], login, pendingExit)).toBe(false);
+    expect(login).not.toHaveBeenCalled();
+    expect(pendingExit).not.toHaveBeenCalled();
+  });
+
+  it("CI: no browser AND no pending session (nobody will ever complete it)", async () => {
     setTTY(true);
     process.env.CI = "true";
     const login = vi.fn();
-    expect(await ensureLoggedIn([], login)).toBe(false);
+    const pendingExit = vi.fn(async () => {});
+    expect(await ensureLoggedIn([], login, pendingExit)).toBe(false);
     expect(login).not.toHaveBeenCalled();
+    expect(pendingExit).not.toHaveBeenCalled();
+  });
+
+  it("resumes a pending sidecar before anything else (the agent loop's second half)", async () => {
+    setTTY(true); // even interactive: the pending session the human may already have opened wins
+    const { mkdirSync, writeFileSync } = await import("node:fs");
+    const { dirname } = await import("node:path");
+    const { pendingLoginPath } = await import("../src/cliLogin");
+    const sidecar = {
+      sessionId: "11111111-2222-4333-8444-555555555555",
+      privateKeyPkcs8: "AAAA",
+      url: "https://web.test/cli-auth?session=x&pub=y",
+      apiBase: "http://127.0.0.1:1", // refuses instantly — proves the resume path ran (fetch throws)
+      expiresAt: Date.now() + 600_000,
+    };
+    mkdirSync(dirname(pendingLoginPath()), { recursive: true });
+    writeFileSync(pendingLoginPath(), JSON.stringify(sidecar));
+    const login = vi.fn();
+    const pendingExit = vi.fn(async () => {});
+    // The resume attempt fails on transport (unreachable) → false, but neither a fresh browser
+    // login nor a fresh pending session was started, and the sidecar survives for the next run.
+    expect(await ensureLoggedIn([], login, pendingExit)).toBe(false);
+    expect(login).not.toHaveBeenCalled();
+    expect(pendingExit).not.toHaveBeenCalled();
+    const { existsSync } = await import("node:fs");
+    expect(existsSync(pendingLoginPath())).toBe(true);
   });
 
   it("runs the login handoff and persists credentials when interactive with none stored", async () => {
@@ -137,5 +189,14 @@ describe("ensureLoggedIn", () => {
     });
     expect(await ensureLoggedIn([], login)).toBe(false);
     expect(loadAuth()).toBeNull();
+  });
+});
+
+describe("isKnownAgentEnv", () => {
+  it("matches only agent-exclusive markers (a human's plain env stays interactive)", () => {
+    expect(isKnownAgentEnv({})).toBe(false);
+    expect(isKnownAgentEnv({ TERM: "xterm", CURSOR_TRACE_ID: "x" })).toBe(false); // integrated-terminal humans have this
+    expect(isKnownAgentEnv({ CLAUDECODE: "1" })).toBe(true);
+    expect(isKnownAgentEnv({ CLAUDE_CODE_SESSION_ID: "abc" })).toBe(true);
   });
 });

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -58,7 +58,10 @@ credentials. Do exactly two things:
 2. Immediately re-run the `resume` command (it is the command you just ran). It waits for the
    sign-in to finish, then continues normally — you don't need to poll or sleep first.
 
-If the link expires before the human opens it, the re-run prints a fresh URL — repeat from 1.
+The wait in step 2 is bounded (~3 minutes). If the human hasn't finished by then, the command
+exits with a timeout message while the session is still valid — that is not a hard error: just
+re-run the same command and it resumes the same sign-in. If the link itself expires
+(`expiresInSec`, ~10 minutes), the re-run prints a fresh URL — repeat from 1.
 
 ## File convention
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -47,6 +47,19 @@ produces the headless message above, immediately, without attempting recovery. T
 works headless until a binary is present, but the human can't review in the GUI — surface the
 fix to them and proceed.
 
+## Signing in (cloud documents)
+
+Any cloud command (`wait --remote`, `login`, …) may exit with code 7 and a JSON line:
+`{"status":"login_required","url":…,"resume":…,"expiresInSec":…}`. Sign-in happens in the
+human's browser — never try to open the URL yourself, fetch it, or ask the human for
+credentials. Do exactly two things:
+
+1. Show the `url` to the human and ask them to open it in a browser and sign in.
+2. Immediately re-run the `resume` command (it is the command you just ran). It waits for the
+   sign-in to finish, then continues normally — you don't need to poll or sleep first.
+
+If the link expires before the human opens it, the re-run prints a fresh URL — repeat from 1.
+
 ## File convention
 
 Save plans as `<name>.plan.md`. The `inplan` CLI keeps its own working files under


### PR DESCRIPTION
## Problem

The loopback login handoff requires the browser to reach the CLI's `127.0.0.1`. That fails exactly where agent workflows live:

1. **Coding agents** only read a process's output when it exits — the CLI printed the auth URL and then blocked up to 3 minutes for the loopback callback, so the agent never saw the URL before the login timed out.
2. **Cross-machine** (remote box / container / sandbox): the page's POST to `127.0.0.1` lands on the *human's* machine; the handoff can never arrive even after a successful sign-in.

## Design

Cloud rendezvous (cloud-side PR: Crazy-Idea-Studio/inplan-cloud#193, deployed before this releases; the design doc lives there as `docs/cli-login-rendezvous.plan.md`):

- `cliLogin.ts` — ephemeral ECDH P-256 keypair + cloud session; a resumable **pending-login sidecar** (`~/.inplan/login-pending.json`, 0600, never holds credentials); `/cli-auth?session=&pub=`; poll → sealed handoff (ECDH → HKDF-SHA256 → AES-256-GCM) decrypted locally — the server only ever stores bytes it can't read. The page acks `opened` on load: the cross-machine-safe "browser really opened" signal; **no ack in 30 s ⇒ nudge the human to open the URL manually** (`open()` is fire-and-forget and a spawn success proves nothing). Foreground timeout keeps the sidecar (the next invocation resumes); server-side expiry clears it.
- `cli.ts` — detection ladder: interactive humans keep the one-command blocking flow; a non-interactive caller (or an agent-exclusive env marker like `CLAUDECODE`, even on a PTY) gets a fresh session, the URL + exact resume command as text **and** a `login_required` JSON line, and exits `EXIT_LOGIN_PENDING` (7). `--no-login`/CI keep the old return-false contract. Both `ensureLoggedIn` and `inplan login` resume a pending sidecar first — so the agent contract is just: *relay the URL, re-run the command you just ran*. Misdetection in either direction converges on the same resumable session.
- `skill/SKILL.md` — a *Signing in* section teaching agents exactly that two-step procedure.

## Tests

Full client flow against a scripted server (create/poll/sealed completion), nudge-exactly-once vs no-nudge-after-`opened`, timeout-vs-expiry sidecar semantics, wrong-key rejection, sealing **byte-compatible with the page's implementation** (parameter drift fails CI), `ensureLoggedIn` routing matrix incl. the agent-env rung and sidecar-resume precedence, sidecar-never-holds-credentials. 1101 pass, coverage 96.4%.

## Rollout

Needs the cloud endpoints live (inplan-cloud#193 → DEV → prod) before this ships in a release; `/cli-auth`'s `port=` mode keeps already-published CLIs working meanwhile.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/80?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated CLI sign-in to use secure browser-based sessions.
  - Added resumable authentication with commands for completing sign-in later.
  - Added support for pending-login detection in headless and agent environments.
  - Improved credential security during browser handoff.
  - Added browser-open notifications and guidance when authentication is delayed.
  - Added clearer handling for expired or timed-out sign-in sessions.

- **Documentation**
  - Added instructions for completing and resuming cloud-document sign-in flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->