### PR TITLE
wait: survive page reloads — grace-and-resume on window_closed

### DIFF
--- a/packages/backend-supabase/src/supabaseControlChannel.ts
+++ b/packages/backend-supabase/src/supabaseControlChannel.ts
@@ -117,7 +117,7 @@ export class SupabaseControlChannel implements ControlChannel {
     return current != null && current !== token;
   }
 
-  async presence(): Promise<boolean> {
+  async presence(sinceMs?: number): Promise<boolean> {
     // TODO(M4.3): derive from live/Realtime presence on the doc's collaboration room.
     // Interim: an editor heartbeat row fresher than PRESENCE_TTL_MS.
     const { data, error } = await this.db
@@ -128,7 +128,11 @@ export class SupabaseControlChannel implements ControlChannel {
     if (error) throw new Error(`presence failed: ${error.message}`);
     const lastSeen = (data as { last_seen?: string } | null)?.last_seen;
     if (!lastSeen) return false;
-    return Date.now() - new Date(lastSeen).getTime() < PRESENCE_TTL_MS;
+    const lastSeenMs = new Date(lastSeen).getTime();
+    // With `sinceMs`, only a heartbeat written AFTER the caller started watching counts. The
+    // heartbeat outlives a window_closed by up to PRESENCE_TTL_MS, so without this a reopen-watch
+    // would read the just-closed editor's stale row as "still here" and resume a dead session.
+    return sinceMs !== undefined ? lastSeenMs > sinceMs : Date.now() - lastSeenMs < PRESENCE_TTL_MS;
   }
 }
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -428,6 +428,17 @@ async function waitCycle(backend: WaitBackend, explicitCursor: number | null, co
   const acceptance = acceptanceFrom(history);
   const quarantine = acceptance === "review" && parse(canonicalText).body !== parse(current).body;
   // `usePlugin ? gate : null` — only route through the plugin when its read succeeded.
+  // A RESUMED cycle checks the lock BEFORE it mutates anything. The edit pipeline and the
+  // `agent_revised` append below both run ahead of any lock handling, and `waitForActions` only
+  // notices supersession on its first poll — so a recovery that lost the doc while it was watching
+  // would already have applied an edit and announced itself on behalf of a waiter that no longer
+  // owns the document. Not claiming the lock stops it stealing; this stops it acting.
+  if (resumeToken && (await channel.isSuperseded(resumeToken))) {
+    backend.logExit("superseded");
+    output({ status: "superseded" });
+    return "ok";
+  }
+
   await applyGatedEdit(store, channel, ev, { current, canonicalText, quarantine, gate: usePlugin ? gate : null });
 
   // Signal the agent has (re)engaged this round so the editor can clear its
@@ -528,7 +539,11 @@ async function waitCycle(backend: WaitBackend, explicitCursor: number | null, co
     // closed minutes later, on evidence we are holding.
     if (result.entries.some((e) => e.seq > closeEntry.seq && e.actor === "user" && e.type !== LogEventType.SessionClosed)) {
       process.stderr.write("inplan: the editor closed and is already active again — resuming the wait.\n");
-      return waitCycle(backend, result.cursor, confirmed, model, gate, true, lockToken);
+      // Resume from the CLOSE, not from `result.cursor`. The cursor is this batch's max seq, so the
+      // very actions that proved the editor is back sit at or below it and would be skipped —
+      // silently dropping the user's work on a reload. Rewinding to `closeEntry.seq` re-reads them
+      // so they wake the resumed cycle, matching the grace path's documented behaviour.
+      return waitCycle(backend, closeEntry.seq, confirmed, model, gate, true, lockToken);
     }
     process.stderr.write("inplan: the editor closed — often just a page reload. Watching for it to come back…\n");
     const reopen = await awaitReopen(channel, result.cursor, { token: lockToken });

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -532,18 +532,24 @@ async function waitCycle(backend: WaitBackend, explicitCursor: number | null, co
     }
     process.stderr.write("inplan: the editor closed — often just a page reload. Watching for it to come back…\n");
     const reopen = await awaitReopen(channel, result.cursor, { token: lockToken });
-    if (reopen === "superseded") {
+    if (reopen.kind === "superseded") {
       backend.logExit("superseded");
       output({ status: "superseded" });
       return "ok";
     }
-    if (reopen === "completed") {
+    if (reopen.kind === "completed") {
       // An explicit build handoff arrived mid-grace: end now, with ITS reason, not window_closed.
+      // Persist the GRACE read's cursor and report its entries — the cursor was advanced before the
+      // grace began, so reporting the pre-grace one would leave the terminating SessionClosed
+      // unrecorded and the next wait would re-read and re-report the completed session.
+      await channel.setCursor(reopen.cursor);
       backend.logExit("completed");
-      output({ status: "closed", reason: "completed", cursor: result.cursor, closed: true, entries: result.entries });
+      output({ status: "closed", reason: "completed", cursor: reopen.cursor, closed: true, entries: [...result.entries, ...reopen.entries] });
       return "ok";
     }
-    if (reopen === "reopened") {
+    // A reopen deliberately resumes from the PRE-grace cursor: the user entries that proved the
+    // return are then re-read by the resumed cycle and handled as the actionable wake they are.
+    if (reopen.kind === "reopened") {
       process.stderr.write("inplan: the editor is back — resuming the wait.\n");
       return waitCycle(backend, result.cursor, confirmed, model, gate, true, lockToken);
     }
@@ -802,8 +808,8 @@ function printLoginNudge(): void {
  */
 /** THE list of agent markers, so detection and scrubbing can never drift apart. Exact names, plus
  *  prefixes for families (Claude Code sets a whole CLAUDE_CODE_* family). */
-const AGENT_ENV_VARS = ["CLAUDECODE", "CODEX_SANDBOX", "PI_CODING_AGENT", "INPLAN_AGENT"] as const;
-const AGENT_ENV_PREFIXES = ["CLAUDE_CODE_"] as const;
+export const AGENT_ENV_VARS = ["CLAUDECODE", "CODEX_SANDBOX", "PI_CODING_AGENT", "INPLAN_AGENT"] as const;
+export const AGENT_ENV_PREFIXES = ["CLAUDE_CODE_"] as const;
 
 export function isKnownAgentEnv(env: NodeJS.ProcessEnv = process.env): boolean {
   // Claude Code: CLAUDECODE=1 + a CLAUDE_CODE_* family. Codex CLI: CODEX_SANDBOX for the sandboxed

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -39,7 +39,7 @@ import { docPaths, sidecarRoot, type DocPaths } from "./paths";
 import { loadPluginGate, loadPluginGateOutcome, resolveHubUrl, type PluginAbsenceReason, type PluginGate } from "./pluginGate";
 import { demoteSource, shouldHydrateWorkFile, pendingRequiresReplay, postTurnAction, trackGateDegradations, type WaitOutcome } from "./liveSync";
 import { announcePresence } from "./presence";
-import { wakePredicate, waitForActions } from "./wait";
+import { awaitReopen, wakePredicate, waitForActions } from "./wait";
 import { versionFromModule } from "./version";
 import { toolActivityText } from "./relayActivity";
 import { ensureDocFile } from "./ensureDoc";
@@ -499,6 +499,21 @@ async function waitCycle(backend: WaitBackend, explicitCursor: number | null, co
 
   // The editor logs WHY it closed (completed / window_closed); a crash logs nothing.
   const closeEntry = result.entries.find((e) => e.type === LogEventType.SessionClosed);
+  // A `window_closed` is routinely just a page RELOAD — the web editor tears down (logging the
+  // close) and is back seconds later — or a stray second surface (an old desktop window) closing
+  // while the live session goes on. Exiting on that signal alone strands the returning human
+  // with no agent attached, and nothing restarts the wait. So: linger, and if the human shows
+  // signs of being back within the grace (a new user action, or the editor presence heartbeat
+  // returning), resume the wait as if the close never happened. An explicit `completed` (the
+  // build handoff) still ends the session immediately.
+  if (closeEntry && ((closeEntry.payload as { reason?: string } | undefined)?.reason ?? "completed") === "window_closed") {
+    process.stderr.write("inplan: the editor closed — often just a page reload. Watching for it to come back…\n");
+    if (await awaitReopen(channel, result.cursor)) {
+      process.stderr.write("inplan: the editor is back — resuming the wait.\n");
+      return waitCycle(backend, result.cursor, confirmed, model, gate);
+    }
+    process.stderr.write("inplan: the editor did not come back — treating the session as closed.\n");
+  }
   // One status per situation:
   //   your_turn — Turn mode: human finished their turn and is LOCKED; revise, then
   //               call wait to hand control back.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -39,7 +39,7 @@ import { docPaths, sidecarRoot, type DocPaths } from "./paths";
 import { loadPluginGate, loadPluginGateOutcome, resolveHubUrl, type PluginAbsenceReason, type PluginGate } from "./pluginGate";
 import { demoteSource, shouldHydrateWorkFile, pendingRequiresReplay, postTurnAction, trackGateDegradations, type WaitOutcome } from "./liveSync";
 import { announcePresence } from "./presence";
-import { awaitReopen, wakePredicate, waitForActions } from "./wait";
+import { awaitReopen, lockForCycle, wakePredicate, waitForActions } from "./wait";
 import { versionFromModule } from "./version";
 import { toolActivityText } from "./relayActivity";
 import { ensureDocFile } from "./ensureDoc";
@@ -371,7 +371,7 @@ function logWaitExit(p: DocPaths, reason: string): void {
  * cursor, else "start from now" (current max). It is persisted on return so the
  * agent never hand-manages it and turns can't be skipped.
  */
-async function waitCycle(backend: WaitBackend, explicitCursor: number | null, confirmed: Set<string>, model?: string, gate: PluginGate | null = null, resumed = false): Promise<WaitOutcome> {
+async function waitCycle(backend: WaitBackend, explicitCursor: number | null, confirmed: Set<string>, model?: string, gate: PluginGate | null = null, resumed = false, resumeToken?: string): Promise<WaitOutcome> {
   const { channel, store } = backend;
   const history = await backend.history();
 
@@ -438,8 +438,14 @@ async function waitCycle(backend: WaitBackend, explicitCursor: number | null, co
   // double-waiters). Log the exit reason — including OS signals — so a reaped
   // waiter is diagnosable instead of "vanishing" silently.
   // Last writer wins — any older waiter sees the token change and steps down.
-  const lockToken = `${process.pid}-${Date.now()}`;
-  await channel.claimLock(lockToken);
+  // A RESUMED cycle keeps its original token and does NOT re-claim. Claiming would overwrite a
+  // newer waiter's token — a stale waiter stealing the lock back from its replacement, which is
+  // exactly what the grace is documented never to allow. Keeping the old token instead means the
+  // worst case is losing: `waitForActions` polls `isSuperseded(lockToken)` and steps down on its
+  // first tick. A stale waiter can only discover it lost, never take.
+  const lock = lockForCycle(resumeToken, () => `${process.pid}-${Date.now()}`);
+  const lockToken = lock.token;
+  if (lock.claim) await channel.claimLock(lockToken);
   // Register the exit-on-signal handlers ONCE per wait invocation. A resumed cycle (after a reopen)
   // re-enters this function recursively; re-adding them each time leaks listeners across repeated
   // reloads (Node's MaxListenersExceededWarning). The handler only needs `backend` (stable across
@@ -517,6 +523,13 @@ async function waitCycle(backend: WaitBackend, explicitCursor: number | null, co
   // build handoff) still ends the session immediately, and a NEWER waiter supersedes this one
   // mid-grace exactly as it would mid-wait.
   if (closeEntry && ((closeEntry.payload as { reason?: string } | undefined)?.reason ?? "completed") === "window_closed") {
+    // The editor may already be demonstrably back: a debounced batch can carry the close AND the
+    // user actions that followed it. Waiting out the grace in that case reports a live editor as
+    // closed minutes later, on evidence we are holding.
+    if (result.entries.some((e) => e.seq > closeEntry.seq && e.actor === "user" && e.type !== LogEventType.SessionClosed)) {
+      process.stderr.write("inplan: the editor closed and is already active again — resuming the wait.\n");
+      return waitCycle(backend, result.cursor, confirmed, model, gate, true, lockToken);
+    }
     process.stderr.write("inplan: the editor closed — often just a page reload. Watching for it to come back…\n");
     const reopen = await awaitReopen(channel, result.cursor, { token: lockToken });
     if (reopen === "superseded") {
@@ -524,9 +537,15 @@ async function waitCycle(backend: WaitBackend, explicitCursor: number | null, co
       output({ status: "superseded" });
       return "ok";
     }
+    if (reopen === "completed") {
+      // An explicit build handoff arrived mid-grace: end now, with ITS reason, not window_closed.
+      backend.logExit("completed");
+      output({ status: "closed", reason: "completed", cursor: result.cursor, closed: true, entries: result.entries });
+      return "ok";
+    }
     if (reopen === "reopened") {
       process.stderr.write("inplan: the editor is back — resuming the wait.\n");
-      return waitCycle(backend, result.cursor, confirmed, model, gate, true);
+      return waitCycle(backend, result.cursor, confirmed, model, gate, true, lockToken);
     }
     process.stderr.write("inplan: the editor did not come back — treating the session as closed.\n");
   }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -497,18 +497,28 @@ async function waitCycle(backend: WaitBackend, explicitCursor: number | null, co
     return "ok";
   }
 
-  // The editor logs WHY it closed (completed / window_closed); a crash logs nothing.
-  const closeEntry = result.entries.find((e) => e.type === LogEventType.SessionClosed);
+  // The editor logs WHY it closed (completed / window_closed); a crash logs nothing. The LAST
+  // close is the terminal one: a batch may hold window_closed (a reload) followed by completed
+  // (the human came back and did the build handoff) — grace must key on the final word, not
+  // delay an explicit handoff by three minutes.
+  const closeEntry = [...result.entries].reverse().find((e) => e.type === LogEventType.SessionClosed);
   // A `window_closed` is routinely just a page RELOAD — the web editor tears down (logging the
   // close) and is back seconds later — or a stray second surface (an old desktop window) closing
   // while the live session goes on. Exiting on that signal alone strands the returning human
   // with no agent attached, and nothing restarts the wait. So: linger, and if the human shows
   // signs of being back within the grace (a new user action, or the editor presence heartbeat
   // returning), resume the wait as if the close never happened. An explicit `completed` (the
-  // build handoff) still ends the session immediately.
+  // build handoff) still ends the session immediately, and a NEWER waiter supersedes this one
+  // mid-grace exactly as it would mid-wait.
   if (closeEntry && ((closeEntry.payload as { reason?: string } | undefined)?.reason ?? "completed") === "window_closed") {
     process.stderr.write("inplan: the editor closed — often just a page reload. Watching for it to come back…\n");
-    if (await awaitReopen(channel, result.cursor)) {
+    const reopen = await awaitReopen(channel, result.cursor, { token: lockToken });
+    if (reopen === "superseded") {
+      backend.logExit("superseded");
+      output({ status: "superseded" });
+      return "ok";
+    }
+    if (reopen === "reopened") {
       process.stderr.write("inplan: the editor is back — resuming the wait.\n");
       return waitCycle(backend, result.cursor, confirmed, model, gate);
     }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -558,8 +558,8 @@ async function waitCycle(backend: WaitBackend, explicitCursor: number | null, co
       // grace began, so reporting the pre-grace one would leave the terminating SessionClosed
       // unrecorded and the next wait would re-read and re-report the completed session.
       await channel.setCursor(reopen.cursor);
-      backend.logExit("completed");
-      output({ status: "closed", reason: "completed", cursor: reopen.cursor, closed: true, entries: [...result.entries, ...reopen.entries] });
+      backend.logExit(reopen.reason);
+      output({ status: "closed", reason: reopen.reason, cursor: reopen.cursor, closed: true, entries: [...result.entries, ...reopen.entries] });
       return "ok";
     }
     // A reopen deliberately resumes from the PRE-grace cursor: the user entries that proved the

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -782,7 +782,19 @@ function printLoginNudge(): void {
  * same resumable session.
  */
 export function isKnownAgentEnv(env: NodeJS.ProcessEnv = process.env): boolean {
-  return Boolean(env.CLAUDECODE) || Object.keys(env).some((k) => k.startsWith("CLAUDE_CODE_"));
+  return (
+    // Claude Code: sets CLAUDECODE=1 + a family of CLAUDE_CODE_* vars in its tool shell.
+    Boolean(env.CLAUDECODE) ||
+    Object.keys(env).some((k) => k.startsWith("CLAUDE_CODE_")) ||
+    // OpenAI Codex CLI: sets CODEX_SANDBOX for the sandboxed command run. Codex filters CODEX_*
+    // out of the shell env it inherits, so this can't leak in from a human's shell config.
+    Boolean(env.CODEX_SANDBOX) ||
+    // Pi (earendil-works/pi): PI_CODING_AGENT=true, set expressly so sub-processes can self-identify.
+    Boolean(env.PI_CODING_AGENT) ||
+    // Explicit opt-in for any other harness (e.g. set by the inplan skill) — never present in a
+    // human's terminal, so it's a safe catch-all as new agents appear.
+    Boolean(env.INPLAN_AGENT)
+  );
 }
 
 /**

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -800,20 +800,36 @@ function printLoginNudge(): void {
  * allocate one for streaming); misdetection is safe either way because both paths converge on the
  * same resumable session.
  */
+/** THE list of agent markers, so detection and scrubbing can never drift apart. Exact names, plus
+ *  prefixes for families (Claude Code sets a whole CLAUDE_CODE_* family). */
+const AGENT_ENV_VARS = ["CLAUDECODE", "CODEX_SANDBOX", "PI_CODING_AGENT", "INPLAN_AGENT"] as const;
+const AGENT_ENV_PREFIXES = ["CLAUDE_CODE_"] as const;
+
 export function isKnownAgentEnv(env: NodeJS.ProcessEnv = process.env): boolean {
+  // Claude Code: CLAUDECODE=1 + a CLAUDE_CODE_* family. Codex CLI: CODEX_SANDBOX for the sandboxed
+  // run (Codex filters CODEX_* out of the inherited shell env, so it can't leak from a human's
+  // config). Pi: PI_CODING_AGENT=true, set expressly for self-identification. INPLAN_AGENT: the
+  // explicit opt-in for any other harness, never present in a human's terminal.
   return (
-    // Claude Code: sets CLAUDECODE=1 + a family of CLAUDE_CODE_* vars in its tool shell.
-    Boolean(env.CLAUDECODE) ||
-    Object.keys(env).some((k) => k.startsWith("CLAUDE_CODE_")) ||
-    // OpenAI Codex CLI: sets CODEX_SANDBOX for the sandboxed command run. Codex filters CODEX_*
-    // out of the shell env it inherits, so this can't leak in from a human's shell config.
-    Boolean(env.CODEX_SANDBOX) ||
-    // Pi (earendil-works/pi): PI_CODING_AGENT=true, set expressly so sub-processes can self-identify.
-    Boolean(env.PI_CODING_AGENT) ||
-    // Explicit opt-in for any other harness (e.g. set by the inplan skill) — never present in a
-    // human's terminal, so it's a safe catch-all as new agents appear.
-    Boolean(env.INPLAN_AGENT)
+    AGENT_ENV_VARS.some((k) => Boolean(env[k])) || Object.keys(env).some((k) => AGENT_ENV_PREFIXES.some((p) => k.startsWith(p)))
   );
+}
+
+/**
+ * A copy of `env` with every marker {@link isKnownAgentEnv} recognises removed.
+ *
+ * Tests that spawn the CLI and assert the NON-interactive path need this: a marker inherited from
+ * whichever agent shell runs the suite routes the subprocess to the rendezvous pending-exit
+ * instead. Sharing one list with the detector is the point — scrubbing a hand-written subset is
+ * how the tests came to cover Claude's markers only, and would silently rot again the next time a
+ * harness is added to the detector.
+ */
+export function scrubAgentEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const out = { ...env };
+  for (const k of Object.keys(out)) {
+    if ((AGENT_ENV_VARS as readonly string[]).includes(k) || AGENT_ENV_PREFIXES.some((p) => k.startsWith(p))) delete out[k];
+  }
+  return out;
 }
 
 /**

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -39,7 +39,7 @@ import { docPaths, sidecarRoot, type DocPaths } from "./paths";
 import { loadPluginGate, loadPluginGateOutcome, resolveHubUrl, type PluginAbsenceReason, type PluginGate } from "./pluginGate";
 import { demoteSource, shouldHydrateWorkFile, pendingRequiresReplay, postTurnAction, trackGateDegradations, type WaitOutcome } from "./liveSync";
 import { announcePresence } from "./presence";
-import { awaitReopen, lockForCycle, wakePredicate, waitForActions } from "./wait";
+import { awaitReopen, lockForCycle, verifyResumedLock, wakePredicate, waitForActions } from "./wait";
 import { versionFromModule } from "./version";
 import { toolActivityText } from "./relayActivity";
 import { ensureDocFile } from "./ensureDoc";
@@ -433,10 +433,23 @@ async function waitCycle(backend: WaitBackend, explicitCursor: number | null, co
   // notices supersession on its first poll — so a recovery that lost the doc while it was watching
   // would already have applied an edit and announced itself on behalf of a waiter that no longer
   // owns the document. Not claiming the lock stops it stealing; this stops it acting.
-  if (resumeToken && (await channel.isSuperseded(resumeToken))) {
-    backend.logExit("superseded");
-    output({ status: "superseded" });
-    return "ok";
+  if (resumeToken) {
+    const owns = await verifyResumedLock(channel, resumeToken);
+    if (owns === "lost") {
+      backend.logExit("superseded");
+      output({ status: "superseded" });
+      return "ok";
+    }
+    if (owns === "unverifiable") {
+      // The lock read itself failed. Ending here is deliberate: an unverifiable lock must not be
+      // treated as ours, and letting the rejection escape would reject waitCycle — a stack trace
+      // with no JSON on the agent's channel, the failure mode this codebase already removed once.
+      backend.logExit("lock_unverifiable");
+      process.stderr.write("inplan: couldn't confirm this wait still owns the document — ending rather than risking a double write.\n  Re-attach to continue.\n");
+      output({ status: "wait_failed", message: "resumed wait could not verify its lock" });
+      exitAfterFlush(EXIT_WAIT_FAILED);
+      return "exiting";
+    }
   }
 
   await applyGatedEdit(store, channel, ev, { current, canonicalText, quarantine, gate: usePlugin ? gate : null });

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -39,7 +39,7 @@ import { docPaths, sidecarRoot, type DocPaths } from "./paths";
 import { loadPluginGate, loadPluginGateOutcome, resolveHubUrl, type PluginAbsenceReason, type PluginGate } from "./pluginGate";
 import { demoteSource, shouldHydrateWorkFile, pendingRequiresReplay, postTurnAction, trackGateDegradations, type WaitOutcome } from "./liveSync";
 import { announcePresence } from "./presence";
-import { awaitReopen, lockForCycle, verifyResumedLock, wakePredicate, waitForActions } from "./wait";
+import { awaitReopen, wakePredicate, waitForActions } from "./wait";
 import { versionFromModule } from "./version";
 import { toolActivityText } from "./relayActivity";
 import { ensureDocFile } from "./ensureDoc";
@@ -88,8 +88,6 @@ function hasFlag(args: string[], name: string): boolean {
   return args.includes(`--${name}`);
 }
 
-const debounceMs = Number(process.env.INPLAN_DEBOUNCE_MS ?? 3000);
-const pollMs = Number(process.env.INPLAN_POLL_MS ?? 200);
 /**
  * Result of locating the Electron editor bundled alongside this CLI in the published
  * `inplan` package (layout: `bin/cli.js` + `app/main/index.cjs`, with `electron` as a
@@ -330,7 +328,7 @@ function maxSeqFrom(entries: LogEntry[]): number {
  * over either, since it consumes only the {@link ControlChannel}/{@link DocumentStore}
  * interfaces.
  */
-interface WaitBackend {
+export interface WaitBackend {
   channel: ControlChannel;
   store: DocumentStore;
   /** Full protocol history, for deriving cadence/acceptance/settings/start cursor. */
@@ -371,7 +369,7 @@ function logWaitExit(p: DocPaths, reason: string): void {
  * cursor, else "start from now" (current max). It is persisted on return so the
  * agent never hand-manages it and turns can't be skipped.
  */
-async function waitCycle(backend: WaitBackend, explicitCursor: number | null, confirmed: Set<string>, model?: string, gate: PluginGate | null = null, resumed = false, resumeToken?: string): Promise<WaitOutcome> {
+export async function waitCycle(backend: WaitBackend, explicitCursor: number | null, confirmed: Set<string>, model?: string, gate: PluginGate | null = null): Promise<WaitOutcome> {
   const { channel, store } = backend;
   const history = await backend.history();
 
@@ -428,197 +426,186 @@ async function waitCycle(backend: WaitBackend, explicitCursor: number | null, co
   const acceptance = acceptanceFrom(history);
   const quarantine = acceptance === "review" && parse(canonicalText).body !== parse(current).body;
   // `usePlugin ? gate : null` — only route through the plugin when its read succeeded.
-  // A RESUMED cycle checks the lock BEFORE it mutates anything. The edit pipeline and the
-  // `agent_revised` append below both run ahead of any lock handling, and `waitForActions` only
-  // notices supersession on its first poll — so a recovery that lost the doc while it was watching
-  // would already have applied an edit and announced itself on behalf of a waiter that no longer
-  // owns the document. Not claiming the lock stops it stealing; this stops it acting.
-  if (resumeToken) {
-    const owns = await verifyResumedLock(channel, resumeToken);
-    if (owns === "lost") {
-      backend.logExit("superseded");
-      output({ status: "superseded" });
-      return "ok";
-    }
-    if (owns === "unverifiable") {
-      // The lock read itself failed. Ending here is deliberate: an unverifiable lock must not be
-      // treated as ours, and letting the rejection escape would reject waitCycle — a stack trace
-      // with no JSON on the agent's channel, the failure mode this codebase already removed once.
-      backend.logExit("lock_unverifiable");
-      process.stderr.write("inplan: couldn't confirm this wait still owns the document — ending rather than risking a double write.\n  Re-attach to continue.\n");
-      output({ status: "wait_failed", message: "resumed wait could not verify its lock" });
-      exitAfterFlush(EXIT_WAIT_FAILED);
-      return "exiting";
-    }
-  }
-
   await applyGatedEdit(store, channel, ev, { current, canonicalText, quarantine, gate: usePlugin ? gate : null });
 
   // Signal the agent has (re)engaged this round so the editor can clear its
   // "Agent is thinking…" indicator even when the agent made no body change.
   await channel.append({ actor: "agent", type: LogEventType.AgentRevised });
 
-  // Single-waiter lock: claim the doc so any older waiter steps down (no racing
-  // double-waiters). Log the exit reason — including OS signals — so a reaped
-  // waiter is diagnosable instead of "vanishing" silently.
-  // Last writer wins — any older waiter sees the token change and steps down.
-  // A RESUMED cycle keeps its original token and does NOT re-claim. Claiming would overwrite a
-  // newer waiter's token — a stale waiter stealing the lock back from its replacement, which is
-  // exactly what the grace is documented never to allow. Keeping the old token instead means the
-  // worst case is losing: `waitForActions` polls `isSuperseded(lockToken)` and steps down on its
-  // first tick. A stale waiter can only discover it lost, never take.
-  const lock = lockForCycle(resumeToken, () => `${process.pid}-${Date.now()}`);
-  const lockToken = lock.token;
-  if (lock.claim) await channel.claimLock(lockToken);
-  // Register the exit-on-signal handlers ONCE per wait invocation. A resumed cycle (after a reopen)
-  // re-enters this function recursively; re-adding them each time leaks listeners across repeated
-  // reloads (Node's MaxListenersExceededWarning). The handler only needs `backend` (stable across
-  // cycles), so the first registration covers every subsequent resume.
-  if (!resumed) {
-    for (const sig of ["SIGTERM", "SIGHUP", "SIGINT"] as const) {
-      process.on(sig, () => {
-        backend.logExit(`signal:${sig}`);
-        process.exit(0);
-      });
+  // ── Everything below only READS, WAITS, and REPORTS. ──────────────────────────────────────────
+  //
+  // The turn processing above ran exactly once; the wait below may cycle through any number of
+  // editor reloads without coming back up here. A reopen-resume is a `continue`, not a recursive
+  // call — and that STRUCTURE, not a guard, is what enforces the reopen invariants that were being
+  // patched one review round at a time:
+  //   • a resume cannot re-run the edit pipeline. Under recursion every reload re-appended
+  //     agent_revised, and on the PLUGIN path — where quarantine does not revert the working copy
+  //     to canonical — a pending Review proposal was re-parked and agent_revision_proposed
+  //     re-appended, duplicating agent events the editor renders;
+  //   • a resume cannot re-claim or re-mint the lock, so a stale waiter returning from a grace can
+  //     only DISCOVER it lost — waitForActions polls isSuperseded(lockToken) every tick — never
+  //     overwrite the newer waiter's token, and it mutates nothing on the way to finding out;
+  //   • the signal handlers are registered once, so repeated reloads cannot leak listeners.
+
+  // Single-waiter lock: claim the doc so any older waiter steps down (no racing double-waiters).
+  // Last writer wins — any older waiter sees the token change and steps down. Log the exit reason —
+  // including OS signals — so a reaped waiter is diagnosable instead of "vanishing" silently.
+  const lockToken = `${process.pid}-${Date.now()}`;
+  await channel.claimLock(lockToken);
+  for (const sig of ["SIGTERM", "SIGHUP", "SIGINT"] as const) {
+    process.on(sig, () => {
+      backend.logExit(`signal:${sig}`);
+      process.exit(0);
+    });
+  }
+
+  const debounceMs = Number(process.env.INPLAN_DEBOUNCE_MS ?? 3000);
+  const pollMs = Number(process.env.INPLAN_POLL_MS ?? 200);
+
+  let waitCursor = cursor;
+  let historyForMode = history;
+  for (;;) {
+    // Mode-aware wake from the recorded policy: a turn-end mode wakes only on turn-end /
+    // session-close; an any-action mode wakes on any user action. Re-derived each iteration
+    // (history is re-read on resume), so a mode switched just before the reload is honoured.
+    const mode = modeFrom(historyForMode);
+    const isActionable = wakePredicate(mode.wake);
+    const result = await waitForActions({ channel, cursor: waitCursor, debounceMs, pollMs, isActionable, token: lockToken });
+
+    // The wait gave up after a streak of failed polls — an expired session is the common cause.
+    // Report it as a status the agent can act on and exit non-zero. It used to reach here as an
+    // unhandled rejection that killed the process mid-poll: a stack trace on stderr, nothing on stdout.
+    if (result.failed) {
+      backend.logExit("poll_failed");
+      process.stderr.write(`inplan: lost contact with the document (${result.failed.message}).\n  If your session expired, run \`inplan login\` and re-attach.\n`);
+      output({ status: "wait_failed", message: result.failed.message });
+      exitAfterFlush(EXIT_WAIT_FAILED);
+      return "exiting";
     }
-  }
 
-  // Mode-aware wake from the recorded policy: a turn-end mode wakes only on turn-end /
-  // session-close; an any-action mode wakes on any user action.
-  const mode = modeFrom(history);
-  const isActionable = wakePredicate(mode.wake);
-  const result = await waitForActions({ channel, cursor, debounceMs, pollMs, isActionable, token: lockToken });
-
-  // The wait gave up after a streak of failed polls — an expired session is the common cause. Report
-  // it as a status the agent can act on and exit non-zero. It used to reach here as an unhandled
-  // rejection that killed the process mid-poll: a stack trace on stderr, nothing on stdout.
-  if (result.failed) {
-    backend.logExit("poll_failed");
-    process.stderr.write(`inplan: lost contact with the document (${result.failed.message}).\n  If your session expired, run \`inplan login\` and re-attach.\n`);
-    output({ status: "wait_failed", message: result.failed.message });
-    exitAfterFlush(EXIT_WAIT_FAILED);
-    return "exiting";
-  }
-
-  // Superseded: a newer waiter owns the doc now. Step down quietly without
-  // advancing the cursor (the live waiter handles it).
-  if (result.superseded) {
-    backend.logExit("superseded");
-    output({ status: "superseded" });
-    return "ok";
-  }
-
-  // Cloud→local handoff: a human on the web asked us to bring the doc back to disk.
-  // The backend's handler downloads + relocates + flips status and emits its own
-  // result, so we hand off instead of printing the normal turn status. Do this BEFORE advancing the
-  // cursor: if the handler throws (e.g. the gate path's hub read fails), the SaveLocallyRequested
-  // event stays unconsumed so the next run retries — otherwise the handoff would be lost. On success
-  // the doc becomes local, so the cloud cursor is moot.
-  if (backend.onSaveLocally && result.entries.some((e) => e.type === LogEventType.SaveLocallyRequested)) {
-    backend.logExit("save_locally");
-    await backend.onSaveLocally();
-    return "ok";
-  }
-
-  await channel.setCursor(result.cursor); // advance the persisted cursor so the next call continues here
-
-  // In-window navigation: the editor followed a link to a sibling doc and parked a
-  // `navigated_to {path}`. Step down here and report the new path so the agent loop
-  // re-attaches there (`wait <path>`), following the human across docs.
-  const navEntry = result.entries.find((e) => e.type === LogEventType.NavigatedTo);
-  if (navEntry) {
-    const path = (navEntry.payload as { path?: string } | undefined)?.path;
-    backend.logExit("navigated");
-    output({ status: "navigated", ...(path ? { path } : {}), cursor: result.cursor, closed: false });
-    return "ok";
-  }
-
-  // The editor logs WHY it closed (completed / window_closed); a crash logs nothing. The LAST
-  // close is the terminal one: a batch may hold window_closed (a reload) followed by completed
-  // (the human came back and did the build handoff) — grace must key on the final word, not
-  // delay an explicit handoff by three minutes.
-  const closeEntry = [...result.entries].reverse().find((e) => e.type === LogEventType.SessionClosed);
-  // A `window_closed` is routinely just a page RELOAD — the web editor tears down (logging the
-  // close) and is back seconds later — or a stray second surface (an old desktop window) closing
-  // while the live session goes on. Exiting on that signal alone strands the returning human
-  // with no agent attached, and nothing restarts the wait. So: linger, and if the human shows
-  // signs of being back within the grace (a new user action, or the editor presence heartbeat
-  // returning), resume the wait as if the close never happened. An explicit `completed` (the
-  // build handoff) still ends the session immediately, and a NEWER waiter supersedes this one
-  // mid-grace exactly as it would mid-wait.
-  if (closeEntry && ((closeEntry.payload as { reason?: string } | undefined)?.reason ?? "completed") === "window_closed") {
-    // The editor may already be demonstrably back: a debounced batch can carry the close AND the
-    // user actions that followed it. Waiting out the grace in that case reports a live editor as
-    // closed minutes later, on evidence we are holding.
-    if (result.entries.some((e) => e.seq > closeEntry.seq && e.actor === "user" && e.type !== LogEventType.SessionClosed)) {
-      process.stderr.write("inplan: the editor closed and is already active again — resuming the wait.\n");
-      // Resume from the CLOSE, not from `result.cursor`. The cursor is this batch's max seq, so the
-      // very actions that proved the editor is back sit at or below it and would be skipped —
-      // silently dropping the user's work on a reload. Rewinding to `closeEntry.seq` re-reads them
-      // so they wake the resumed cycle, matching the grace path's documented behaviour.
-      return waitCycle(backend, closeEntry.seq, confirmed, model, gate, true, lockToken);
-    }
-    process.stderr.write("inplan: the editor closed — often just a page reload. Watching for it to come back…\n");
-    const reopen = await awaitReopen(channel, result.cursor, { token: lockToken });
-    if (reopen.kind === "superseded") {
+    // Superseded: a newer waiter owns the doc now. Step down quietly without
+    // advancing the cursor (the live waiter handles it).
+    if (result.superseded) {
       backend.logExit("superseded");
       output({ status: "superseded" });
       return "ok";
     }
-    if (reopen.kind === "completed") {
-      // An explicit build handoff arrived mid-grace: end now, with ITS reason, not window_closed.
-      // Persist the GRACE read's cursor and report its entries — the cursor was advanced before the
-      // grace began, so reporting the pre-grace one would leave the terminating SessionClosed
-      // unrecorded and the next wait would re-read and re-report the completed session.
-      await channel.setCursor(reopen.cursor);
-      backend.logExit(reopen.reason);
-      output({ status: "closed", reason: reopen.reason, cursor: reopen.cursor, closed: true, entries: [...result.entries, ...reopen.entries] });
+
+    // Cloud→local handoff: a human on the web asked us to bring the doc back to disk.
+    // The backend's handler downloads + relocates + flips status and emits its own
+    // result, so we hand off instead of printing the normal turn status. Do this BEFORE advancing
+    // the cursor: if the handler throws (e.g. the gate path's hub read fails), the
+    // SaveLocallyRequested event stays unconsumed so the next run retries — otherwise the handoff
+    // would be lost. On success the doc becomes local, so the cloud cursor is moot.
+    if (backend.onSaveLocally && result.entries.some((e) => e.type === LogEventType.SaveLocallyRequested)) {
+      backend.logExit("save_locally");
+      await backend.onSaveLocally();
       return "ok";
     }
-    // A reopen deliberately resumes from the PRE-grace cursor: the user entries that proved the
-    // return are then re-read by the resumed cycle and handled as the actionable wake they are.
-    if (reopen.kind === "reopened") {
-      process.stderr.write("inplan: the editor is back — resuming the wait.\n");
-      return waitCycle(backend, result.cursor, confirmed, model, gate, true, lockToken);
+
+    await channel.setCursor(result.cursor); // advance the persisted cursor so the next call continues here
+
+    // In-window navigation: the editor followed a link to a sibling doc and parked a
+    // `navigated_to {path}`. Step down here and report the new path so the agent loop
+    // re-attaches there (`wait <path>`), following the human across docs.
+    const navEntry = result.entries.find((e) => e.type === LogEventType.NavigatedTo);
+    if (navEntry) {
+      const path = (navEntry.payload as { path?: string } | undefined)?.path;
+      backend.logExit("navigated");
+      output({ status: "navigated", ...(path ? { path } : {}), cursor: result.cursor, closed: false });
+      return "ok";
     }
-    process.stderr.write("inplan: the editor did not come back — treating the session as closed.\n");
+
+    // The editor logs WHY it closed (completed / window_closed); a crash logs nothing. The LAST
+    // close is the terminal one: a batch may hold window_closed (a reload) followed by completed
+    // (the human came back and did the build handoff) — grace must key on the final word, not
+    // delay an explicit handoff by three minutes.
+    const closeEntry = [...result.entries].reverse().find((e) => e.type === LogEventType.SessionClosed);
+    // A `window_closed` is routinely just a page RELOAD — the web editor tears down (logging the
+    // close) and is back seconds later — or a stray second surface (an old desktop window) closing
+    // while the live session goes on. Exiting on that signal alone strands the returning human
+    // with no agent attached, and nothing restarts the wait. So: linger, and if the human shows
+    // signs of being back within the grace (a new user action, or the editor presence heartbeat
+    // returning), loop back to waiting as if the close never happened. An explicit `completed`
+    // (the build handoff) still ends the session immediately, and a NEWER waiter supersedes this
+    // one mid-grace exactly as it would mid-wait.
+    if (closeEntry && ((closeEntry.payload as { reason?: string } | undefined)?.reason ?? "completed") === "window_closed") {
+      // The editor may already be demonstrably back: a debounced batch can carry the close AND the
+      // user actions that followed it. Waiting out the grace in that case reports a live editor as
+      // closed minutes later, on evidence we are holding. Resume from the CLOSE, not from
+      // `result.cursor` — the cursor is this batch's max seq, so the very actions that proved the
+      // editor is back sit at or below it and would be skipped, silently dropping the user's work.
+      if (result.entries.some((e) => e.seq > closeEntry.seq && e.actor === "user" && e.type !== LogEventType.SessionClosed)) {
+        process.stderr.write("inplan: the editor closed and is already active again — resuming the wait.\n");
+        waitCursor = closeEntry.seq;
+        historyForMode = await backend.history();
+        continue;
+      }
+      process.stderr.write("inplan: the editor closed — often just a page reload. Watching for it to come back…\n");
+      const reopen = await awaitReopen(channel, result.cursor, { token: lockToken });
+      if (reopen.kind === "superseded") {
+        backend.logExit("superseded");
+        output({ status: "superseded" });
+        return "ok";
+      }
+      if (reopen.kind === "completed") {
+        // An explicit build handoff arrived mid-grace: end now, with ITS reason, not window_closed.
+        // Persist the GRACE read's cursor and report its entries — the cursor was advanced before
+        // the grace began, so reporting the pre-grace one would leave the terminating SessionClosed
+        // unrecorded and the next wait would re-read and re-report the completed session.
+        await channel.setCursor(reopen.cursor);
+        backend.logExit(reopen.reason);
+        output({ status: "closed", reason: reopen.reason, cursor: reopen.cursor, closed: true, entries: [...result.entries, ...reopen.entries] });
+        return "ok";
+      }
+      // A grace reopen deliberately resumes from the PRE-grace cursor: the user entries that proved
+      // the return are then re-read by the next iteration and handled as the actionable wake they are.
+      if (reopen.kind === "reopened") {
+        process.stderr.write("inplan: the editor is back — resuming the wait.\n");
+        waitCursor = result.cursor;
+        historyForMode = await backend.history();
+        continue;
+      }
+      process.stderr.write("inplan: the editor did not come back — treating the session as closed.\n");
+    }
+
+    // One status per situation:
+    //   your_turn — Turn mode: human finished their turn and is LOCKED; revise, then
+    //               call wait to hand control back.
+    //   activity  — Instant mode: human is editing LIVE and is NOT blocked.
+    //   closed    — the session ended; stop. `reason` says how: completed / window_closed
+    //               / crashed_or_killed.
+    let status: string;
+    let reason: string | undefined;
+    if (closeEntry) {
+      status = "closed";
+      reason = (closeEntry.payload as { reason?: string } | undefined)?.reason ?? "completed";
+    } else if (result.editorGone) {
+      status = "closed";
+      reason = "crashed_or_killed";
+    } else {
+      // A locking mode means the human's editor is locked waiting for the agent (your_turn);
+      // a non-locking (live) mode means they keep editing (activity).
+      status = mode.locksEditor ? "your_turn" : "activity";
+    }
+    backend.logExit(`status:${status}${reason ? `/${reason}` : ""}`);
+    output({
+      status,
+      mode: mode.cadence,
+      humanLocked: status === "your_turn",
+      // Materialized current settings (global file + this session's settings_changed),
+      // so the agent always has them without scanning the log history.
+      settings: settingsFromEntries(historyForMode),
+      // The canonical name the agent should author comments under (model-qualified
+      // when --model was passed), so presence + authorship stay consistent.
+      agentAuthor: agentAuthorFor(model),
+      ...(reason ? { reason } : {}),
+      cursor: result.cursor,
+      closed: status === "closed",
+      entries: result.entries,
+    });
+    return "ok";
   }
-  // One status per situation:
-  //   your_turn — Turn mode: human finished their turn and is LOCKED; revise, then
-  //               call wait to hand control back.
-  //   activity  — Instant mode: human is editing LIVE and is NOT blocked.
-  //   closed    — the session ended; stop. `reason` says how: completed / window_closed
-  //               / crashed_or_killed.
-  let status: string;
-  let reason: string | undefined;
-  if (closeEntry) {
-    status = "closed";
-    reason = (closeEntry.payload as { reason?: string } | undefined)?.reason ?? "completed";
-  } else if (result.editorGone) {
-    status = "closed";
-    reason = "crashed_or_killed";
-  } else {
-    // A locking mode means the human's editor is locked waiting for the agent (your_turn);
-    // a non-locking (live) mode means they keep editing (activity).
-    status = mode.locksEditor ? "your_turn" : "activity";
-  }
-  backend.logExit(`status:${status}${reason ? `/${reason}` : ""}`);
-  output({
-    status,
-    mode: mode.cadence,
-    humanLocked: status === "your_turn",
-    // Materialized current settings (global file + this session's settings_changed),
-    // so the agent always has them without scanning the log history.
-    settings: settingsFromEntries(history),
-    // The canonical name the agent should author comments under (model-qualified
-    // when --model was passed), so presence + authorship stay consistent.
-    agentAuthor: agentAuthorFor(model),
-    ...(reason ? { reason } : {}),
-    cursor: result.cursor,
-    closed: status === "closed",
-    entries: result.entries,
-  });
-  return "ok";
 }
 
 /**

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -371,7 +371,7 @@ function logWaitExit(p: DocPaths, reason: string): void {
  * cursor, else "start from now" (current max). It is persisted on return so the
  * agent never hand-manages it and turns can't be skipped.
  */
-async function waitCycle(backend: WaitBackend, explicitCursor: number | null, confirmed: Set<string>, model?: string, gate: PluginGate | null = null): Promise<WaitOutcome> {
+async function waitCycle(backend: WaitBackend, explicitCursor: number | null, confirmed: Set<string>, model?: string, gate: PluginGate | null = null, resumed = false): Promise<WaitOutcome> {
   const { channel, store } = backend;
   const history = await backend.history();
 
@@ -440,11 +440,17 @@ async function waitCycle(backend: WaitBackend, explicitCursor: number | null, co
   // Last writer wins — any older waiter sees the token change and steps down.
   const lockToken = `${process.pid}-${Date.now()}`;
   await channel.claimLock(lockToken);
-  for (const sig of ["SIGTERM", "SIGHUP", "SIGINT"] as const) {
-    process.on(sig, () => {
-      backend.logExit(`signal:${sig}`);
-      process.exit(0);
-    });
+  // Register the exit-on-signal handlers ONCE per wait invocation. A resumed cycle (after a reopen)
+  // re-enters this function recursively; re-adding them each time leaks listeners across repeated
+  // reloads (Node's MaxListenersExceededWarning). The handler only needs `backend` (stable across
+  // cycles), so the first registration covers every subsequent resume.
+  if (!resumed) {
+    for (const sig of ["SIGTERM", "SIGHUP", "SIGINT"] as const) {
+      process.on(sig, () => {
+        backend.logExit(`signal:${sig}`);
+        process.exit(0);
+      });
+    }
   }
 
   // Mode-aware wake from the recorded policy: a turn-end mode wakes only on turn-end /
@@ -520,7 +526,7 @@ async function waitCycle(backend: WaitBackend, explicitCursor: number | null, co
     }
     if (reopen === "reopened") {
       process.stderr.write("inplan: the editor is back — resuming the wait.\n");
-      return waitCycle(backend, result.cursor, confirmed, model, gate);
+      return waitCycle(backend, result.cursor, confirmed, model, gate, true);
     }
     process.stderr.write("inplan: the editor did not come back — treating the session as closed.\n");
   }

--- a/packages/cli/src/cliAuth.ts
+++ b/packages/cli/src/cliAuth.ts
@@ -426,7 +426,7 @@ export function liveRemoteBackend(docId: string, consumerId = "cli-agent"): Live
     setCursor: async (s) => (await need()).channel.setCursor(s),
     claimLock: async (t) => (await need()).channel.claimLock(t),
     isSuperseded: async (t) => (await need()).channel.isSuperseded(t),
-    presence: async () => (await need()).channel.presence(),
+    presence: async (sinceMs?: number) => (await need()).channel.presence(sinceMs),
   };
   const store: DocumentStore = {
     loadDoc: async () => (await need()).store.loadDoc(),

--- a/packages/cli/src/wait.ts
+++ b/packages/cli/src/wait.ts
@@ -148,6 +148,20 @@ export type ReopenOutcome =
   | { kind: "superseded" }
   | { kind: "completed"; cursor: number; entries: LogEntry[]; reason: string };
 
+/** Whether a RESUMED cycle still owns the document, for the check that must run before it mutates.
+ *
+ *  `unverifiable` is its own answer on purpose. `isSuperseded` rejects when the lock read fails, and
+ *  an unverifiable lock must not be read as "still ours": acting could double-write on behalf of a
+ *  waiter that lost the doc during the grace. Declining merely ends this cycle — the agent's next
+ *  `wait` re-attaches — so the asymmetry favours refusing. */
+export async function verifyResumedLock(channel: Pick<ControlChannel, "isSuperseded">, token: string): Promise<"ours" | "lost" | "unverifiable"> {
+  try {
+    return (await channel.isSuperseded(token)) ? "lost" : "ours";
+  } catch {
+    return "unverifiable";
+  }
+}
+
 export function lockForCycle(resumeToken: string | undefined, mint: () => string): { token: string; claim: boolean } {
   return resumeToken ? { token: resumeToken, claim: false } : { token: mint(), claim: true };
 }

--- a/packages/cli/src/wait.ts
+++ b/packages/cli/src/wait.ts
@@ -115,6 +115,41 @@ export function wakePredicate(wake: "turn-end" | "any-action"): (e: LogEntry) =>
     : (e) => e.type === LogEventType.TurnEnded || e.type === LogEventType.SessionClosed || e.type === LogEventType.SaveLocallyRequested || e.type === LogEventType.NavigatedTo;
 }
 
+/** How long a `window_closed` close may linger before it is believed. A page RELOAD tears the
+ *  editor down (which logs the close) and is typically back within seconds; ending the agent's
+ *  wait on that signal alone strands the returning human with nobody attached. */
+export const REOPEN_GRACE_MS = 3 * 60_000;
+
+/**
+ * After a `window_closed` session-close: watch for the human coming BACK within `graceMs` —
+ * either a NEW user-authored entry past `cursor`, or editor presence turning alive again (a
+ * reload appends no events, so the presence heartbeat is the only signal for a silent return).
+ * Resolves true on resumption, false when the grace passes in silence (they really left).
+ * Transient read failures don't abort the watch; the grace bounds everything.
+ */
+export async function awaitReopen(
+  channel: ControlChannel,
+  cursor: number,
+  opts: { graceMs?: number; pollMs?: number; now?: () => number; sleep?: (ms: number) => Promise<void> } = {},
+): Promise<boolean> {
+  const graceMs = opts.graceMs ?? REOPEN_GRACE_MS;
+  const pollMs = opts.pollMs ?? 2000;
+  const now = opts.now ?? Date.now;
+  const sleep = opts.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  const deadline = now() + graceMs;
+  while (now() < deadline) {
+    try {
+      const { entries } = await channel.readSince(cursor);
+      if (entries.some((e) => e.actor === "user" && e.type !== LogEventType.SessionClosed)) return true;
+      if (await channel.presence()) return true;
+    } catch {
+      /* transient read/presence failure — keep watching until the grace expires */
+    }
+    await sleep(pollMs);
+  }
+  return false;
+}
+
 /**
  * Block until the control log gains a new actionable entry past `cursor`, then —
  * after a debounce window of quiescence — resolve with all new entries and the

--- a/packages/cli/src/wait.ts
+++ b/packages/cli/src/wait.ts
@@ -149,20 +149,30 @@ export async function awaitReopen(
   const now = opts.now ?? Date.now;
   const sleep = opts.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
   const deadline = now() + graceMs;
-  // Bound a probe by min(probeTimeoutMs, remaining grace): the race's loser keeps running but is
-  // abandoned — the grace budget, not the channel's health, decides when the watch ends.
-  const bounded = <T>(fn: () => Promise<T>): Promise<T> => {
-    const budget = Math.max(1, Math.min(opts.probeTimeoutMs ?? 10_000, deadline - now()));
-    return Promise.race([fn(), new Promise<never>((_, rej) => setTimeout(() => rej(new Error("probe timed out")), budget).unref?.())]);
-  };
+  // Only a heartbeat FRESHER than this counts as a reopen: a window_closed's presence heartbeat
+  // lingers for the backend's TTL, so a `presence()` read right after the close reports the OLD
+  // editor, not a return — which would resume a dead session (its stale heartbeat then expires and
+  // ends the wait, defeating the grace). Gate presence on "written since we started watching".
+  const graceStart = now();
+  // Per-probe bound = min(probeTimeoutMs, remaining grace): a probe that loses the race keeps
+  // running but is abandoned — the grace budget, not the channel's health, decides when to stop.
+  const budget = (): number => Math.max(1, Math.min(opts.probeTimeoutMs ?? 10_000, deadline - now()));
+  // Independent in-flight gates per probe. A probe that stalls during an outage times out for THIS
+  // iteration, but its underlying request is not cancellable and keeps pending — the gate skips
+  // launching another on top of it, so timed-out reads don't stack across the grace window.
+  const supersede = inFlightGate();
+  const reads = inFlightGate();
+  const presences = inFlightGate();
   while (now() < deadline) {
     try {
-      if (opts.token && (await bounded(() => channel.isSuperseded(opts.token!)))) return "superseded";
-      const { entries } = await bounded(() => channel.readSince(cursor));
-      if (entries.some((e) => e.actor === "user" && e.type !== LogEventType.SessionClosed)) return "reopened";
-      if (await bounded(() => channel.presence())) return "reopened";
+      if (opts.token && !supersede.busy() && (await supersede.run(() => channel.isSuperseded(opts.token!), budget()))) return "superseded";
+      if (!reads.busy()) {
+        const { entries } = await reads.run(() => channel.readSince(cursor), budget());
+        if (entries.some((e) => e.actor === "user" && e.type !== LogEventType.SessionClosed)) return "reopened";
+      }
+      if (!presences.busy() && (await presences.run(() => channel.presence(graceStart), budget()))) return "reopened";
     } catch {
-      /* transient read/presence failure — keep watching until the grace expires */
+      /* a probe timed out, or a read/presence failed transiently — keep watching until grace expires */
     }
     await sleep(Math.max(1, Math.min(pollMs, deadline - now())));
   }

--- a/packages/cli/src/wait.ts
+++ b/packages/cli/src/wait.ts
@@ -137,6 +137,15 @@ export const REOPEN_GRACE_MS = 3 * 60_000;
  *  waiter stealing the lock back from its replacement, exactly what the grace is documented never to
  *  allow. Keeping the old token means the worst case is losing, since the poll loop's
  *  `isSuperseded(token)` check steps a superseded waiter down on its first tick. */
+/** What the grace watch concluded. `completed` carries the cursor and entries FROM THE GRACE READ:
+ *  the caller persisted its cursor before the grace began, so without these the SessionClosed that
+ *  ended the session is never recorded and the next wait re-reads and re-reports it. */
+export type ReopenOutcome =
+  | { kind: "reopened" }
+  | { kind: "expired" }
+  | { kind: "superseded" }
+  | { kind: "completed"; cursor: number; entries: LogEntry[] };
+
 export function lockForCycle(resumeToken: string | undefined, mint: () => string): { token: string; claim: boolean } {
   return resumeToken ? { token: resumeToken, claim: false } : { token: mint(), claim: true };
 }
@@ -154,7 +163,7 @@ export async function awaitReopen(
     now?: () => number;
     sleep?: (ms: number) => Promise<void>;
   } = {},
-): Promise<"reopened" | "expired" | "superseded" | "completed"> {
+): Promise<ReopenOutcome> {
   const graceMs = opts.graceMs ?? REOPEN_GRACE_MS;
   const pollMs = opts.pollMs ?? 2000;
   const now = opts.now ?? Date.now;
@@ -176,9 +185,9 @@ export async function awaitReopen(
   const presences = inFlightGate();
   while (now() < deadline) {
     try {
-      if (opts.token && !supersede.busy() && (await supersede.run(() => channel.isSuperseded(opts.token!), budget()))) return "superseded";
+      if (opts.token && !supersede.busy() && (await supersede.run(() => channel.isSuperseded(opts.token!), budget()))) return { kind: "superseded" };
       if (!reads.busy()) {
-        const { entries } = await reads.run(() => channel.readSince(cursor), budget());
+        const { entries, cursor: readCursor } = await reads.run(() => channel.readSince(cursor), budget());
         // An explicit `completed` (the build handoff) logged DURING the grace ends it immediately.
         // Without this it was ignored for the full window and then reported as `window_closed` —
         // the deliberate handoff both delayed by minutes and mislabelled. A newer `window_closed`
@@ -191,16 +200,16 @@ export async function awaitReopen(
           const reason = (e.payload as { reason?: string } | undefined)?.reason;
           return reason !== undefined && reason !== "window_closed";
         });
-        if (closed) return "completed";
-        if (entries.some((e) => e.actor === "user" && e.type !== LogEventType.SessionClosed)) return "reopened";
+        if (closed) return { kind: "completed", cursor: readCursor, entries };
+        if (entries.some((e) => e.actor === "user" && e.type !== LogEventType.SessionClosed)) return { kind: "reopened" };
       }
-      if (!presences.busy() && (await presences.run(() => channel.presence(graceStart), budget()))) return "reopened";
+      if (!presences.busy() && (await presences.run(() => channel.presence(graceStart), budget()))) return { kind: "reopened" };
     } catch {
       /* a probe timed out, or a read/presence failed transiently — keep watching until grace expires */
     }
     await sleep(Math.max(1, Math.min(pollMs, deadline - now())));
   }
-  return "expired";
+  return { kind: "expired" };
 }
 
 /**

--- a/packages/cli/src/wait.ts
+++ b/packages/cli/src/wait.ts
@@ -184,14 +184,24 @@ export async function awaitReopen(
   const reads = inFlightGate();
   const presences = inFlightGate();
   while (now() < deadline) {
-    try {
-      if (opts.token && !supersede.busy() && (await supersede.run(() => channel.isSuperseded(opts.token!), budget()))) return { kind: "superseded" };
-      if (!reads.busy()) {
+    // Each probe gets its OWN try/catch. A single catch around all three meant a timing-out lock or
+    // log read skipped the healthy ones for that iteration — so during a read outage a returning
+    // editor's presence heartbeat could not resume the wait, which is the one signal that matters.
+    if (opts.token && !supersede.busy()) {
+      try {
+        if (await supersede.run(() => channel.isSuperseded(opts.token!), budget())) return { kind: "superseded" };
+      } catch {
+        /* lock unreadable this iteration — keep watching; a missed supersede is retried next poll */
+      }
+    }
+    if (!reads.busy()) {
+      try {
         const { entries, cursor: readCursor } = await reads.run(() => channel.readSince(cursor), budget());
         // An explicit `completed` (the build handoff) logged DURING the grace ends it immediately.
         // Without this it was ignored for the full window and then reported as `window_closed` —
         // the deliberate handoff both delayed by minutes and mislabelled. A newer `window_closed`
         // is NOT terminal: that is still just another reload.
+        //
         // Requires an EXPLICIT non-window_closed reason. Defaulting a bare SessionClosed to
         // "completed" would end the grace on an ambiguous signal; when in doubt keep watching, since
         // the grace can only expire naturally, whereas ending early strands a returning human.
@@ -202,10 +212,16 @@ export async function awaitReopen(
         });
         if (closed) return { kind: "completed", cursor: readCursor, entries };
         if (entries.some((e) => e.actor === "user" && e.type !== LogEventType.SessionClosed)) return { kind: "reopened" };
+      } catch {
+        /* log read timed out or failed transiently — presence below can still prove the return */
       }
-      if (!presences.busy() && (await presences.run(() => channel.presence(graceStart), budget()))) return { kind: "reopened" };
-    } catch {
-      /* a probe timed out, or a read/presence failed transiently — keep watching until grace expires */
+    }
+    if (!presences.busy()) {
+      try {
+        if (await presences.run(() => channel.presence(graceStart), budget())) return { kind: "reopened" };
+      } catch {
+        /* presence unreadable this iteration — keep watching until the grace expires */
+      }
     }
     await sleep(Math.max(1, Math.min(pollMs, deadline - now())));
   }

--- a/packages/cli/src/wait.ts
+++ b/packages/cli/src/wait.ts
@@ -130,13 +130,6 @@ export const REOPEN_GRACE_MS = 3 * 60_000;
  * is bounded by the REMAINING grace (a stalled channel read must not park the watch forever),
  * and transient failures don't abort it.
  */
-/** The wait-lock a cycle should use, and whether it must CLAIM it.
- *
- *  A fresh cycle mints a token and claims the doc. A RESUMED cycle (after a reopen grace) carries
- *  its original token and must NOT claim: claiming would overwrite a newer waiter's token — a stale
- *  waiter stealing the lock back from its replacement, exactly what the grace is documented never to
- *  allow. Keeping the old token means the worst case is losing, since the poll loop's
- *  `isSuperseded(token)` check steps a superseded waiter down on its first tick. */
 /** What the grace watch concluded. `completed` carries the cursor and entries FROM THE GRACE READ:
  *  the caller persisted its cursor before the grace began, so without these the SessionClosed that
  *  ended the session is never recorded and the next wait re-reads and re-reports it. `reason` is the
@@ -147,24 +140,6 @@ export type ReopenOutcome =
   | { kind: "expired" }
   | { kind: "superseded" }
   | { kind: "completed"; cursor: number; entries: LogEntry[]; reason: string };
-
-/** Whether a RESUMED cycle still owns the document, for the check that must run before it mutates.
- *
- *  `unverifiable` is its own answer on purpose. `isSuperseded` rejects when the lock read fails, and
- *  an unverifiable lock must not be read as "still ours": acting could double-write on behalf of a
- *  waiter that lost the doc during the grace. Declining merely ends this cycle — the agent's next
- *  `wait` re-attaches — so the asymmetry favours refusing. */
-export async function verifyResumedLock(channel: Pick<ControlChannel, "isSuperseded">, token: string): Promise<"ours" | "lost" | "unverifiable"> {
-  try {
-    return (await channel.isSuperseded(token)) ? "lost" : "ours";
-  } catch {
-    return "unverifiable";
-  }
-}
-
-export function lockForCycle(resumeToken: string | undefined, mint: () => string): { token: string; claim: boolean } {
-  return resumeToken ? { token: resumeToken, claim: false } : { token: mint(), claim: true };
-}
 
 export async function awaitReopen(
   channel: ControlChannel,

--- a/packages/cli/src/wait.ts
+++ b/packages/cli/src/wait.ts
@@ -130,6 +130,17 @@ export const REOPEN_GRACE_MS = 3 * 60_000;
  * is bounded by the REMAINING grace (a stalled channel read must not park the watch forever),
  * and transient failures don't abort it.
  */
+/** The wait-lock a cycle should use, and whether it must CLAIM it.
+ *
+ *  A fresh cycle mints a token and claims the doc. A RESUMED cycle (after a reopen grace) carries
+ *  its original token and must NOT claim: claiming would overwrite a newer waiter's token — a stale
+ *  waiter stealing the lock back from its replacement, exactly what the grace is documented never to
+ *  allow. Keeping the old token means the worst case is losing, since the poll loop's
+ *  `isSuperseded(token)` check steps a superseded waiter down on its first tick. */
+export function lockForCycle(resumeToken: string | undefined, mint: () => string): { token: string; claim: boolean } {
+  return resumeToken ? { token: resumeToken, claim: false } : { token: mint(), claim: true };
+}
+
 export async function awaitReopen(
   channel: ControlChannel,
   cursor: number,
@@ -143,7 +154,7 @@ export async function awaitReopen(
     now?: () => number;
     sleep?: (ms: number) => Promise<void>;
   } = {},
-): Promise<"reopened" | "expired" | "superseded"> {
+): Promise<"reopened" | "expired" | "superseded" | "completed"> {
   const graceMs = opts.graceMs ?? REOPEN_GRACE_MS;
   const pollMs = opts.pollMs ?? 2000;
   const now = opts.now ?? Date.now;
@@ -168,6 +179,19 @@ export async function awaitReopen(
       if (opts.token && !supersede.busy() && (await supersede.run(() => channel.isSuperseded(opts.token!), budget()))) return "superseded";
       if (!reads.busy()) {
         const { entries } = await reads.run(() => channel.readSince(cursor), budget());
+        // An explicit `completed` (the build handoff) logged DURING the grace ends it immediately.
+        // Without this it was ignored for the full window and then reported as `window_closed` —
+        // the deliberate handoff both delayed by minutes and mislabelled. A newer `window_closed`
+        // is NOT terminal: that is still just another reload.
+        // Requires an EXPLICIT non-window_closed reason. Defaulting a bare SessionClosed to
+        // "completed" would end the grace on an ambiguous signal; when in doubt keep watching, since
+        // the grace can only expire naturally, whereas ending early strands a returning human.
+        const closed = entries.find((e) => {
+          if (e.type !== LogEventType.SessionClosed) return false;
+          const reason = (e.payload as { reason?: string } | undefined)?.reason;
+          return reason !== undefined && reason !== "window_closed";
+        });
+        if (closed) return "completed";
         if (entries.some((e) => e.actor === "user" && e.type !== LogEventType.SessionClosed)) return "reopened";
       }
       if (!presences.busy() && (await presences.run(() => channel.presence(graceStart), budget()))) return "reopened";

--- a/packages/cli/src/wait.ts
+++ b/packages/cli/src/wait.ts
@@ -139,12 +139,14 @@ export const REOPEN_GRACE_MS = 3 * 60_000;
  *  `isSuperseded(token)` check steps a superseded waiter down on its first tick. */
 /** What the grace watch concluded. `completed` carries the cursor and entries FROM THE GRACE READ:
  *  the caller persisted its cursor before the grace began, so without these the SessionClosed that
- *  ended the session is never recorded and the next wait re-reads and re-reports it. */
+ *  ended the session is never recorded and the next wait re-reads and re-reports it. `reason` is the
+ *  one the editor actually logged — this path is terminal for ANY explicit non-window_closed reason,
+ *  so reporting a fixed "completed" would relabel a different close as the build handoff. */
 export type ReopenOutcome =
   | { kind: "reopened" }
   | { kind: "expired" }
   | { kind: "superseded" }
-  | { kind: "completed"; cursor: number; entries: LogEntry[] };
+  | { kind: "completed"; cursor: number; entries: LogEntry[]; reason: string };
 
 export function lockForCycle(resumeToken: string | undefined, mint: () => string): { token: string; claim: boolean } {
   return resumeToken ? { token: resumeToken, claim: false } : { token: mint(), claim: true };
@@ -183,6 +185,13 @@ export async function awaitReopen(
   const supersede = inFlightGate();
   const reads = inFlightGate();
   const presences = inFlightGate();
+  // The probe cursor ADVANCES: re-reading from the pre-grace cursor every poll re-fetches the whole
+  // post-close range ~90 times over the default grace, growing with the doc's traffic. Reading only
+  // the delta is equivalent for both checks (an entry is seen on the poll it appears in) — but the
+  // entries must be ACCUMULATED, or a `completed` report would carry only the final delta and lose
+  // everything the earlier polls saw, undoing the reason this returns entries at all.
+  let probeCursor = cursor;
+  const seen: LogEntry[] = [];
   while (now() < deadline) {
     // Each probe gets its OWN try/catch. A single catch around all three meant a timing-out lock or
     // log read skipped the healthy ones for that iteration — so during a read outage a returning
@@ -196,7 +205,9 @@ export async function awaitReopen(
     }
     if (!reads.busy()) {
       try {
-        const { entries, cursor: readCursor } = await reads.run(() => channel.readSince(cursor), budget());
+        const { entries, cursor: readCursor } = await reads.run(() => channel.readSince(probeCursor), budget());
+        probeCursor = readCursor;
+        seen.push(...entries);
         // An explicit `completed` (the build handoff) logged DURING the grace ends it immediately.
         // Without this it was ignored for the full window and then reported as `window_closed` —
         // the deliberate handoff both delayed by minutes and mislabelled. A newer `window_closed`
@@ -210,7 +221,10 @@ export async function awaitReopen(
           const reason = (e.payload as { reason?: string } | undefined)?.reason;
           return reason !== undefined && reason !== "window_closed";
         });
-        if (closed) return { kind: "completed", cursor: readCursor, entries };
+        if (closed) {
+          const reason = (closed.payload as { reason?: string } | undefined)?.reason ?? "completed";
+          return { kind: "completed", cursor: readCursor, entries: seen, reason };
+        }
         if (entries.some((e) => e.actor === "user" && e.type !== LogEventType.SessionClosed)) return { kind: "reopened" };
       } catch {
         /* log read timed out or failed transiently — presence below can still prove the return */

--- a/packages/cli/src/wait.ts
+++ b/packages/cli/src/wait.ts
@@ -124,30 +124,49 @@ export const REOPEN_GRACE_MS = 3 * 60_000;
  * After a `window_closed` session-close: watch for the human coming BACK within `graceMs` —
  * either a NEW user-authored entry past `cursor`, or editor presence turning alive again (a
  * reload appends no events, so the presence heartbeat is the only signal for a silent return).
- * Resolves true on resumption, false when the grace passes in silence (they really left).
- * Transient read failures don't abort the watch; the grace bounds everything.
+ * Resolves "reopened" on resumption, "expired" when the grace passes in silence (they really
+ * left), and "superseded" the moment a NEWER waiter claims the doc's wait-lock — the grace must
+ * not let a stale waiter outlive its replacement and steal the lock back on resume. Every probe
+ * is bounded by the REMAINING grace (a stalled channel read must not park the watch forever),
+ * and transient failures don't abort it.
  */
 export async function awaitReopen(
   channel: ControlChannel,
   cursor: number,
-  opts: { graceMs?: number; pollMs?: number; now?: () => number; sleep?: (ms: number) => Promise<void> } = {},
-): Promise<boolean> {
+  opts: {
+    graceMs?: number;
+    pollMs?: number;
+    /** Per-probe bound; additionally capped to the remaining grace. Default 10s. */
+    probeTimeoutMs?: number;
+    /** This waiter's wait-lock token; when set, a newer claimant resolves "superseded". */
+    token?: string;
+    now?: () => number;
+    sleep?: (ms: number) => Promise<void>;
+  } = {},
+): Promise<"reopened" | "expired" | "superseded"> {
   const graceMs = opts.graceMs ?? REOPEN_GRACE_MS;
   const pollMs = opts.pollMs ?? 2000;
   const now = opts.now ?? Date.now;
   const sleep = opts.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
   const deadline = now() + graceMs;
+  // Bound a probe by min(probeTimeoutMs, remaining grace): the race's loser keeps running but is
+  // abandoned — the grace budget, not the channel's health, decides when the watch ends.
+  const bounded = <T>(fn: () => Promise<T>): Promise<T> => {
+    const budget = Math.max(1, Math.min(opts.probeTimeoutMs ?? 10_000, deadline - now()));
+    return Promise.race([fn(), new Promise<never>((_, rej) => setTimeout(() => rej(new Error("probe timed out")), budget).unref?.())]);
+  };
   while (now() < deadline) {
     try {
-      const { entries } = await channel.readSince(cursor);
-      if (entries.some((e) => e.actor === "user" && e.type !== LogEventType.SessionClosed)) return true;
-      if (await channel.presence()) return true;
+      if (opts.token && (await bounded(() => channel.isSuperseded(opts.token!)))) return "superseded";
+      const { entries } = await bounded(() => channel.readSince(cursor));
+      if (entries.some((e) => e.actor === "user" && e.type !== LogEventType.SessionClosed)) return "reopened";
+      if (await bounded(() => channel.presence())) return "reopened";
     } catch {
       /* transient read/presence failure — keep watching until the grace expires */
     }
-    await sleep(pollMs);
+    await sleep(Math.max(1, Math.min(pollMs, deadline - now())));
   }
-  return false;
+  return "expired";
 }
 
 /**

--- a/packages/cli/test/awaitReopen.test.ts
+++ b/packages/cli/test/awaitReopen.test.ts
@@ -9,12 +9,12 @@ import { describe, expect, it, vi } from "vitest";
 import { LogEventType } from "@inplan/core/node";
 import { awaitReopen } from "../src/wait";
 
-function clock() {
-  let t = 0;
+function clock(t0 = 0) {
+  let t = t0;
   return { now: () => t, sleep: async (ms: number) => void (t += ms) };
 }
 
-type Chan = { readSince: (c: number) => Promise<{ entries: unknown[]; cursor: number }>; presence: () => Promise<boolean>; isSuperseded: (t: string) => Promise<boolean> };
+type Chan = { readSince: (c: number) => Promise<{ entries: unknown[]; cursor: number }>; presence: (sinceMs?: number) => Promise<boolean>; isSuperseded: (t: string) => Promise<boolean> };
 const chan = (over: Partial<Chan>): never =>
   ({ readSince: async () => ({ entries: [], cursor: 0 }), presence: async () => false, isSuperseded: async () => false, ...over }) as never;
 
@@ -31,6 +31,22 @@ describe("awaitReopen", () => {
     const ch = chan({ presence: async () => ++polls >= 3 }); // page back after a couple of polls
     await expect(awaitReopen(ch, 0, { ...c, graceMs: 60_000, pollMs: 1000 })).resolves.toBe("reopened");
     expect(polls).toBe(3);
+  });
+
+  it("ignores a pre-close heartbeat still inside its TTL — freshness-gated, not mere presence", async () => {
+    const c = clock(1_000_000);
+    // The just-closed editor's heartbeat lingers for the presence TTL. Written 5s BEFORE the watch
+    // began (< graceStart), it must NOT read as a reopen — otherwise a real close resumes a dead
+    // session until the stale row expires, then ends the wait, defeating the grace.
+    const ch = chan({ presence: async (sinceMs) => 995_000 > (sinceMs ?? 0) });
+    await expect(awaitReopen(ch, 0, { ...c, graceMs: 10_000, pollMs: 2000 })).resolves.toBe("expired");
+  });
+
+  it("resumes only once a heartbeat is written AFTER the watch begins (a genuine return)", async () => {
+    const c = clock(1_000_000);
+    // A fresh heartbeat (last_seen advances with the clock) crosses graceStart a few polls in.
+    const ch = chan({ presence: async (sinceMs) => c.now() > (sinceMs ?? 0) && c.now() >= 1_004_000 });
+    await expect(awaitReopen(ch, 0, { ...c, graceMs: 60_000, pollMs: 2000 })).resolves.toBe("reopened");
   });
 
   it("a trailing SessionClosed alone is NOT resumption", async () => {

--- a/packages/cli/test/awaitReopen.test.ts
+++ b/packages/cli/test/awaitReopen.test.ts
@@ -142,3 +142,50 @@ describe("lockForCycle", () => {
     expect(token).toBe("t-original");
   });
 });
+
+// One catch around all three probes meant a timing-out lock or log read skipped the healthy ones for
+// that iteration. During a read outage the presence heartbeat is the ONLY signal that a human came
+// back, so swallowing it there defeats the grace exactly when it is needed.
+describe("probe failures are isolated", () => {
+  it("a failing lock probe does not stop presence from proving the return", async () => {
+    const c = clock();
+    const ch = chan({
+      isSuperseded: async () => {
+        throw new Error("locks table unreachable");
+      },
+      presence: async () => true,
+    });
+    await expect(awaitReopen(ch, 0, { ...c, graceMs: 10_000, pollMs: 500, token: "t" })).resolves.toMatchObject({ kind: "reopened" });
+  });
+
+  it("a failing log read does not stop presence from proving the return", async () => {
+    const c = clock();
+    const ch = chan({
+      readSince: async () => {
+        throw new Error("events read timed out");
+      },
+      presence: async () => true,
+    });
+    await expect(awaitReopen(ch, 0, { ...c, graceMs: 10_000, pollMs: 500 })).resolves.toMatchObject({ kind: "reopened" });
+  });
+
+  it("a failing presence probe does not stop a user entry from proving the return", async () => {
+    const c = clock();
+    const ch = chan({
+      readSince: async () => ({ entries: [{ seq: 9, actor: "user", type: LogEventType.TurnEnded }], cursor: 9 }),
+      presence: async () => {
+        throw new Error("presence unreadable");
+      },
+    });
+    await expect(awaitReopen(ch, 0, { ...c, graceMs: 10_000, pollMs: 500 })).resolves.toMatchObject({ kind: "reopened" });
+  });
+
+  it("all three failing still expires cleanly rather than hanging", async () => {
+    const c = clock();
+    const boom = async () => {
+      throw new Error("outage");
+    };
+    const ch = chan({ isSuperseded: boom, readSince: boom, presence: boom });
+    await expect(awaitReopen(ch, 0, { ...c, graceMs: 5_000, pollMs: 500, token: "t" })).resolves.toMatchObject({ kind: "expired" });
+  });
+});

--- a/packages/cli/test/awaitReopen.test.ts
+++ b/packages/cli/test/awaitReopen.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, expect, it, vi } from "vitest";
 import { LogEventType } from "@inplan/core/node";
-import { awaitReopen, lockForCycle, verifyResumedLock } from "../src/wait";
+import { awaitReopen } from "../src/wait";
 
 function clock(t0 = 0) {
   let t = t0;
@@ -117,79 +117,6 @@ describe("awaitReopen", () => {
   });
 });
 
-// The reopen grace promises that a stale waiter cannot outlive its replacement and steal the lock
-// back. That promise lives entirely in whether a RESUMED cycle re-claims.
-describe("lockForCycle", () => {
-  it("a fresh cycle mints a token and claims", () => {
-    expect(lockForCycle(undefined, () => "pid-1")).toEqual({ token: "pid-1", claim: true });
-  });
-
-  it("a resumed cycle keeps its token and does NOT claim", () => {
-    // Claiming here would overwrite whatever a newer waiter wrote during the grace.
-    expect(lockForCycle("original-token", () => "pid-2")).toEqual({ token: "original-token", claim: false });
-  });
-
-  it("never mints a replacement token on resume, even if asked", () => {
-    let minted = 0;
-    lockForCycle("original-token", () => `pid-${++minted}`);
-    expect(minted).toBe(0); // the mint function is not even called
-  });
-
-  it("the resumed token is the ORIGINAL, so isSuperseded can detect the loss", () => {
-    // Keeping the old token is what makes losing detectable: the poll loop asks
-    // isSuperseded(token), which is only meaningful for the token this waiter actually held.
-    const { token } = lockForCycle("t-original", () => "t-new");
-    expect(token).toBe("t-original");
-  });
-});
-
-// One catch around all three probes meant a timing-out lock or log read skipped the healthy ones for
-// that iteration. During a read outage the presence heartbeat is the ONLY signal that a human came
-// back, so swallowing it there defeats the grace exactly when it is needed.
-describe("probe failures are isolated", () => {
-  it("a failing lock probe does not stop presence from proving the return", async () => {
-    const c = clock();
-    const ch = chan({
-      isSuperseded: async () => {
-        throw new Error("locks table unreachable");
-      },
-      presence: async () => true,
-    });
-    await expect(awaitReopen(ch, 0, { ...c, graceMs: 10_000, pollMs: 500, token: "t" })).resolves.toMatchObject({ kind: "reopened" });
-  });
-
-  it("a failing log read does not stop presence from proving the return", async () => {
-    const c = clock();
-    const ch = chan({
-      readSince: async () => {
-        throw new Error("events read timed out");
-      },
-      presence: async () => true,
-    });
-    await expect(awaitReopen(ch, 0, { ...c, graceMs: 10_000, pollMs: 500 })).resolves.toMatchObject({ kind: "reopened" });
-  });
-
-  it("a failing presence probe does not stop a user entry from proving the return", async () => {
-    const c = clock();
-    const ch = chan({
-      readSince: async () => ({ entries: [{ seq: 9, actor: "user", type: LogEventType.TurnEnded }], cursor: 9 }),
-      presence: async () => {
-        throw new Error("presence unreadable");
-      },
-    });
-    await expect(awaitReopen(ch, 0, { ...c, graceMs: 10_000, pollMs: 500 })).resolves.toMatchObject({ kind: "reopened" });
-  });
-
-  it("all three failing still expires cleanly rather than hanging", async () => {
-    const c = clock();
-    const boom = async () => {
-      throw new Error("outage");
-    };
-    const ch = chan({ isSuperseded: boom, readSince: boom, presence: boom });
-    await expect(awaitReopen(ch, 0, { ...c, graceMs: 5_000, pollMs: 500, token: "t" })).resolves.toMatchObject({ kind: "expired" });
-  });
-});
-
 describe("the grace read reports what actually happened", () => {
   it("carries the reason the editor logged, not a fixed \"completed\"", async () => {
     // awaitReopen treats ANY explicit non-window_closed reason as terminal, so hard-coding the
@@ -229,38 +156,5 @@ describe("the grace read reports what actually happened", () => {
     // …and the report still contains BOTH polls' entries, not just the last delta.
     expect(r).toMatchObject({ kind: "completed", cursor: 10 });
     expect((r as { entries: { seq: number }[] }).entries.map((e) => e.seq)).toEqual([9, 10]);
-  });
-});
-
-// The guard that stops a lost recovery from mutating can itself fail: SupabaseControlChannel rejects
-// when its lock query fails. A bare `await` would reject waitCycle and surface as a stack trace with
-// no JSON — the failure mode this codebase already removed once.
-describe("verifyResumedLock", () => {
-  it("reports ours when the lock is still held", async () => {
-    expect(await verifyResumedLock({ isSuperseded: async () => false }, "t")).toBe("ours");
-  });
-
-  it("reports lost when a newer waiter claimed it", async () => {
-    expect(await verifyResumedLock({ isSuperseded: async () => true }, "t")).toBe("lost");
-  });
-
-  it("reports unverifiable — NOT ours — when the lock read rejects", async () => {
-    // Fail closed: acting on an unverifiable lock risks a double write on behalf of a waiter that
-    // lost the doc; declining merely ends this cycle and the agent re-attaches.
-    const ch = {
-      isSuperseded: async () => {
-        throw new Error("locks read failed");
-      },
-    };
-    expect(await verifyResumedLock(ch, "t")).toBe("unverifiable");
-  });
-
-  it("never rejects, whatever the channel does", async () => {
-    const throwsSync = {
-      isSuperseded: () => {
-        throw new Error("sync boom");
-      },
-    } as unknown as Parameters<typeof verifyResumedLock>[0];
-    await expect(verifyResumedLock(throwsSync, "t")).resolves.toBe("unverifiable");
   });
 });

--- a/packages/cli/test/awaitReopen.test.ts
+++ b/packages/cli/test/awaitReopen.test.ts
@@ -14,37 +14,55 @@ function clock() {
   return { now: () => t, sleep: async (ms: number) => void (t += ms) };
 }
 
-type Chan = { readSince: (c: number) => Promise<{ entries: unknown[]; cursor: number }>; presence: () => Promise<boolean> };
+type Chan = { readSince: (c: number) => Promise<{ entries: unknown[]; cursor: number }>; presence: () => Promise<boolean>; isSuperseded: (t: string) => Promise<boolean> };
 const chan = (over: Partial<Chan>): never =>
-  ({ readSince: async () => ({ entries: [], cursor: 0 }), presence: async () => false, ...over }) as never;
+  ({ readSince: async () => ({ entries: [], cursor: 0 }), presence: async () => false, isSuperseded: async () => false, ...over }) as never;
 
 describe("awaitReopen", () => {
   it("resumes on a NEW user-authored entry past the cursor", async () => {
     const c = clock();
     const ch = chan({ readSince: async () => ({ entries: [{ seq: 9, actor: "user", type: LogEventType.CommentCreated }], cursor: 9 }) });
-    await expect(awaitReopen(ch, 8, { ...c, graceMs: 60_000 })).resolves.toBe(true);
+    await expect(awaitReopen(ch, 8, { ...c, graceMs: 60_000 })).resolves.toBe("reopened");
   });
 
   it("resumes on the editor presence heartbeat — a silent reload appends no events", async () => {
     const c = clock();
     let polls = 0;
     const ch = chan({ presence: async () => ++polls >= 3 }); // page back after a couple of polls
-    await expect(awaitReopen(ch, 0, { ...c, graceMs: 60_000, pollMs: 1000 })).resolves.toBe(true);
+    await expect(awaitReopen(ch, 0, { ...c, graceMs: 60_000, pollMs: 1000 })).resolves.toBe("reopened");
     expect(polls).toBe(3);
   });
 
   it("a trailing SessionClosed alone is NOT resumption", async () => {
     const c = clock();
     const ch = chan({ readSince: async () => ({ entries: [{ seq: 9, actor: "user", type: LogEventType.SessionClosed }], cursor: 9 }) });
-    await expect(awaitReopen(ch, 8, { ...c, graceMs: 10_000, pollMs: 1000 })).resolves.toBe(false);
+    await expect(awaitReopen(ch, 8, { ...c, graceMs: 10_000, pollMs: 1000 })).resolves.toBe("expired");
   });
 
   it("gives up after a silent grace — the human really left", async () => {
     const c = clock();
     const reads = vi.fn(async () => ({ entries: [], cursor: 0 }));
     const ch = chan({ readSince: reads });
-    await expect(awaitReopen(ch, 0, { ...c, graceMs: 10_000, pollMs: 2000 })).resolves.toBe(false);
+    await expect(awaitReopen(ch, 0, { ...c, graceMs: 10_000, pollMs: 2000 })).resolves.toBe("expired");
     expect(reads.mock.calls.length).toBeGreaterThanOrEqual(4); // it genuinely kept watching
+  });
+
+  it("steps down the moment a newer waiter supersedes it — grace must not steal the lock back", async () => {
+    const c = clock();
+    let checks = 0;
+    const ch = chan({ isSuperseded: async () => ++checks >= 2 });
+    await expect(awaitReopen(ch, 0, { ...c, graceMs: 60_000, pollMs: 1000, token: "tok" })).resolves.toBe("superseded");
+  });
+
+  it("a stalled channel probe cannot park the watch past the grace (bounded per-probe)", async () => {
+    const c = clock();
+    const never = new Promise<never>(() => {});
+    // The bounded race uses real timers, so give the probe a real (tiny) budget and real time.
+    const ch = chan({ readSince: () => never as never });
+    const start = Date.now();
+    const r = await awaitReopen(ch, 0, { graceMs: 300, pollMs: 50, probeTimeoutMs: 50 });
+    expect(r).toBe("expired");
+    expect(Date.now() - start).toBeLessThan(5_000); // returned promptly despite the forever-pending read
   });
 
   it("tolerates transient failures and still catches a later return", async () => {
@@ -57,6 +75,6 @@ describe("awaitReopen", () => {
       },
       presence: async () => n >= 4,
     });
-    await expect(awaitReopen(ch, 0, { ...c, graceMs: 60_000, pollMs: 1000 })).resolves.toBe(true);
+    await expect(awaitReopen(ch, 0, { ...c, graceMs: 60_000, pollMs: 1000 })).resolves.toBe("reopened");
   });
 });

--- a/packages/cli/test/awaitReopen.test.ts
+++ b/packages/cli/test/awaitReopen.test.ts
@@ -189,3 +189,45 @@ describe("probe failures are isolated", () => {
     await expect(awaitReopen(ch, 0, { ...c, graceMs: 5_000, pollMs: 500, token: "t" })).resolves.toMatchObject({ kind: "expired" });
   });
 });
+
+describe("the grace read reports what actually happened", () => {
+  it("carries the reason the editor logged, not a fixed \"completed\"", async () => {
+    // awaitReopen treats ANY explicit non-window_closed reason as terminal, so hard-coding the
+    // report would relabel some other close as the build handoff — and the agent switches to build
+    // mode on that reason.
+    const c = clock();
+    const ch = chan({
+      readSince: async () => ({ entries: [{ seq: 9, actor: "user", type: LogEventType.SessionClosed, payload: { reason: "archived" } }], cursor: 9 }),
+    });
+    await expect(awaitReopen(ch, 8, { ...c, graceMs: 60_000, pollMs: 1000 })).resolves.toMatchObject({ kind: "completed", reason: "archived" });
+  });
+
+  it("still reports `completed` for the build handoff itself", async () => {
+    const c = clock();
+    const ch = chan({
+      readSince: async () => ({ entries: [{ seq: 9, actor: "user", type: LogEventType.SessionClosed, payload: { reason: "completed" } }], cursor: 9 }),
+    });
+    await expect(awaitReopen(ch, 8, { ...c, graceMs: 60_000, pollMs: 1000 })).resolves.toMatchObject({ kind: "completed", reason: "completed" });
+  });
+
+  it("reads only the DELTA each poll, but reports every entry the grace saw", async () => {
+    const c = clock();
+    const asked: number[] = [];
+    let poll = 0;
+    const ch = chan({
+      readSince: async (from: number) => {
+        asked.push(from);
+        poll += 1;
+        // Agent-authored: does NOT prove a reopen, so the loop continues to a second poll.
+        if (poll === 1) return { entries: [{ seq: 9, actor: "agent", type: LogEventType.AgentRevised }], cursor: 9 };
+        return { entries: [{ seq: 10, actor: "user", type: LogEventType.SessionClosed, payload: { reason: "completed" } }], cursor: 10 };
+      },
+    });
+    const r = await awaitReopen(ch, 8, { ...c, graceMs: 60_000, pollMs: 1000 });
+    // The cursor advanced rather than re-reading from 8 forever…
+    expect(asked).toEqual([8, 9]);
+    // …and the report still contains BOTH polls' entries, not just the last delta.
+    expect(r).toMatchObject({ kind: "completed", cursor: 10 });
+    expect((r as { entries: { seq: number }[] }).entries.map((e) => e.seq)).toEqual([9, 10]);
+  });
+});

--- a/packages/cli/test/awaitReopen.test.ts
+++ b/packages/cli/test/awaitReopen.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, expect, it, vi } from "vitest";
 import { LogEventType } from "@inplan/core/node";
-import { awaitReopen } from "../src/wait";
+import { awaitReopen, lockForCycle } from "../src/wait";
 
 function clock(t0 = 0) {
   let t = t0;
@@ -44,9 +44,31 @@ describe("awaitReopen", () => {
 
   it("resumes only once a heartbeat is written AFTER the watch begins (a genuine return)", async () => {
     const c = clock(1_000_000);
-    // A fresh heartbeat (last_seen advances with the clock) crosses graceStart a few polls in.
-    const ch = chan({ presence: async (sinceMs) => c.now() > (sinceMs ?? 0) && c.now() >= 1_004_000 });
+    // The mock's answer depends on the ARGUMENT it received, not on the clock alone: it reports a
+    // heartbeat only when told to count ones newer than a time at/after the grace start. Deriving it
+    // from `c.now()` instead would return true even if `awaitReopen` stopped passing `graceStart`
+    // (sinceMs would default to 0 and still satisfy it) — the test would then pass with the very
+    // gate it claims to cover removed.
+    const ch = chan({ presence: async (sinceMs) => (sinceMs ?? 0) >= 1_000_000 && c.now() >= 1_004_000 });
     await expect(awaitReopen(ch, 0, { ...c, graceMs: 60_000, pollMs: 2000 })).resolves.toBe("reopened");
+  });
+
+  it("an explicit `completed` during the grace ends it NOW, not after the full window", async () => {
+    // The build handoff. Before this it was ignored for the whole grace and then surfaced as
+    // `window_closed` — the deliberate action both delayed by minutes and mislabelled.
+    const c = clock();
+    const ch = chan({
+      readSince: async () => ({ entries: [{ seq: 9, actor: "user", type: LogEventType.SessionClosed, payload: { reason: "completed" } }], cursor: 9 }),
+    });
+    await expect(awaitReopen(ch, 8, { ...c, graceMs: 600_000, pollMs: 1000 })).resolves.toBe("completed");
+  });
+
+  it("a NEWER window_closed during the grace is just another reload, not an end", async () => {
+    const c = clock();
+    const ch = chan({
+      readSince: async () => ({ entries: [{ seq: 9, actor: "user", type: LogEventType.SessionClosed, payload: { reason: "window_closed" } }], cursor: 9 }),
+    });
+    await expect(awaitReopen(ch, 8, { ...c, graceMs: 10_000, pollMs: 1000 })).resolves.toBe("expired");
   });
 
   it("a trailing SessionClosed alone is NOT resumption", async () => {
@@ -92,5 +114,31 @@ describe("awaitReopen", () => {
       presence: async () => n >= 4,
     });
     await expect(awaitReopen(ch, 0, { ...c, graceMs: 60_000, pollMs: 1000 })).resolves.toBe("reopened");
+  });
+});
+
+// The reopen grace promises that a stale waiter cannot outlive its replacement and steal the lock
+// back. That promise lives entirely in whether a RESUMED cycle re-claims.
+describe("lockForCycle", () => {
+  it("a fresh cycle mints a token and claims", () => {
+    expect(lockForCycle(undefined, () => "pid-1")).toEqual({ token: "pid-1", claim: true });
+  });
+
+  it("a resumed cycle keeps its token and does NOT claim", () => {
+    // Claiming here would overwrite whatever a newer waiter wrote during the grace.
+    expect(lockForCycle("original-token", () => "pid-2")).toEqual({ token: "original-token", claim: false });
+  });
+
+  it("never mints a replacement token on resume, even if asked", () => {
+    let minted = 0;
+    lockForCycle("original-token", () => `pid-${++minted}`);
+    expect(minted).toBe(0); // the mint function is not even called
+  });
+
+  it("the resumed token is the ORIGINAL, so isSuperseded can detect the loss", () => {
+    // Keeping the old token is what makes losing detectable: the poll loop asks
+    // isSuperseded(token), which is only meaningful for the token this waiter actually held.
+    const { token } = lockForCycle("t-original", () => "t-new");
+    expect(token).toBe("t-original");
   });
 });

--- a/packages/cli/test/awaitReopen.test.ts
+++ b/packages/cli/test/awaitReopen.test.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// The reopen grace (wait.ts awaitReopen): a `window_closed` session-close is routinely a page
+// RELOAD — the editor logs the close on teardown and is back seconds later, appending no events.
+// These tests pin the resumption signals (a new user action; the presence heartbeat) and the
+// silence semantics (grace expiry ⇒ the human really left), plus tolerance of transient failures.
+
+import { describe, expect, it, vi } from "vitest";
+import { LogEventType } from "@inplan/core/node";
+import { awaitReopen } from "../src/wait";
+
+function clock() {
+  let t = 0;
+  return { now: () => t, sleep: async (ms: number) => void (t += ms) };
+}
+
+type Chan = { readSince: (c: number) => Promise<{ entries: unknown[]; cursor: number }>; presence: () => Promise<boolean> };
+const chan = (over: Partial<Chan>): never =>
+  ({ readSince: async () => ({ entries: [], cursor: 0 }), presence: async () => false, ...over }) as never;
+
+describe("awaitReopen", () => {
+  it("resumes on a NEW user-authored entry past the cursor", async () => {
+    const c = clock();
+    const ch = chan({ readSince: async () => ({ entries: [{ seq: 9, actor: "user", type: LogEventType.CommentCreated }], cursor: 9 }) });
+    await expect(awaitReopen(ch, 8, { ...c, graceMs: 60_000 })).resolves.toBe(true);
+  });
+
+  it("resumes on the editor presence heartbeat — a silent reload appends no events", async () => {
+    const c = clock();
+    let polls = 0;
+    const ch = chan({ presence: async () => ++polls >= 3 }); // page back after a couple of polls
+    await expect(awaitReopen(ch, 0, { ...c, graceMs: 60_000, pollMs: 1000 })).resolves.toBe(true);
+    expect(polls).toBe(3);
+  });
+
+  it("a trailing SessionClosed alone is NOT resumption", async () => {
+    const c = clock();
+    const ch = chan({ readSince: async () => ({ entries: [{ seq: 9, actor: "user", type: LogEventType.SessionClosed }], cursor: 9 }) });
+    await expect(awaitReopen(ch, 8, { ...c, graceMs: 10_000, pollMs: 1000 })).resolves.toBe(false);
+  });
+
+  it("gives up after a silent grace — the human really left", async () => {
+    const c = clock();
+    const reads = vi.fn(async () => ({ entries: [], cursor: 0 }));
+    const ch = chan({ readSince: reads });
+    await expect(awaitReopen(ch, 0, { ...c, graceMs: 10_000, pollMs: 2000 })).resolves.toBe(false);
+    expect(reads.mock.calls.length).toBeGreaterThanOrEqual(4); // it genuinely kept watching
+  });
+
+  it("tolerates transient failures and still catches a later return", async () => {
+    const c = clock();
+    let n = 0;
+    const ch = chan({
+      readSince: async () => {
+        if (++n <= 2) throw new Error("blip");
+        return { entries: [], cursor: 0 };
+      },
+      presence: async () => n >= 4,
+    });
+    await expect(awaitReopen(ch, 0, { ...c, graceMs: 60_000, pollMs: 1000 })).resolves.toBe(true);
+  });
+});

--- a/packages/cli/test/awaitReopen.test.ts
+++ b/packages/cli/test/awaitReopen.test.ts
@@ -22,14 +22,14 @@ describe("awaitReopen", () => {
   it("resumes on a NEW user-authored entry past the cursor", async () => {
     const c = clock();
     const ch = chan({ readSince: async () => ({ entries: [{ seq: 9, actor: "user", type: LogEventType.CommentCreated }], cursor: 9 }) });
-    await expect(awaitReopen(ch, 8, { ...c, graceMs: 60_000 })).resolves.toBe("reopened");
+    await expect(awaitReopen(ch, 8, { ...c, graceMs: 60_000 })).resolves.toMatchObject({ kind: "reopened" });
   });
 
   it("resumes on the editor presence heartbeat — a silent reload appends no events", async () => {
     const c = clock();
     let polls = 0;
     const ch = chan({ presence: async () => ++polls >= 3 }); // page back after a couple of polls
-    await expect(awaitReopen(ch, 0, { ...c, graceMs: 60_000, pollMs: 1000 })).resolves.toBe("reopened");
+    await expect(awaitReopen(ch, 0, { ...c, graceMs: 60_000, pollMs: 1000 })).resolves.toMatchObject({ kind: "reopened" });
     expect(polls).toBe(3);
   });
 
@@ -39,7 +39,7 @@ describe("awaitReopen", () => {
     // began (< graceStart), it must NOT read as a reopen — otherwise a real close resumes a dead
     // session until the stale row expires, then ends the wait, defeating the grace.
     const ch = chan({ presence: async (sinceMs) => 995_000 > (sinceMs ?? 0) });
-    await expect(awaitReopen(ch, 0, { ...c, graceMs: 10_000, pollMs: 2000 })).resolves.toBe("expired");
+    await expect(awaitReopen(ch, 0, { ...c, graceMs: 10_000, pollMs: 2000 })).resolves.toMatchObject({ kind: "expired" });
   });
 
   it("resumes only once a heartbeat is written AFTER the watch begins (a genuine return)", async () => {
@@ -50,7 +50,7 @@ describe("awaitReopen", () => {
     // (sinceMs would default to 0 and still satisfy it) — the test would then pass with the very
     // gate it claims to cover removed.
     const ch = chan({ presence: async (sinceMs) => (sinceMs ?? 0) >= 1_000_000 && c.now() >= 1_004_000 });
-    await expect(awaitReopen(ch, 0, { ...c, graceMs: 60_000, pollMs: 2000 })).resolves.toBe("reopened");
+    await expect(awaitReopen(ch, 0, { ...c, graceMs: 60_000, pollMs: 2000 })).resolves.toMatchObject({ kind: "reopened" });
   });
 
   it("an explicit `completed` during the grace ends it NOW, not after the full window", async () => {
@@ -60,7 +60,7 @@ describe("awaitReopen", () => {
     const ch = chan({
       readSince: async () => ({ entries: [{ seq: 9, actor: "user", type: LogEventType.SessionClosed, payload: { reason: "completed" } }], cursor: 9 }),
     });
-    await expect(awaitReopen(ch, 8, { ...c, graceMs: 600_000, pollMs: 1000 })).resolves.toBe("completed");
+    await expect(awaitReopen(ch, 8, { ...c, graceMs: 600_000, pollMs: 1000 })).resolves.toMatchObject({ kind: "completed" });
   });
 
   it("a NEWER window_closed during the grace is just another reload, not an end", async () => {
@@ -68,20 +68,20 @@ describe("awaitReopen", () => {
     const ch = chan({
       readSince: async () => ({ entries: [{ seq: 9, actor: "user", type: LogEventType.SessionClosed, payload: { reason: "window_closed" } }], cursor: 9 }),
     });
-    await expect(awaitReopen(ch, 8, { ...c, graceMs: 10_000, pollMs: 1000 })).resolves.toBe("expired");
+    await expect(awaitReopen(ch, 8, { ...c, graceMs: 10_000, pollMs: 1000 })).resolves.toMatchObject({ kind: "expired" });
   });
 
   it("a trailing SessionClosed alone is NOT resumption", async () => {
     const c = clock();
     const ch = chan({ readSince: async () => ({ entries: [{ seq: 9, actor: "user", type: LogEventType.SessionClosed }], cursor: 9 }) });
-    await expect(awaitReopen(ch, 8, { ...c, graceMs: 10_000, pollMs: 1000 })).resolves.toBe("expired");
+    await expect(awaitReopen(ch, 8, { ...c, graceMs: 10_000, pollMs: 1000 })).resolves.toMatchObject({ kind: "expired" });
   });
 
   it("gives up after a silent grace — the human really left", async () => {
     const c = clock();
     const reads = vi.fn(async () => ({ entries: [], cursor: 0 }));
     const ch = chan({ readSince: reads });
-    await expect(awaitReopen(ch, 0, { ...c, graceMs: 10_000, pollMs: 2000 })).resolves.toBe("expired");
+    await expect(awaitReopen(ch, 0, { ...c, graceMs: 10_000, pollMs: 2000 })).resolves.toMatchObject({ kind: "expired" });
     expect(reads.mock.calls.length).toBeGreaterThanOrEqual(4); // it genuinely kept watching
   });
 
@@ -89,7 +89,7 @@ describe("awaitReopen", () => {
     const c = clock();
     let checks = 0;
     const ch = chan({ isSuperseded: async () => ++checks >= 2 });
-    await expect(awaitReopen(ch, 0, { ...c, graceMs: 60_000, pollMs: 1000, token: "tok" })).resolves.toBe("superseded");
+    await expect(awaitReopen(ch, 0, { ...c, graceMs: 60_000, pollMs: 1000, token: "tok" })).resolves.toMatchObject({ kind: "superseded" });
   });
 
   it("a stalled channel probe cannot park the watch past the grace (bounded per-probe)", async () => {
@@ -99,7 +99,7 @@ describe("awaitReopen", () => {
     const ch = chan({ readSince: () => never as never });
     const start = Date.now();
     const r = await awaitReopen(ch, 0, { graceMs: 300, pollMs: 50, probeTimeoutMs: 50 });
-    expect(r).toBe("expired");
+    expect(r).toMatchObject({ kind: "expired" });
     expect(Date.now() - start).toBeLessThan(5_000); // returned promptly despite the forever-pending read
   });
 
@@ -113,7 +113,7 @@ describe("awaitReopen", () => {
       },
       presence: async () => n >= 4,
     });
-    await expect(awaitReopen(ch, 0, { ...c, graceMs: 60_000, pollMs: 1000 })).resolves.toBe("reopened");
+    await expect(awaitReopen(ch, 0, { ...c, graceMs: 60_000, pollMs: 1000 })).resolves.toMatchObject({ kind: "reopened" });
   });
 });
 

--- a/packages/cli/test/awaitReopen.test.ts
+++ b/packages/cli/test/awaitReopen.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, expect, it, vi } from "vitest";
 import { LogEventType } from "@inplan/core/node";
-import { awaitReopen, lockForCycle } from "../src/wait";
+import { awaitReopen, lockForCycle, verifyResumedLock } from "../src/wait";
 
 function clock(t0 = 0) {
   let t = t0;
@@ -229,5 +229,38 @@ describe("the grace read reports what actually happened", () => {
     // …and the report still contains BOTH polls' entries, not just the last delta.
     expect(r).toMatchObject({ kind: "completed", cursor: 10 });
     expect((r as { entries: { seq: number }[] }).entries.map((e) => e.seq)).toEqual([9, 10]);
+  });
+});
+
+// The guard that stops a lost recovery from mutating can itself fail: SupabaseControlChannel rejects
+// when its lock query fails. A bare `await` would reject waitCycle and surface as a stack trace with
+// no JSON — the failure mode this codebase already removed once.
+describe("verifyResumedLock", () => {
+  it("reports ours when the lock is still held", async () => {
+    expect(await verifyResumedLock({ isSuperseded: async () => false }, "t")).toBe("ours");
+  });
+
+  it("reports lost when a newer waiter claimed it", async () => {
+    expect(await verifyResumedLock({ isSuperseded: async () => true }, "t")).toBe("lost");
+  });
+
+  it("reports unverifiable — NOT ours — when the lock read rejects", async () => {
+    // Fail closed: acting on an unverifiable lock risks a double write on behalf of a waiter that
+    // lost the doc; declining merely ends this cycle and the agent re-attaches.
+    const ch = {
+      isSuperseded: async () => {
+        throw new Error("locks read failed");
+      },
+    };
+    expect(await verifyResumedLock(ch, "t")).toBe("unverifiable");
+  });
+
+  it("never rejects, whatever the channel does", async () => {
+    const throwsSync = {
+      isSuperseded: () => {
+        throw new Error("sync boom");
+      },
+    } as unknown as Parameters<typeof verifyResumedLock>[0];
+    await expect(verifyResumedLock(throwsSync, "t")).resolves.toBe("unverifiable");
   });
 });

--- a/packages/cli/test/ensureLogin.test.ts
+++ b/packages/cli/test/ensureLogin.test.ts
@@ -23,9 +23,12 @@ import { loadAuth, saveAuth, type AuthFile } from "../src/cliAuth";
 
 let home: string;
 const ttyDescriptors: Record<string, PropertyDescriptor | undefined> = {};
-// These tests may themselves run inside a coding agent's shell (CLAUDECODE/CLAUDE_CODE_* set),
-// which would trip the detection ladder's env rung — scrub and restore around each test.
+// These tests may themselves run inside a coding agent's shell (Claude Code / Codex / Pi markers
+// set), which would trip the detection ladder's env rung — scrub and restore around each test.
 const scrubbedAgentEnv = new Map<string, string>();
+/** Any env key isKnownAgentEnv keys on (kept in sync with cli.ts): Claude Code, Codex, Pi, opt-in. */
+const isAgentMarker = (k: string): boolean =>
+  k === "CLAUDECODE" || k.startsWith("CLAUDE_CODE_") || k === "CODEX_SANDBOX" || k === "PI_CODING_AGENT" || k === "INPLAN_AGENT";
 
 /** Force stdin/stdout's isTTY (a getter on the streams) so "interactive" is deterministic. */
 function setTTY(value: boolean): void {
@@ -65,7 +68,7 @@ beforeEach(() => {
   delete process.env.CI;
   delete process.env.INPLAN_NO_BROWSER;
   for (const k of Object.keys(process.env)) {
-    if (k === "CLAUDECODE" || k.startsWith("CLAUDE_CODE_")) {
+    if (isAgentMarker(k)) {
       scrubbedAgentEnv.set(k, process.env[k]!);
       delete process.env[k];
     }
@@ -80,7 +83,7 @@ afterEach(() => {
   delete process.env.CI;
   delete process.env.INPLAN_NO_BROWSER;
   for (const k of Object.keys(process.env)) {
-    if (k === "CLAUDECODE" || k.startsWith("CLAUDE_CODE_")) delete process.env[k];
+    if (isAgentMarker(k)) delete process.env[k];
   }
   for (const [k, v] of scrubbedAgentEnv) process.env[k] = v;
   scrubbedAgentEnv.clear();
@@ -254,5 +257,8 @@ describe("isKnownAgentEnv", () => {
     expect(isKnownAgentEnv({ TERM: "xterm", CURSOR_TRACE_ID: "x" })).toBe(false); // integrated-terminal humans have this
     expect(isKnownAgentEnv({ CLAUDECODE: "1" })).toBe(true);
     expect(isKnownAgentEnv({ CLAUDE_CODE_SESSION_ID: "abc" })).toBe(true);
+    expect(isKnownAgentEnv({ CODEX_SANDBOX: "seatbelt" })).toBe(true); // OpenAI Codex sandboxed run
+    expect(isKnownAgentEnv({ PI_CODING_AGENT: "true" })).toBe(true); // earendil-works/pi self-id
+    expect(isKnownAgentEnv({ INPLAN_AGENT: "1" })).toBe(true); // explicit opt-in for other harnesses
   });
 });

--- a/packages/cli/test/open.test.ts
+++ b/packages/cli/test/open.test.ts
@@ -12,6 +12,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { scrubAgentEnv } from "../src/cli";
 
 const CLI = join(dirname(fileURLToPath(import.meta.url)), "..", "dist", "cli.js");
 // A throwaway "editor" that just stays alive: open() records its pid and blocks in waitCycle, so
@@ -25,10 +26,10 @@ beforeEach(() => {
   home = mkdtempSync(join(tmpdir(), "inplan-open-"));
   // Hermetic auth env: these spawns assert the non-interactive "not logged in" path, so pin an
   // unattended environment regardless of who runs the suite. CI=1 (loginOptOut) forces that path;
-  // scrubbing CLAUDECODE/CLAUDE_CODE_* stops an agent shell (e.g. Claude Code) from routing to the
-  // rendezvous pending-exit (exit 7) instead — which used to fail the suite when run from an agent.
-  env = { ...process.env, INPLAN_HOME: home, INPLAN_SIDECAR_DIR: join(home, "sidecars"), INPLAN_APP_CMD: FAKE_EDITOR, CI: "1" };
-  for (const k of Object.keys(env)) if (k === "CLAUDECODE" || k.startsWith("CLAUDE_CODE_")) delete env[k];
+  // scrubAgentEnv removes EVERY marker isKnownAgentEnv recognises, so an agent shell (Claude Code,
+  // Codex, Pi, or an INPLAN_AGENT opt-in) can't route the subprocess to the rendezvous pending-exit
+  // (exit 7) instead — which used to fail the suite when run from an agent.
+  env = { ...scrubAgentEnv(process.env), INPLAN_HOME: home, INPLAN_SIDECAR_DIR: join(home, "sidecars"), INPLAN_APP_CMD: FAKE_EDITOR, CI: "1" };
 });
 afterEach(() => {
   rmSync(home, { recursive: true, force: true });

--- a/packages/cli/test/open.test.ts
+++ b/packages/cli/test/open.test.ts
@@ -23,7 +23,12 @@ let env: NodeJS.ProcessEnv;
 
 beforeEach(() => {
   home = mkdtempSync(join(tmpdir(), "inplan-open-"));
-  env = { ...process.env, INPLAN_HOME: home, INPLAN_SIDECAR_DIR: join(home, "sidecars"), INPLAN_APP_CMD: FAKE_EDITOR };
+  // Hermetic auth env: these spawns assert the non-interactive "not logged in" path, so pin an
+  // unattended environment regardless of who runs the suite. CI=1 (loginOptOut) forces that path;
+  // scrubbing CLAUDECODE/CLAUDE_CODE_* stops an agent shell (e.g. Claude Code) from routing to the
+  // rendezvous pending-exit (exit 7) instead — which used to fail the suite when run from an agent.
+  env = { ...process.env, INPLAN_HOME: home, INPLAN_SIDECAR_DIR: join(home, "sidecars"), INPLAN_APP_CMD: FAKE_EDITOR, CI: "1" };
+  for (const k of Object.keys(env)) if (k === "CLAUDECODE" || k.startsWith("CLAUDE_CODE_")) delete env[k];
 });
 afterEach(() => {
   rmSync(home, { recursive: true, force: true });

--- a/packages/cli/test/remoteGating.test.ts
+++ b/packages/cli/test/remoteGating.test.ts
@@ -9,7 +9,7 @@
 // distinct: telling a paying customer to upgrade because a server hiccuped is the worst outcome.
 
 import { describe, expect, it, vi } from "vitest";
-import { EXIT_PLUGIN_UNAVAILABLE, EXIT_UPGRADE_REQUIRED, exitAfterFlush, explainNoGate, shellQuote } from "../src/cli";
+import { EXIT_PLUGIN_UNAVAILABLE, EXIT_UPGRADE_REQUIRED, exitAfterFlush, explainNoGate, isKnownAgentEnv, scrubAgentEnv, shellQuote } from "../src/cli";
 
 function capture(fn: () => void): { err: string; out: string } {
   let err = "";
@@ -128,5 +128,40 @@ describe("shellQuote", () => {
 
   it("escapes an embedded single quote by closing, escaping, and reopening", () => {
     expect(shellQuote("/w/it's.md")).toBe("'/w/it'" + String.fromCharCode(92) + "''s.md'");
+  });
+});
+
+// The scrub and the detector must agree. They came apart once already: the spawn tests removed only
+// Claude's markers while isKnownAgentEnv also recognised Codex, Pi and the INPLAN_AGENT opt-in, so a
+// suite run from those shells routed the subprocess to the rendezvous pending-exit instead of the
+// asserted path. Sharing one list is the fix; this is what keeps it shared.
+describe("scrubAgentEnv ⇄ isKnownAgentEnv", () => {
+  const MARKERS = { CLAUDECODE: "1", CLAUDE_CODE_ENTRYPOINT: "cli", CODEX_SANDBOX: "seatbelt", PI_CODING_AGENT: "true", INPLAN_AGENT: "1" };
+
+  it("an env carrying EVERY known marker is detected", () => {
+    expect(isKnownAgentEnv({ ...MARKERS })).toBe(true);
+  });
+
+  it("scrubbing that env makes it undetectable — the property that must hold for any new marker", () => {
+    expect(isKnownAgentEnv(scrubAgentEnv({ ...MARKERS }))).toBe(false);
+  });
+
+  it("each marker alone is both detected and scrubbed", () => {
+    for (const [k, v] of Object.entries(MARKERS)) {
+      expect(isKnownAgentEnv({ [k]: v }), `${k} detected`).toBe(true);
+      expect(isKnownAgentEnv(scrubAgentEnv({ [k]: v })), `${k} scrubbed`).toBe(false);
+    }
+  });
+
+  it("leaves unrelated variables alone", () => {
+    const env = { PATH: "/usr/bin", HOME: "/home/x", CURSOR_TRACE_ID: "keep-me", ...MARKERS };
+    const out = scrubAgentEnv(env);
+    expect(out).toEqual({ PATH: "/usr/bin", HOME: "/home/x", CURSOR_TRACE_ID: "keep-me" });
+  });
+
+  it("does not mutate the env it was given", () => {
+    const env = { ...MARKERS };
+    scrubAgentEnv(env);
+    expect(env.CLAUDECODE).toBe("1"); // the caller's process.env must be untouched
   });
 });

--- a/packages/cli/test/remoteGating.test.ts
+++ b/packages/cli/test/remoteGating.test.ts
@@ -9,7 +9,7 @@
 // distinct: telling a paying customer to upgrade because a server hiccuped is the worst outcome.
 
 import { describe, expect, it, vi } from "vitest";
-import { EXIT_PLUGIN_UNAVAILABLE, EXIT_UPGRADE_REQUIRED, exitAfterFlush, explainNoGate, isKnownAgentEnv, scrubAgentEnv, shellQuote } from "../src/cli";
+import { AGENT_ENV_PREFIXES, AGENT_ENV_VARS, EXIT_PLUGIN_UNAVAILABLE, EXIT_UPGRADE_REQUIRED, exitAfterFlush, explainNoGate, isKnownAgentEnv, scrubAgentEnv, shellQuote } from "../src/cli";
 
 function capture(fn: () => void): { err: string; out: string } {
   let err = "";
@@ -134,34 +134,60 @@ describe("shellQuote", () => {
 // The scrub and the detector must agree. They came apart once already: the spawn tests removed only
 // Claude's markers while isKnownAgentEnv also recognised Codex, Pi and the INPLAN_AGENT opt-in, so a
 // suite run from those shells routed the subprocess to the rendezvous pending-exit instead of the
-// asserted path. Sharing one list is the fix; this is what keeps it shared.
+// asserted path.
+//
+// Every case below is BUILT FROM the source's own lists. A hand-written copy of the markers would
+// reintroduce the same failure one level up: add a harness to AGENT_ENV_VARS and a stale literal here
+// would keep passing while the scrub missed it. Driving off the exports means a new marker is covered
+// the moment it is declared.
 describe("scrubAgentEnv ⇄ isKnownAgentEnv", () => {
-  const MARKERS = { CLAUDECODE: "1", CLAUDE_CODE_ENTRYPOINT: "cli", CODEX_SANDBOX: "seatbelt", PI_CODING_AGENT: "true", INPLAN_AGENT: "1" };
+  const everyMarker = (): NodeJS.ProcessEnv => ({
+    ...Object.fromEntries(AGENT_ENV_VARS.map((k) => [k, "1"])),
+    ...Object.fromEntries(AGENT_ENV_PREFIXES.map((p) => [`${p}MARKER`, "1"])),
+  });
 
-  it("an env carrying EVERY known marker is detected", () => {
-    expect(isKnownAgentEnv({ ...MARKERS })).toBe(true);
+  it("covers every marker the source declares (the lists are non-empty and used)", () => {
+    expect(AGENT_ENV_VARS.length + AGENT_ENV_PREFIXES.length).toBeGreaterThan(0);
+    expect(Object.keys(everyMarker()).length).toBe(AGENT_ENV_VARS.length + AGENT_ENV_PREFIXES.length);
+  });
+
+  it("an env carrying EVERY declared marker is detected", () => {
+    expect(isKnownAgentEnv(everyMarker())).toBe(true);
   });
 
   it("scrubbing that env makes it undetectable — the property that must hold for any new marker", () => {
-    expect(isKnownAgentEnv(scrubAgentEnv({ ...MARKERS }))).toBe(false);
+    expect(isKnownAgentEnv(scrubAgentEnv(everyMarker()))).toBe(false);
   });
 
-  it("each marker alone is both detected and scrubbed", () => {
-    for (const [k, v] of Object.entries(MARKERS)) {
+  it("each declared marker alone is both detected and scrubbed", () => {
+    for (const [k, v] of Object.entries(everyMarker())) {
       expect(isKnownAgentEnv({ [k]: v }), `${k} detected`).toBe(true);
       expect(isKnownAgentEnv(scrubAgentEnv({ [k]: v })), `${k} scrubbed`).toBe(false);
     }
   });
 
+  // What this suite does NOT prove: that the detector consults only these lists. A hardcoded check
+  // added inside isKnownAgentEnv for some name absent from them is invisible to any env built from
+  // them — no black-box test can enumerate the unknown. The structural guarantee is that the
+  // function reads the lists and nothing else; this case just pins that ordinary and adjacent-looking
+  // variables stay undetected.
+  it("does not detect variables that are not declared markers", () => {
+    expect(isKnownAgentEnv({ PATH: "/usr/bin", HOME: "/home/x" })).toBe(false);
+    // Cursor sets CURSOR_* in its integrated terminal, where a real human types — deliberately not a
+    // marker, and the nearest thing to a false positive.
+    expect(isKnownAgentEnv({ CURSOR_TRACE_ID: "abc" })).toBe(false);
+    expect(isKnownAgentEnv({ CLAUDE_SOMETHING_ELSE: "1" })).toBe(false); // CLAUDE_ but not CLAUDE_CODE_
+  });
+
   it("leaves unrelated variables alone", () => {
-    const env = { PATH: "/usr/bin", HOME: "/home/x", CURSOR_TRACE_ID: "keep-me", ...MARKERS };
-    const out = scrubAgentEnv(env);
-    expect(out).toEqual({ PATH: "/usr/bin", HOME: "/home/x", CURSOR_TRACE_ID: "keep-me" });
+    // CURSOR_* is deliberately NOT a marker (Cursor's integrated terminal is where a human types).
+    const env = { PATH: "/usr/bin", HOME: "/home/x", CURSOR_TRACE_ID: "keep-me", ...everyMarker() };
+    expect(scrubAgentEnv(env)).toEqual({ PATH: "/usr/bin", HOME: "/home/x", CURSOR_TRACE_ID: "keep-me" });
   });
 
   it("does not mutate the env it was given", () => {
-    const env = { ...MARKERS };
+    const env = everyMarker();
     scrubAgentEnv(env);
-    expect(env.CLAUDECODE).toBe("1"); // the caller's process.env must be untouched
+    expect(Object.keys(env).length).toBe(AGENT_ENV_VARS.length + AGENT_ENV_PREFIXES.length);
   });
 });

--- a/packages/cli/test/statusRouting.test.ts
+++ b/packages/cli/test/statusRouting.test.ts
@@ -12,6 +12,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { scrubAgentEnv } from "../src/cli";
 
 const CLI = join(dirname(fileURLToPath(import.meta.url)), "..", "dist", "cli.js");
 
@@ -24,10 +25,9 @@ beforeEach(() => {
   file = join(home, "plan.md");
   writeFileSync(file, "# Plan\n\nbody\n");
   // Hermetic auth env (see open.test.ts): assert the non-interactive "not logged in" path from any
-  // shell — CI=1 forces loginOptOut, and scrubbing CLAUDECODE/CLAUDE_CODE_* stops an agent shell from
-  // routing to the rendezvous pending-exit (exit 7).
-  env = { ...process.env, INPLAN_HOME: home, INPLAN_SIDECAR_DIR: join(home, "sidecars"), CI: "1" };
-  for (const k of Object.keys(env)) if (k === "CLAUDECODE" || k.startsWith("CLAUDE_CODE_")) delete env[k];
+  // shell — CI=1 forces loginOptOut, and scrubAgentEnv removes every marker isKnownAgentEnv knows,
+  // so no agent shell routes the subprocess to the rendezvous pending-exit (exit 7).
+  env = { ...scrubAgentEnv(process.env), INPLAN_HOME: home, INPLAN_SIDECAR_DIR: join(home, "sidecars"), CI: "1" };
 });
 
 afterEach(() => {

--- a/packages/cli/test/statusRouting.test.ts
+++ b/packages/cli/test/statusRouting.test.ts
@@ -23,7 +23,11 @@ beforeEach(() => {
   home = mkdtempSync(join(tmpdir(), "inplan-route-"));
   file = join(home, "plan.md");
   writeFileSync(file, "# Plan\n\nbody\n");
-  env = { ...process.env, INPLAN_HOME: home, INPLAN_SIDECAR_DIR: join(home, "sidecars") };
+  // Hermetic auth env (see open.test.ts): assert the non-interactive "not logged in" path from any
+  // shell — CI=1 forces loginOptOut, and scrubbing CLAUDECODE/CLAUDE_CODE_* stops an agent shell from
+  // routing to the rendezvous pending-exit (exit 7).
+  env = { ...process.env, INPLAN_HOME: home, INPLAN_SIDECAR_DIR: join(home, "sidecars"), CI: "1" };
+  for (const k of Object.keys(env)) if (k === "CLAUDECODE" || k.startsWith("CLAUDE_CODE_")) delete env[k];
 });
 
 afterEach(() => {

--- a/packages/cli/test/waitCycleResume.test.ts
+++ b/packages/cli/test/waitCycleResume.test.ts
@@ -52,9 +52,16 @@ async function waitUntil(cond: () => Promise<boolean>, timeoutMs = 5_000): Promi
   }
 }
 
+const SIGNALS = ["SIGTERM", "SIGHUP", "SIGINT"] as const;
+
 function harness(initialDoc: string) {
   const channel = new MemoryControlChannel();
   const store = new MemoryDocumentStore(initialDoc);
+  // waitCycle installs real signal handlers that call process.exit(0) — process-global state in the
+  // shared Vitest worker. Left in place, four tests stack twelve handlers, and a Ctrl+C or a CI
+  // cancellation would exit the worker 0 — before afterEach — masking an interrupted run as a pass.
+  // Snapshot the listeners now; restore() removes exactly what a run added.
+  const preListeners = new Map(SIGNALS.map((sig) => [sig, new Set(process.listeners(sig))]));
   const backend: WaitBackend = {
     channel,
     store,
@@ -75,6 +82,9 @@ function harness(initialDoc: string) {
     restore: () => {
       so.mockRestore();
       se.mockRestore();
+      for (const sig of SIGNALS) {
+        for (const l of process.listeners(sig)) if (!preListeners.get(sig)!.has(l)) process.off(sig, l);
+      }
     },
   };
 }
@@ -162,6 +172,21 @@ describe("waitCycle resume is a loop, not a re-entry", () => {
       h.restore();
     }
   }, 10_000); // the grace's read probe re-polls at its own 2s cadence — give the slow path headroom
+
+  it("the harness tears down the signal handlers waitCycle installs", async () => {
+    const before = process.listeners("SIGTERM").length;
+    const h = harness(DOC_A);
+    try {
+      const run = waitCycle(h.backend, null, new Set());
+      await waitUntil(async () => (await countEvents(h.channel, LogEventType.AgentRevised)) >= 1);
+      expect(process.listeners("SIGTERM").length).toBe(before + 1); // installed by the wait
+      await h.channel.append({ actor: "user", type: LogEventType.SessionClosed, payload: { reason: "completed" } });
+      await run;
+    } finally {
+      h.restore();
+    }
+    expect(process.listeners("SIGTERM").length).toBe(before); // and removed with the harness
+  });
 
   it("an explicit completed close still ends the wait (the loop does not swallow terminal batches)", async () => {
     const h = harness(DOC_A);

--- a/packages/cli/test/waitCycleResume.test.ts
+++ b/packages/cli/test/waitCycleResume.test.ts
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// The reopen grace took seven review rounds of seam-patches — lock re-claims, pre-mutation guards,
+// guards for the guards — because resume was a RECURSIVE re-entry into waitCycle, so every reload
+// walked back through the turn-processing pipeline. These tests pin the restructure that removed
+// the disease instead of the symptoms: turn processing runs exactly once per invocation, and a
+// reload-resume is a `continue` inside the wait loop.
+//
+// The discriminating assertion is the agent-event count. Under recursion, a resumed cycle re-ran
+// applyGatedEdit and re-appended agent_revised — and on the plugin path, where quarantine does not
+// revert the working copy, it re-parked a pending Review proposal too. One reload, duplicated events.
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { LogEventType, MemoryControlChannel, MemoryDocumentStore, type LogEntry } from "@inplan/core/node";
+import { waitCycle, type WaitBackend } from "../src/cli";
+
+const DOC_A = "# Plan\n\nOriginal body.\n\n<!--inplan\n[]\n-->\n";
+const DOC_B = "# Plan\n\nAgent-edited body.\n\n<!--inplan\n[]\n-->\n";
+
+let home: string;
+beforeEach(() => {
+  // Isolate settings (acceptance defaults to "review" with no settings file) and run the wait fast.
+  home = mkdtempSync(join(tmpdir(), "inplan-resume-"));
+  process.env.INPLAN_HOME = home;
+  process.env.INPLAN_DEBOUNCE_MS = "25";
+  process.env.INPLAN_POLL_MS = "2";
+});
+afterEach(() => {
+  delete process.env.INPLAN_HOME;
+  delete process.env.INPLAN_DEBOUNCE_MS;
+  delete process.env.INPLAN_POLL_MS;
+  rmSync(home, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+function harness(initialDoc: string) {
+  const channel = new MemoryControlChannel();
+  const store = new MemoryDocumentStore(initialDoc);
+  const backend: WaitBackend = {
+    channel,
+    store,
+    history: async () => (await channel.readSince(0)).entries,
+    logExit: () => {},
+  };
+  let out = "";
+  let err = "";
+  const so = vi.spyOn(process.stdout, "write").mockImplementation((c: unknown) => ((out += String(c)), true));
+  const se = vi.spyOn(process.stderr, "write").mockImplementation((c: unknown) => ((err += String(c)), true));
+  return {
+    channel,
+    store,
+    backend,
+    stdout: () => out,
+    stderr: () => err,
+    lastJson: () => JSON.parse(out.trim().split("\n").pop()!) as { status: string; entries: LogEntry[] },
+    restore: () => {
+      so.mockRestore();
+      se.mockRestore();
+    },
+  };
+}
+
+const countEvents = async (channel: MemoryControlChannel, type: string): Promise<number> =>
+  (await channel.readSince(0)).entries.filter((e) => e.type === type).length;
+
+/** Reload mid-wait: window_closed followed by a user action in the same debounced batch. */
+async function reloadThenAct(channel: MemoryControlChannel): Promise<void> {
+  await sleep(80); // the wait has claimed the lock and is polling
+  await channel.append({ actor: "user", type: LogEventType.SessionClosed, payload: { reason: "window_closed" } });
+  await channel.append({ actor: "user", type: LogEventType.TurnEnded });
+}
+
+describe("waitCycle resume is a loop, not a re-entry", () => {
+  it("a reload-resume does not re-run the turn pipeline (exactly one agent_revised)", async () => {
+    const h = harness(DOC_A);
+    try {
+      const run = waitCycle(h.backend, null, new Set());
+      await reloadThenAct(h.channel);
+      await expect(run).resolves.toBe("ok");
+
+      // The resume continued the SAME invocation: it re-read the post-close user action and
+      // reported it as the wake, instead of ending the session…
+      expect(h.stderr()).toContain("already active again");
+      const last = h.lastJson();
+      expect(last.status).toBe("your_turn");
+      expect(last.entries.some((e) => e.type === LogEventType.TurnEnded)).toBe(true);
+
+      // …and the pipeline ran once. Recursion appended a second agent_revised on every reload.
+      expect(await countEvents(h.channel, LogEventType.AgentRevised)).toBe(1);
+    } finally {
+      h.restore();
+    }
+  });
+
+  it("a reload never re-parks a pending Review proposal on the PLUGIN path", async () => {
+    // The duplication lived on the gate path specifically: quarantine reverts the working FILE to
+    // canonical (applyEdit.ts), so a recursed file-path resume saw no change — but with a gate the
+    // working copy is the plugin's and is NOT reverted, so recursion re-parked the same proposal
+    // and re-appended agent_revision_proposed on every reload.
+    const h = harness(DOC_B); // the agent's working copy, differing from the hub canonical
+    const gate = { readCanonical: async () => DOC_A, applyRevision: async () => {} };
+    try {
+      const run = waitCycle(h.backend, null, new Set(), undefined, gate);
+      await reloadThenAct(h.channel);
+      await expect(run).resolves.toBe("ok");
+
+      expect(await countEvents(h.channel, LogEventType.AgentRevisionProposed)).toBe(1);
+      expect(h.lastJson().status).toBe("your_turn");
+    } finally {
+      h.restore();
+    }
+  });
+
+  it("an explicit completed close still ends the wait (the loop does not swallow terminal batches)", async () => {
+    const h = harness(DOC_A);
+    try {
+      const run = waitCycle(h.backend, null, new Set());
+      await sleep(80);
+      await h.channel.append({ actor: "user", type: LogEventType.SessionClosed, payload: { reason: "completed" } });
+      await expect(run).resolves.toBe("ok");
+      const last = h.lastJson() as unknown as { status: string; reason: string };
+      expect(last.status).toBe("closed");
+      expect(last.reason).toBe("completed");
+    } finally {
+      h.restore();
+    }
+  });
+});

--- a/packages/cli/test/waitCycleResume.test.ts
+++ b/packages/cli/test/waitCycleResume.test.ts
@@ -20,13 +20,18 @@ import { waitCycle, type WaitBackend } from "../src/cli";
 const DOC_A = "# Plan\n\nOriginal body.\n\n<!--inplan\n[]\n-->\n";
 const DOC_B = "# Plan\n\nAgent-edited body.\n\n<!--inplan\n[]\n-->\n";
 
+// One source for the cadence: the env the wait reads and every timing decision below derive from
+// these, so slowing the suite down for a loaded CI is a one-line change.
+const DEBOUNCE_MS = 25;
+const POLL_MS = 2;
+
 let home: string;
 beforeEach(() => {
   // Isolate settings (acceptance defaults to "review" with no settings file) and run the wait fast.
   home = mkdtempSync(join(tmpdir(), "inplan-resume-"));
   process.env.INPLAN_HOME = home;
-  process.env.INPLAN_DEBOUNCE_MS = "25";
-  process.env.INPLAN_POLL_MS = "2";
+  process.env.INPLAN_DEBOUNCE_MS = String(DEBOUNCE_MS);
+  process.env.INPLAN_POLL_MS = String(POLL_MS);
 });
 afterEach(() => {
   delete process.env.INPLAN_HOME;
@@ -37,6 +42,15 @@ afterEach(() => {
 });
 
 const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+/** Poll until `cond` holds — the deterministic replacement for "sleep long enough". */
+async function waitUntil(cond: () => Promise<boolean>, timeoutMs = 5_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!(await cond())) {
+    if (Date.now() > deadline) throw new Error("waitUntil: condition not reached");
+    await sleep(POLL_MS);
+  }
+}
 
 function harness(initialDoc: string) {
   const channel = new MemoryControlChannel();
@@ -68,9 +82,15 @@ function harness(initialDoc: string) {
 const countEvents = async (channel: MemoryControlChannel, type: string): Promise<number> =>
   (await channel.readSince(0)).entries.filter((e) => e.type === type).length;
 
-/** Reload mid-wait: window_closed followed by a user action in the same debounced batch. */
+/** Reload mid-wait: window_closed followed by a user action.
+ *
+ *  Ordering is by OBSERVATION, not by sleeping: the pipeline's agent_revised append proves waitCycle
+ *  has long since read its initial history (so cursor 0 covers these appends), which is the only
+ *  ordering the test needs. Whether the two appends land in one debounced batch or split across two
+ *  is the scheduler's business — the in-batch branch and the grace branch must both resume, and the
+ *  assertions below accept either. */
 async function reloadThenAct(channel: MemoryControlChannel): Promise<void> {
-  await sleep(80); // the wait has claimed the lock and is polling
+  await waitUntil(async () => (await countEvents(channel, LogEventType.AgentRevised)) >= 1);
   await channel.append({ actor: "user", type: LogEventType.SessionClosed, payload: { reason: "window_closed" } });
   await channel.append({ actor: "user", type: LogEventType.TurnEnded });
 }
@@ -84,8 +104,11 @@ describe("waitCycle resume is a loop, not a re-entry", () => {
       await expect(run).resolves.toBe("ok");
 
       // The resume continued the SAME invocation: it re-read the post-close user action and
-      // reported it as the wake, instead of ending the session…
-      expect(h.stderr()).toContain("already active again");
+      // reported it as the wake, instead of ending the session. Both resume branches print
+      // "resuming the wait" — which branch fired depends on whether the scheduler split the two
+      // appends across debounce batches, and the invariant under test is the resume, not the batch.
+      expect(h.stderr()).toContain("resuming the wait");
+      expect(h.stderr()).not.toContain("did not come back");
       const last = h.lastJson();
       expect(last.status).toBe("your_turn");
       expect(last.entries.some((e) => e.type === LogEventType.TurnEnded)).toBe(true);
@@ -116,11 +139,35 @@ describe("waitCycle resume is a loop, not a re-entry", () => {
     }
   });
 
+  it("a batch-split reload (the close fires alone) resumes via the grace, pipeline still once", async () => {
+    // The case the in-batch branch cannot see: the debounce fires between the close and the user's
+    // next action, so the batch carries only window_closed. The grace watch must then catch the
+    // action and loop back — same invariant, other branch. Forced deterministically by waiting for
+    // the grace to begin before appending the action.
+    const h = harness(DOC_A);
+    try {
+      const run = waitCycle(h.backend, null, new Set());
+      await waitUntil(async () => (await countEvents(h.channel, LogEventType.AgentRevised)) >= 1);
+      await h.channel.append({ actor: "user", type: LogEventType.SessionClosed, payload: { reason: "window_closed" } });
+      await waitUntil(async () => h.stderr().includes("Watching for it to come back"));
+      await h.channel.append({ actor: "user", type: LogEventType.TurnEnded });
+
+      await expect(run).resolves.toBe("ok");
+      expect(h.stderr()).toContain("resuming the wait");
+      const last = h.lastJson();
+      expect(last.status).toBe("your_turn");
+      expect(last.entries.some((e) => e.type === LogEventType.TurnEnded)).toBe(true);
+      expect(await countEvents(h.channel, LogEventType.AgentRevised)).toBe(1);
+    } finally {
+      h.restore();
+    }
+  }, 10_000); // the grace's read probe re-polls at its own 2s cadence — give the slow path headroom
+
   it("an explicit completed close still ends the wait (the loop does not swallow terminal batches)", async () => {
     const h = harness(DOC_A);
     try {
       const run = waitCycle(h.backend, null, new Set());
-      await sleep(80);
+      await waitUntil(async () => (await countEvents(h.channel, LogEventType.AgentRevised)) >= 1);
       await h.channel.append({ actor: "user", type: LogEventType.SessionClosed, payload: { reason: "completed" } });
       await expect(run).resolves.toBe("ok");
       const last = h.lastJson() as unknown as { status: string; reason: string };

--- a/packages/core/src/channel.ts
+++ b/packages/core/src/channel.ts
@@ -42,8 +42,11 @@ export interface ControlChannel {
   claimLock(token: WaitToken): Promise<void>;
   /** True once a newer waiter has claimed the lock away from `token`. */
   isSuperseded(token: WaitToken): Promise<boolean>;
-  /** Editor liveness — true if an editor is currently present for this doc. */
-  presence(): Promise<boolean>;
+  /** Editor liveness. With no argument: true if an editor is present now (within the backend's
+   *  heartbeat TTL). With `sinceMs` (epoch ms): true only if the liveness signal is FRESHER than
+   *  `sinceMs` — used when watching for a reopen so a pre-close heartbeat still lingering inside
+   *  its TTL isn't mistaken for the editor coming back. */
+  presence(sinceMs?: number): Promise<boolean>;
 }
 
 /**

--- a/packages/core/src/fsBackend.ts
+++ b/packages/core/src/fsBackend.ts
@@ -124,7 +124,9 @@ export class FsControlChannel implements ControlChannel {
     return Promise.resolve(readFileSync(this.paths.waitLockPath, "utf8").trim() !== token);
   }
 
-  presence(): Promise<boolean> {
+  // `sinceMs` is ignored: liveness here is "is the editor PROCESS alive", which flips to false the
+  // instant the window closes — there's no lingering-heartbeat TTL window to disambiguate.
+  presence(_sinceMs?: number): Promise<boolean> {
     const log = readLog(this.paths.logPath);
     for (let i = log.length - 1; i >= 0; i--) {
       if (log[i]!.type === LogEventType.EditorPid) {

--- a/packages/core/src/memoryBackend.ts
+++ b/packages/core/src/memoryBackend.ts
@@ -15,6 +15,7 @@ export class MemoryControlChannel implements ControlChannel {
   private cursor = 0;
   private lockToken: WaitToken | null = null;
   private present = false;
+  private presentAt = 0;
   private listeners = new Set<() => void>();
 
   /** Deterministic timestamp source (override in tests); defaults to wall clock. */
@@ -61,12 +62,14 @@ export class MemoryControlChannel implements ControlChannel {
     return Promise.resolve(this.lockToken !== null && this.lockToken !== token);
   }
 
-  presence(): Promise<boolean> {
-    return Promise.resolve(this.present);
+  presence(sinceMs?: number): Promise<boolean> {
+    return Promise.resolve(this.present && (sinceMs === undefined || this.presentAt >= sinceMs));
   }
-  /** Test hook: simulate the editor being present/absent. */
-  setPresent(present: boolean): void {
+  /** Test hook: simulate the editor being present/absent. `at` (epoch ms, default now) stamps when
+   *  the heartbeat was written, so a `presence(sinceMs)` freshness check can be exercised. */
+  setPresent(present: boolean, at: number = Date.now()): void {
     this.present = present;
+    if (present) this.presentAt = at;
   }
 }
 

--- a/packages/core/src/memoryBackend.ts
+++ b/packages/core/src/memoryBackend.ts
@@ -63,7 +63,9 @@ export class MemoryControlChannel implements ControlChannel {
   }
 
   presence(sinceMs?: number): Promise<boolean> {
-    return Promise.resolve(this.present && (sinceMs === undefined || this.presentAt >= sinceMs));
+    // Strict `>`: the signal must be fresher than `sinceMs` (a heartbeat exactly at the grace-start
+    // was not written AFTER watching began). Matches SupabaseControlChannel.presence.
+    return Promise.resolve(this.present && (sinceMs === undefined || this.presentAt > sinceMs));
   }
   /** Test hook: simulate the editor being present/absent. `at` (epoch ms, default now) stamps when
    *  the heartbeat was written, so a `presence(sinceMs)` freshness check can be exercised. */

--- a/packages/core/test/memoryBackend.more.test.ts
+++ b/packages/core/test/memoryBackend.more.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { describe, expect, it } from "vitest";
-import { MemoryDocumentStore } from "../src/index";
+import { MemoryControlChannel, MemoryDocumentStore } from "../src/index";
 
 describe("MemoryDocumentStore", () => {
   it("accumulates backups and reports the count", async () => {
@@ -10,5 +10,16 @@ describe("MemoryDocumentStore", () => {
     await store.backup("a");
     await store.backup("b");
     expect(store.backupCount()).toBe(2);
+  });
+});
+
+describe("MemoryControlChannel presence freshness", () => {
+  it("uses a strict `>` bound — a heartbeat exactly at sinceMs is NOT counted as fresh", async () => {
+    const ch = new MemoryControlChannel();
+    ch.setPresent(true, 1000); // heartbeat stamped at t=1000
+    expect(await ch.presence()).toBe(true); // no bound → present
+    expect(await ch.presence(999)).toBe(true); // written AFTER 999 → fresh
+    expect(await ch.presence(1000)).toBe(false); // equal to the grace-start → NOT "after"
+    expect(await ch.presence(1001)).toBe(false); // older than the bound → stale
   });
 });


### PR DESCRIPTION
## Problem (found live, mid-collaboration)

A page reload tears the web editor down, which logs `session_closed {reason: window_closed}`. The agent's `wait` exits on that event — so when the human's reloaded page comes back seconds later, nobody is listening, and nothing restarts the wait. From the human's side the agent silently vanished.

## Fix

On a `window_closed` close (an explicit `completed` build handoff still ends immediately), the wait lingers for a reopen grace (3 min) watching for the human's return:

- a **new user-authored entry** past the cursor, or
- the **editor presence heartbeat** returning — a reload appends no events, so presence is the only signal for a silent return.

On resumption the wait re-enters `waitCycle` from the advanced cursor as if the close never happened; a silent grace reports `closed` exactly as before.

## Companion

Presence previously had readers but **no writer** — the web editor never heartbeated `editor_presence`. Crazy-Idea-Studio/inplan-cloud#195 adds the 7 s heartbeat (and fixes the stale-JWT reconnect that stuck the editor on "disconnected" after a deploy). Until that deploys, resumption is still detected via any user action; with it, silent reloads resume too.

## Tests

Resumption via user entry and via presence, trailing `SessionClosed` not counting as resumption, silent-grace giveup (keeps polling the whole window), transient-failure tolerance. Full suite green, coverage ≥95%.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/81?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sessions closed because an editor window was closed can now resume when the editor reopens.
  * Brief connection or channel read failures no longer prevent session recovery.
  * Sessions remain closed when reopening is not detected within the grace period.
  * Explicitly completed sessions continue to close immediately.
  * Older recovery attempts are superseded by newer ones.
  * CLI agent detection now supports Codex, Pi, and `INPLAN_AGENT` environments.

* **Tests**
  * Added coverage for reopening, presence freshness, user activity, transient failures, supersession, and timeout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->