### PR TITLE
release: 0.1.29 — a wait survives page reloads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5335,7 +5335,7 @@
     },
     "packages/cli": {
       "name": "@inplan/cli",
-      "version": "0.1.28",
+      "version": "0.1.29",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@hocuspocus/provider": "^2.15.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inplan/cli",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "private": true,
   "description": "inplan CLI: open / wait / signal orchestration over the document core.",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
Version bump only (`packages/cli/package.json` + lockfile). Merging this and publishing a `v0.1.29` GitHub Release triggers `release.yml` → npm publish via OIDC.

## What ships since 0.1.28

**#81 — a wait survives page reloads.** `window_closed` is routinely just a reload, and the wait used to end on it — stranding the returning human with no agent attached. It now lingers through a grace window and resumes when the human shows signs of being back: a fresh presence heartbeat (freshness-gated against the just-closed editor's lingering one), their next action during the grace, or an action already sitting in the same debounced batch as the close. The actions that proved the return are reported as the wake they are.

Review-driven hardening in the same change:
- an explicit `completed` handoff mid-grace ends the session **immediately**, with the reason the editor actually logged
- resume is a **loop, not a re-entry**: a reload can never re-run the turn pipeline (no duplicate `agent_revised`, no re-parked Review proposal on the plugin path), never re-claim the wait-lock from a newer waiter, and never mutate on a document it lost
- grace probes are individually fault-isolated and read only the log delta
- the spawn-test env scrub covers every agent harness the CLI detects, from one shared list

## Verification

1147 tests green, typecheck clean, coverage ≥95%. #81 was reviewed to zero open findings across nine rounds (23 threads).

`0.1.29` confirmed unused: npm latest is `0.1.28`, no `v0.1.29` tag.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/83?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CLI package to version 0.1.29.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->