### PR TITLE
Bump Electron to 43.3.0; fix the update check's Gatekeeper false-error

### DIFF
--- a/.github/workflows/electron-update-check.yml
+++ b/.github/workflows/electron-update-check.yml
@@ -96,12 +96,11 @@ jobs:
           npm install --no-save "electron@${LATEST}"
           # Some npm/runner combos don't run electron's postinstall for a transient `--no-save`
           # install, which leaves the platform binary un-fetched and the next step misreads it as a
-          # failed download (issue #82). Fetch it explicitly — idempotent: a no-op if the postinstall
-          # already ran, and it fails loudly here (not silently as a "missing app") if the download
-          # genuinely can't complete.
-          if [ ! -d node_modules/electron/dist/Electron.app ]; then
-            node node_modules/electron/install.js
-          fi
+          # failed download (issue #82). Fetch it explicitly. `install.js` is idempotent (a no-op if
+          # the postinstall already ran) and platform-aware — it pulls the right binary on macOS,
+          # Windows, or Linux — so this stays correct if the job is ever run on another OS. It fails
+          # loudly here if the download genuinely can't complete, rather than silently as a missing app.
+          node node_modules/electron/install.js
       - id: spctl
         # Fail CLOSED: only the two patterns confirmed by hand (a clean accept, and the
         # ad-hoc-signed dev binary's harmless "no resources" quirk — both 31.7.7 and 43.2.0

--- a/.github/workflows/electron-update-check.yml
+++ b/.github/workflows/electron-update-check.yml
@@ -94,6 +94,14 @@ jobs:
           mkdir -p /tmp/gk-check && cd /tmp/gk-check
           npm init -y >/dev/null
           npm install --no-save "electron@${LATEST}"
+          # Some npm/runner combos don't run electron's postinstall for a transient `--no-save`
+          # install, which leaves the platform binary un-fetched and the next step misreads it as a
+          # failed download (issue #82). Fetch it explicitly — idempotent: a no-op if the postinstall
+          # already ran, and it fails loudly here (not silently as a "missing app") if the download
+          # genuinely can't complete.
+          if [ ! -d node_modules/electron/dist/Electron.app ]; then
+            node node_modules/electron/install.js
+          fi
       - id: spctl
         # Fail CLOSED: only the two patterns confirmed by hand (a clean accept, and the
         # ad-hoc-signed dev binary's harmless "no resources" quirk — both 31.7.7 and 43.2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -2400,9 +2400,9 @@
       "license": "MIT"
     },
     "node_modules/electron": {
-      "version": "43.2.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-43.2.0.tgz",
-      "integrity": "sha512-80zvrgG7ZRXD+tD0IyLvrnN9n+veSxadMRsMaC9wKKP3iUbtC7rGM8+dVuCmOb0Rrwwv8ESW4awnUZh9Hbp1fA==",
+      "version": "43.3.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-43.3.0.tgz",
+      "integrity": "sha512-nLlvu0WFjftWsSaTkV2B/c4NDuJBspTyXu8vKSQ6vLvFt8uG3NgN49LLKcXddwX0GqVvAQDhciWp+4xOdTdhew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5319,7 +5319,7 @@
         "@types/react": "^18.3.5",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.3.1",
-        "electron": "^43.2.0",
+        "electron": "^43.3.0",
         "electron-vite": "^2.3.0",
         "vite": "^5.4.0"
       }

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -22,7 +22,7 @@
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",
-    "electron": "^43.2.0",
+    "electron": "^43.3.0",
     "electron-vite": "^2.3.0",
     "vite": "^5.4.0"
   }


### PR DESCRIPTION
Closes #82.

## What
- Bump the pinned Electron from `43.2.0` → `43.3.0` (`@inplan/app`).
- Harden the `electron-update-check` Gatekeeper job so it stops false-erroring.

## Why the auto-check errored (investigated before bumping)
The issue's Gatekeeper (`spctl`) step reported *"Electron.app not found — the download step likely failed"*. That was **not** a problem with 43.3.0:

- Reproduced locally: `npm install --no-save electron@43.3.0` adds the package but **does not run electron's postinstall** on current npm/runner combos, so the platform binary is never fetched → `Electron.app` missing → the step misreads it as a failed download.
- Running electron's installer directly (`node node_modules/electron/install.js`) fetches the binary fine (exit 0), and `spctl -a -vvv --type execute` returns `code has no resources but signature indicates they must be present` — the **same** benign ad-hoc-signed dev-binary result the check already classifies as `ok` for 43.2.0 and 31.7.7.

So 43.3.0 is safe; the check just needed to actually fetch the binary. The fix fetches it explicitly (idempotent — a no-op when the postinstall already ran, and it fails loudly if a download genuinely can't complete, rather than silently reporting a missing app).

## Verification
- `npm run build` ✓ · `npm run typecheck` (all packages, incl. `@inplan/app`) ✓ · `npm test` ✓ (1147 passed, 2 skipped)
- Local Gatekeeper: 43.3.0 → `ok` (same result as the current pin)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/84?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS installation checks so Electron downloads and installation failures are clearly surfaced.

* **Chores**
  * Updated the Electron development dependency to version 43.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->