### PR TITLE
Fix first-run login ENOENT + make `login --help` safe

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -621,6 +621,18 @@ export async function waitCycle(backend: WaitBackend, explicitCursor: number | n
  *    would expose it).
  */
 async function doLogin(args: string[]): Promise<void> {
+  // `--help` prints usage and exits BEFORE any rendezvous/sidecar work — asking how to sign in must
+  // never mint a login session or touch the ~/.inplan lock.
+  if (args.includes("--help") || args.includes("-h")) {
+    process.stdout.write(
+      "inplan login — sign in to the cloud\n" +
+        "  inplan login                                              browser rendezvous handoff (interactive)\n" +
+        "  inplan login --url <URL> --anon <KEY> --refresh <TOKEN> [--email <EMAIL>]\n" +
+        "                                                           store credentials directly (scripts / desktop)\n" +
+        "  env equivalents: INPLAN_SUPABASE_URL, INPLAN_SUPABASE_ANON_KEY, INPLAN_REFRESH_TOKEN\n",
+    );
+    return;
+  }
   const url = getFlag(args, "url") ?? process.env.INPLAN_SUPABASE_URL;
   const anonKey = getFlag(args, "anon") ?? process.env.INPLAN_SUPABASE_ANON_KEY;
   const refreshToken = getFlag(args, "refresh") ?? process.env.INPLAN_REFRESH_TOKEN;

--- a/packages/cli/src/cliLogin.ts
+++ b/packages/cli/src/cliLogin.ts
@@ -110,7 +110,9 @@ async function withSidecarLock<T>(fn: () => T | Promise<T>): Promise<T> {
   // Ensure the base dir exists first. On a machine that has never run inplan, ~/.inplan/ is absent,
   // so the lock mkdir below would throw ENOENT (not the retryable EEXIST) and bubble up — breaking
   // first-ever login, and any `inplan login` that reaches the sidecar before a dir-creating write.
-  mkdirSync(dirname(lock), { recursive: true });
+  // Owner-only (0o700): it holds the auth session + refresh token (the pending file is 0o600). mode
+  // is masked by umask, but 0o700 has no group/other bits to begin with, so the dir is never wider.
+  mkdirSync(dirname(lock), { recursive: true, mode: 0o700 });
   const deadline = Date.now() + LOCK_WAIT_MS;
   for (;;) {
     try {

--- a/packages/cli/src/cliLogin.ts
+++ b/packages/cli/src/cliLogin.ts
@@ -107,6 +107,10 @@ const LOCK_STALE_MS = 5000;
 
 async function withSidecarLock<T>(fn: () => T | Promise<T>): Promise<T> {
   const lock = pendingLoginPath() + ".lock";
+  // Ensure the base dir exists first. On a machine that has never run inplan, ~/.inplan/ is absent,
+  // so the lock mkdir below would throw ENOENT (not the retryable EEXIST) and bubble up — breaking
+  // first-ever login, and any `inplan login` that reaches the sidecar before a dir-creating write.
+  mkdirSync(dirname(lock), { recursive: true });
   const deadline = Date.now() + LOCK_WAIT_MS;
   for (;;) {
     try {

--- a/packages/cli/test/cliLogin.test.ts
+++ b/packages/cli/test/cliLogin.test.ts
@@ -8,7 +8,7 @@
 // way the /cli-auth page does, so parameter drift between the two halves fails here).
 
 import { webcrypto } from "node:crypto";
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -103,6 +103,16 @@ describe("createLoginSession", () => {
     const fetchImpl = (async () => res(503, { error: "nope" })) as unknown as typeof fetch;
     await expect(createLoginSession({ ...OPTS, fetchImpl })).rejects.toThrow(/HTTP 503/);
     expect(existsSync(pendingLoginPath())).toBe(false);
+  });
+
+  it("creates a never-existed base dir owner-only (0o700) rather than ENOENT on the lock", async () => {
+    // First-ever run: the base dir doesn't exist. The sidecar lock must not ENOENT, and the dir —
+    // which will hold the refresh token — must be created owner-only.
+    process.env.INPLAN_HOME = join(home, "never-run", ".inplan");
+    const { fetchImpl } = fakeServer([]);
+    await createLoginSession({ ...OPTS, fetchImpl, now: clock().now });
+    expect(existsSync(pendingLoginPath())).toBe(true);
+    if (process.platform !== "win32") expect(statSync(process.env.INPLAN_HOME).mode & 0o777).toBe(0o700);
   });
 });
 


### PR DESCRIPTION
## Problem
`inplan login --help` (and, more seriously, **first-ever `inplan login` on a clean machine**) failed with:

```
inplan: ENOENT: no such file or directory, mkdir '~/.inplan/login-pending.json.lock'
{ "status": "internal_error", ... }
```

The login sidecar lock in `withSidecarLock` does `mkdirSync(lock, { recursive: false })`, but nothing ensures the base `~/.inplan/` dir exists first. On a machine that has never run inplan, that `mkdir` throws **ENOENT** (not the retryable `EEXIST`), so it bubbles up. Any `login` that reaches the sidecar before a dir-creating write hits it — and `login --help` reached it because `--help` wasn't handled and fell through into the rendezvous path.

## Fix
- **`withSidecarLock`**: `mkdirSync(dirname(lock), { recursive: true })` before acquiring the lock — guarantees the base dir on first run.
- **`login --help`**: prints usage and returns **before** any rendezvous/sidecar work — asking how to sign in must never mint a session or touch the lock.

## Verification
- `inplan login --help` on a non-existent `INPLAN_HOME` → prints usage, exit 0, sidecar dir left untouched (previously ENOENT).
- Fresh-home non-interactive login stores `auth.json` without crashing.
- `npm run typecheck` ✓, full test suite ✓ (1147 passed), `cliLogin`/`cliAuth`/`cliAuthSession` ✓ (44 passed), pre-commit coverage gate ✓.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/85?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `inplan login --help` and `-h` support, including login usage, credential options, and environment-variable equivalents.

- **Bug Fixes**
  - Fixed first-time login failures when the pending-login directory does not yet exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->