### PR TITLE
Presence: surface auth failures and re-resolve the token (fixes the silent-death half of #88)

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -38,7 +38,7 @@ import { addComment, AddCommentError } from "./commentAdd";
 import { docPaths, sidecarRoot, type DocPaths } from "./paths";
 import { loadPluginGate, loadPluginGateOutcome, resolveHubUrl, type PluginAbsenceReason, type PluginGate } from "./pluginGate";
 import { demoteSource, shouldHydrateWorkFile, pendingRequiresReplay, postTurnAction, trackGateDegradations, type WaitOutcome } from "./liveSync";
-import { announcePresence } from "./presence";
+import { announcePresence, presenceTokenResolver } from "./presence";
 import { awaitReopen, wakePredicate, waitForActions } from "./wait";
 import { versionFromModule } from "./version";
 import { toolActivityText } from "./relayActivity";
@@ -1083,22 +1083,9 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
   // (Presence is a cosmetic websocket; the correctness-critical DB polling rides `live` above.)
   // Its connection is LONG-lived — a wait can span hours and hub restarts — so hand it a token
   // RESOLVER, not a string frozen at attach: the provider re-resolves on every reconnect, where a
-  // stale ~1h JWT would otherwise fail auth. On a transient re-mint failure, fall back to the last
-  // good token (presence must never break the wait).
-  let lastPresenceToken = backend.token;
-  const presence = announcePresence(
-    docId,
-    async () => {
-      try {
-        const fresh = await remoteBackend(docId, "cli-agent");
-        if (fresh) lastPresenceToken = fresh.token;
-      } catch {
-        /* transient — reuse the last good token */
-      }
-      return lastPresenceToken;
-    },
-    model,
-  );
+  // stale ~1h JWT would otherwise fail auth (see presenceTokenResolver for the transient-vs-signed-
+  // out split — a definitively-gone session must not re-send a stale token).
+  const presence = announcePresence(docId, presenceTokenResolver(backend.token, () => remoteBackend(docId, "cli-agent")), model);
   try {
     const workFile = join(sidecarRoot(), "remote", `${docId}.plan.md`);
     const pendingPath = `${workFile}.pending`; // marker: a local fallback edit awaits a hub push

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -27,7 +27,7 @@ import {
 } from "@inplan/core/node";
 import { agentAuthorFor } from "./agentAuthor";
 import { gitProvenance } from "./provenance";
-import { authedSession, clearAuth, currentUser, liveRemoteBackend, loadAuth, remoteBackend, saveAuth, type AuthFile } from "./cliAuth";
+import { authedSession, authPath, clearAuth, currentUser, liveRemoteBackend, loadAuth, remoteBackend, saveAuth, type AuthFile } from "./cliAuth";
 import { LoginSessionExpiredError, clearPendingLogin, createLoginSession, loadPendingLogin, pollLoginSession, rendezvousLogin, type PendingLogin } from "./cliLogin";
 import { resolveIdentity, setManualProfile, writeLocalProfile } from "./cliProfile";
 import { checkForUpdate, selfUpdate, UPDATE_PKG, warnIfOutdated } from "./update";
@@ -1091,10 +1091,11 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
       const fresh = await remoteBackend(docId, "cli-agent");
       if (fresh) return fresh;
       // remoteBackend's null conflates "signed out" with "refresh failed". Only a MISSING auth file
-      // is definitive sign-out; credentials still on disk mean a transient failure, which must take
-      // the resolver's last-good-token fallback rather than kill the badge for the rest of an
-      // otherwise recoverable outage.
-      if (!loadAuth()) return null;
+      // is definitive sign-out (a pure existence check — loadAuth() also nulls on a transiently
+      // unreadable or corrupt file, which must NOT read as logout); anything still on disk means a
+      // transient failure, which takes the resolver's last-good-token fallback (itself bounded by
+      // the token's expiry) rather than killing the badge for a recoverable outage.
+      if (!existsSync(authPath())) return null;
       throw new Error("transient token refresh failure");
     }),
     model,

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1085,7 +1085,20 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
   // RESOLVER, not a string frozen at attach: the provider re-resolves on every reconnect, where a
   // stale ~1h JWT would otherwise fail auth (see presenceTokenResolver for the transient-vs-signed-
   // out split — a definitively-gone session must not re-send a stale token).
-  const presence = announcePresence(docId, presenceTokenResolver(backend.token, () => remoteBackend(docId, "cli-agent")), model);
+  const presence = announcePresence(
+    docId,
+    presenceTokenResolver(backend.token, async () => {
+      const fresh = await remoteBackend(docId, "cli-agent");
+      if (fresh) return fresh;
+      // remoteBackend's null conflates "signed out" with "refresh failed". Only a MISSING auth file
+      // is definitive sign-out; credentials still on disk mean a transient failure, which must take
+      // the resolver's last-good-token fallback rather than kill the badge for the rest of an
+      // otherwise recoverable outage.
+      if (!loadAuth()) return null;
+      throw new Error("transient token refresh failure");
+    }),
+    model,
+  );
   try {
     const workFile = join(sidecarRoot(), "remote", `${docId}.plan.md`);
     const pendingPath = `${workFile}.pending`; // marker: a local fallback edit awaits a hub push

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1080,9 +1080,25 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
   }
 
   // the web badge shows "agent · your machine"; clear it on exit.
-  // (Presence is a cosmetic websocket on the initial token; the correctness-critical DB polling
-  // rides `live` above and stays authenticated across the whole wait, even past the ~1h expiry.)
-  const presence = announcePresence(docId, backend.token, model);
+  // (Presence is a cosmetic websocket; the correctness-critical DB polling rides `live` above.)
+  // Its connection is LONG-lived — a wait can span hours and hub restarts — so hand it a token
+  // RESOLVER, not a string frozen at attach: the provider re-resolves on every reconnect, where a
+  // stale ~1h JWT would otherwise fail auth. On a transient re-mint failure, fall back to the last
+  // good token (presence must never break the wait).
+  let lastPresenceToken = backend.token;
+  const presence = announcePresence(
+    docId,
+    async () => {
+      try {
+        const fresh = await remoteBackend(docId, "cli-agent");
+        if (fresh) lastPresenceToken = fresh.token;
+      } catch {
+        /* transient — reuse the last good token */
+      }
+      return lastPresenceToken;
+    },
+    model,
+  );
   try {
     const workFile = join(sidecarRoot(), "remote", `${docId}.plan.md`);
     const pendingPath = `${workFile}.pending`; // marker: a local fallback edit awaits a hub push

--- a/packages/cli/src/presence.ts
+++ b/packages/cli/src/presence.ts
@@ -84,19 +84,38 @@ export function announcePresence(docId: string, token: string | (() => Promise<s
     const ydoc = new Y.Doc();
     // Node has no DOM WebSocket; hand the socket the `ws` polyfill.
     const socket = new HocuspocusProviderWebsocket({ url: COLLAB_URL, WebSocketPolyfill: WebSocket });
+    // The did-not-authenticate check follows the CONNECTION lifecycle, not just attach: re-armed on
+    // every (re)connect so a silent death at hour 2 — after a hub restart — is still reported, and
+    // cleared on a successful auth so a slow-but-successful connect can't leave a false alarm as
+    // the channel's last word (a "recovered" line corrects one that already fired).
+    let reported = false;
+    let authCheck: ReturnType<typeof setTimeout> | undefined;
+    const armAuthCheck = (): void => {
+      if (authCheck) clearTimeout(authCheck);
+      authCheck = setTimeout(() => {
+        if (!provider.isAuthenticated) {
+          reported = true;
+          process.stderr.write(`inplan: presence badge channel did not authenticate — ${COSMETIC_NOTE}\n`);
+        }
+      }, AUTH_REPORT_DELAY_MS);
+      authCheck.unref?.(); // a cosmetic check must never keep the process alive
+    };
     const provider = new HocuspocusProvider({
       websocketProvider: socket,
       name: docId,
       document: ydoc,
       token,
+      onOpen: () => armAuthCheck(), // every (re)connect gets its own grace window
+      onAuthenticated: () => {
+        if (authCheck) clearTimeout(authCheck);
+        if (reported) {
+          reported = false;
+          process.stderr.write(`inplan: presence badge authenticated after all — ${COSMETIC_NOTE}\n`);
+        }
+      },
       onAuthenticationFailed: ({ reason }) => process.stderr.write(`inplan: presence badge auth failed (${reason}) — ${COSMETIC_NOTE}\n`),
     });
-    const authCheck = setTimeout(() => {
-      if (!provider.isAuthenticated) {
-        process.stderr.write(`inplan: presence badge channel did not authenticate — ${COSMETIC_NOTE}\n`);
-      }
-    }, AUTH_REPORT_DELAY_MS);
-    authCheck.unref?.(); // a cosmetic check must never keep the process alive
+    armAuthCheck(); // attach-time arm: covers a connection that never even opens
     // CROSS-REPO CONTRACT: this exact shape — {kind:"agent", agentLocation:"local", model?} — is
     // read verbatim by two places in the proprietary `inplan-cloud` repo: the web's
     // computeAgent() in packages/web/src/supabaseApi.ts (drives the connected-agent badge +
@@ -108,7 +127,7 @@ export function announcePresence(docId: string, token: string | (() => Promise<s
     provider.awareness?.setLocalStateField("inplanPresence", { kind: "agent", agentLocation: "local", ...(model ? { model } : {}) });
     return {
       destroy: () => {
-        clearTimeout(authCheck);
+        if (authCheck) clearTimeout(authCheck);
         try {
           provider.destroy();
           socket.destroy();

--- a/packages/cli/src/presence.ts
+++ b/packages/cli/src/presence.ts
@@ -10,8 +10,9 @@ import { resolveHubUrl } from "./pluginGate";
 const COLLAB_URL = resolveHubUrl();
 
 /** Grace before reporting an unauthenticated presence channel. Long enough for a cold hub start +
- *  auth round-trip; short enough that the report lands while the human is still looking. */
-const AUTH_REPORT_DELAY_MS = 15_000;
+ *  auth round-trip; short enough that the report lands while the human is still looking.
+ *  Exported for the tests, so the assertions track the real grace period. */
+export const AUTH_REPORT_DELAY_MS = 15_000;
 
 /** One shared suffix so every presence warning says the same, load-bearing thing: this channel is
  *  COSMETIC. A silently dead presence connection has been misread as "sync is broken" before — a
@@ -37,12 +38,28 @@ export function presenceTokenResolver(initial: string, mint: () => Promise<{ tok
     try {
       fresh = await mint();
     } catch {
-      return last; // transient — the last good token is the best available answer
+      // Transient — the last good token is the best available answer, but ONLY while it is still
+      // unexpired: during a prolonged refresh outage, a long wait would otherwise re-send the same
+      // expired JWT on every reconnect, a stale-token loop the hub can only answer with auth
+      // failures. An opaque (non-JWT) token has no readable expiry and keeps the plain fallback.
+      const exp = jwtExpMs(last);
+      if (exp !== null && exp <= Date.now()) throw new Error("cached token expired during a refresh outage — presence token unavailable");
+      return last;
     }
     if (!fresh) throw new Error("signed out — presence token unavailable");
     last = fresh.token;
     return last;
   };
+}
+
+/** Epoch-ms expiry from a JWT's payload, or null when unreadable (opaque/test tokens). */
+function jwtExpMs(token: string): number | null {
+  try {
+    const payload = JSON.parse(Buffer.from(token.split(".")[1] ?? "", "base64url").toString()) as { exp?: number };
+    return typeof payload.exp === "number" ? payload.exp * 1000 : null;
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/packages/cli/src/presence.ts
+++ b/packages/cli/src/presence.ts
@@ -9,6 +9,15 @@ import { resolveHubUrl } from "./pluginGate";
 // the badge can't probe a different hub than where edits land.
 const COLLAB_URL = resolveHubUrl();
 
+/** Grace before reporting an unauthenticated presence channel. Long enough for a cold hub start +
+ *  auth round-trip; short enough that the report lands while the human is still looking. */
+const AUTH_REPORT_DELAY_MS = 15_000;
+
+/** One shared suffix so every presence warning says the same, load-bearing thing: this channel is
+ *  COSMETIC. A silently dead presence connection has been misread as "sync is broken" before — a
+ *  real agent session deleted its local work over exactly that (issue #88). */
+const COSMETIC_NOTE = "cosmetic only; document edits sync on a separate channel";
+
 export interface PresenceHandle {
   /** Tear down the awareness connection (call when the wait ends / the process exits). */
   destroy: () => void;
@@ -20,13 +29,35 @@ export interface PresenceHandle {
  * attached. Agent attachment is **derived from live presence, not stored** —
  * disconnecting (the wait exiting) clears it. Best-effort: presence must never
  * break the wait, so any failure here is swallowed and the wait proceeds.
+ *
+ * `token` may be a resolver: this connection is LONG-lived (a wait can span hours and hub
+ * restarts/deploys), and the provider re-resolves the token on every reconnect — a string frozen at
+ * attach goes stale after the ~1h JWT expiry and every later reconnect would fail auth.
+ *
+ * Failures are surfaced, not just swallowed: hocuspocus reports a rejected token via
+ * `onAuthenticationFailed`, but its fatal variant — an `Unauthorized` close — only logs to the
+ * console and permanently stops reconnecting (`shouldConnect = false`). Rather than depend on those
+ * internals, a one-shot timer reports "still not authenticated after the grace period", which
+ * catches every silent-death variant the same way.
  */
-export function announcePresence(docId: string, token: string, model?: string): PresenceHandle {
+export function announcePresence(docId: string, token: string | (() => Promise<string>), model?: string): PresenceHandle {
   try {
     const ydoc = new Y.Doc();
     // Node has no DOM WebSocket; hand the socket the `ws` polyfill.
     const socket = new HocuspocusProviderWebsocket({ url: COLLAB_URL, WebSocketPolyfill: WebSocket });
-    const provider = new HocuspocusProvider({ websocketProvider: socket, name: docId, document: ydoc, token });
+    const provider = new HocuspocusProvider({
+      websocketProvider: socket,
+      name: docId,
+      document: ydoc,
+      token,
+      onAuthenticationFailed: ({ reason }) => process.stderr.write(`inplan: presence badge auth failed (${reason}) — ${COSMETIC_NOTE}\n`),
+    });
+    const authCheck = setTimeout(() => {
+      if (!provider.isAuthenticated) {
+        process.stderr.write(`inplan: presence badge channel did not authenticate — ${COSMETIC_NOTE}\n`);
+      }
+    }, AUTH_REPORT_DELAY_MS);
+    authCheck.unref?.(); // a cosmetic check must never keep the process alive
     // CROSS-REPO CONTRACT: this exact shape — {kind:"agent", agentLocation:"local", model?} — is
     // read verbatim by two places in the proprietary `inplan-cloud` repo: the web's
     // computeAgent() in packages/web/src/supabaseApi.ts (drives the connected-agent badge +
@@ -38,6 +69,7 @@ export function announcePresence(docId: string, token: string, model?: string): 
     provider.awareness?.setLocalStateField("inplanPresence", { kind: "agent", agentLocation: "local", ...(model ? { model } : {}) });
     return {
       destroy: () => {
+        clearTimeout(authCheck);
         try {
           provider.destroy();
           socket.destroy();

--- a/packages/cli/src/presence.ts
+++ b/packages/cli/src/presence.ts
@@ -113,7 +113,11 @@ export function announcePresence(docId: string, token: string | (() => Promise<s
           process.stderr.write(`inplan: presence badge authenticated after all — ${COSMETIC_NOTE}\n`);
         }
       },
-      onAuthenticationFailed: ({ reason }) => process.stderr.write(`inplan: presence badge auth failed (${reason}) — ${COSMETIC_NOTE}\n`),
+      onAuthenticationFailed: ({ reason }) => {
+        if (authCheck) clearTimeout(authCheck); // the specific reason supersedes the pending generic check — one failure, one line
+        reported = true; // a later successful retry still corrects the record ("authenticated after all")
+        process.stderr.write(`inplan: presence badge auth failed (${reason}) — ${COSMETIC_NOTE}\n`);
+      },
     });
     armAuthCheck(); // attach-time arm: covers a connection that never even opens
     // CROSS-REPO CONTRACT: this exact shape — {kind:"agent", agentLocation:"local", model?} — is

--- a/packages/cli/src/presence.ts
+++ b/packages/cli/src/presence.ts
@@ -28,7 +28,7 @@ export interface PresenceHandle {
  *  - `mint` THROWS (network blip, lock contention) → transient: reuse the last good token, the
  *    session may well still be valid and presence must never break the wait;
  *  - `mint` returns NULL (signed out / refresh definitively failed) → throw: knowingly re-sending a
- *    stale or revoked token invites the server's Unauthorized close — the permanent-silent-death
+ *    stale or revoked token invites the hub's Unauthorized close — the permanent-silent-death
  *    path this fix exists to prevent. The rejection surfaces via the presence failure handlers. */
 export function presenceTokenResolver(initial: string, mint: () => Promise<{ token: string } | null>): () => Promise<string> {
   let last = initial;

--- a/packages/cli/src/presence.ts
+++ b/packages/cli/src/presence.ts
@@ -23,6 +23,28 @@ export interface PresenceHandle {
   destroy: () => void;
 }
 
+/** Build the token resolver for the long-lived presence connection: re-mint on each reconnect.
+ *  The failure modes need OPPOSITE handling:
+ *  - `mint` THROWS (network blip, lock contention) → transient: reuse the last good token, the
+ *    session may well still be valid and presence must never break the wait;
+ *  - `mint` returns NULL (signed out / refresh definitively failed) → throw: knowingly re-sending a
+ *    stale or revoked token invites the server's Unauthorized close — the permanent-silent-death
+ *    path this fix exists to prevent. The rejection surfaces via the presence failure handlers. */
+export function presenceTokenResolver(initial: string, mint: () => Promise<{ token: string } | null>): () => Promise<string> {
+  let last = initial;
+  return async () => {
+    let fresh: { token: string } | null;
+    try {
+      fresh = await mint();
+    } catch {
+      return last; // transient — the last good token is the best available answer
+    }
+    if (!fresh) throw new Error("signed out — presence token unavailable");
+    last = fresh.token;
+    return last;
+  };
+}
+
 /**
  * Announce this local agent in a cloud doc's awareness room (Yjs presence), so
  * the web shows an "agent · your machine" badge while `wait --remote` is

--- a/packages/cli/test/presence.test.ts
+++ b/packages/cli/test/presence.test.ts
@@ -81,16 +81,27 @@ describe("announcePresence", () => {
     p.destroy(); // cancel the pending auth check — it must not fire into a later test's stderr
   });
 
-  it("surfaces an auth rejection on stderr, marked cosmetic-only", () => {
+  it("surfaces an auth rejection once, cosmetic-marked — the pending generic check is suppressed", () => {
+    vi.useFakeTimers();
     const err = vi.spyOn(process.stderr, "write").mockReturnValue(true);
     const p = announcePresence("doc-1", "jwt-token");
     try {
       (lastProviderConfig as { onAuthenticationFailed: (d: { reason: string }) => void }).onAuthenticationFailed({ reason: "permission-denied" });
       expect(err).toHaveBeenCalledWith(expect.stringContaining("presence badge auth failed (permission-denied)"));
       expect(err).toHaveBeenCalledWith(expect.stringContaining("cosmetic only"));
+      // The rejection landed BEFORE the grace elapsed: the pending generic check must not fire a
+      // second, vaguer warning for the same failure.
+      vi.advanceTimersByTime(AUTH_REPORT_DELAY_MS);
+      expect(err.mock.calls.map((c) => String(c[0])).join("")).not.toContain("did not authenticate");
+      expect(err).toHaveBeenCalledTimes(1);
+      // …and a successful retry afterwards still corrects the record.
+      lastProviderInstance!.isAuthenticated = true;
+      (lastProviderConfig as { onAuthenticated: () => void }).onAuthenticated();
+      expect(err).toHaveBeenCalledWith(expect.stringContaining("authenticated after all"));
     } finally {
       p.destroy();
       err.mockRestore();
+      vi.useRealTimers();
     }
   });
 

--- a/packages/cli/test/presence.test.ts
+++ b/packages/cli/test/presence.test.ts
@@ -46,19 +46,21 @@ vi.mock("yjs", () => ({
   },
 }));
 
-import { announcePresence } from "../src/presence";
+import { announcePresence, presenceTokenResolver } from "../src/presence";
 
 describe("announcePresence", () => {
   it("publishes {kind:'agent', agentLocation:'local'} to the doc's awareness room", () => {
-    announcePresence("doc-1", "jwt-token");
+    const p = announcePresence("doc-1", "jwt-token");
     expect(localState.inplanPresence).toEqual({ kind: "agent", agentLocation: "local" });
     expect((lastProviderConfig as { name: string }).name).toBe("doc-1");
     expect((lastProviderConfig as { token: string }).token).toBe("jwt-token");
+    p.destroy(); // cancel the pending auth check — it must not fire into a later test's stderr
   });
 
   it("includes the model when provided", () => {
-    announcePresence("doc-1", "jwt-token", "Opus 4.8");
+    const p = announcePresence("doc-1", "jwt-token", "Opus 4.8");
     expect(localState.inplanPresence).toEqual({ kind: "agent", agentLocation: "local", model: "Opus 4.8" });
+    p.destroy();
   });
 
   it("destroy() tears down the provider, socket, and doc", () => {
@@ -71,17 +73,40 @@ describe("announcePresence", () => {
 
   it("passes a token RESOLVER through to the provider (reconnects re-resolve; a frozen string goes stale)", () => {
     const resolver = async () => "fresh-jwt";
-    announcePresence("doc-1", resolver);
+    const p = announcePresence("doc-1", resolver);
     expect((lastProviderConfig as { token: unknown }).token).toBe(resolver);
+    p.destroy(); // cancel the pending auth check — it must not fire into a later test's stderr
   });
 
   it("surfaces an auth rejection on stderr, marked cosmetic-only", () => {
     const err = vi.spyOn(process.stderr, "write").mockReturnValue(true);
-    announcePresence("doc-1", "jwt-token");
-    (lastProviderConfig as { onAuthenticationFailed: (d: { reason: string }) => void }).onAuthenticationFailed({ reason: "permission-denied" });
-    expect(err).toHaveBeenCalledWith(expect.stringContaining("presence badge auth failed (permission-denied)"));
-    expect(err).toHaveBeenCalledWith(expect.stringContaining("cosmetic only"));
-    err.mockRestore();
+    const p = announcePresence("doc-1", "jwt-token");
+    try {
+      (lastProviderConfig as { onAuthenticationFailed: (d: { reason: string }) => void }).onAuthenticationFailed({ reason: "permission-denied" });
+      expect(err).toHaveBeenCalledWith(expect.stringContaining("presence badge auth failed (permission-denied)"));
+      expect(err).toHaveBeenCalledWith(expect.stringContaining("cosmetic only"));
+    } finally {
+      p.destroy();
+      err.mockRestore();
+    }
+  });
+
+  it("presenceTokenResolver: re-mints, keeps the last good token on a transient throw, fails on sign-out", async () => {
+    let mode: "ok" | "throw" | "null" = "ok";
+    let minted = 0;
+    const resolve = presenceTokenResolver("initial-jwt", async () => {
+      if (mode === "throw") throw new Error("network blip");
+      if (mode === "null") return null;
+      minted += 1;
+      return { token: `fresh-${minted}` };
+    });
+    await expect(resolve()).resolves.toBe("fresh-1"); // re-mints on each call
+    mode = "throw";
+    await expect(resolve()).resolves.toBe("fresh-1"); // transient → last GOOD token, not the initial
+    mode = "null";
+    await expect(resolve()).rejects.toThrow(/signed out/); // definitive → never re-send a stale token
+    mode = "ok";
+    await expect(resolve()).resolves.toBe("fresh-2"); // a recovered session resumes minting
   });
 
   it("reports a channel that never authenticates (the silent Unauthorized death — issue #88)", () => {

--- a/packages/cli/test/presence.test.ts
+++ b/packages/cli/test/presence.test.ts
@@ -10,6 +10,7 @@ let destroyedSocket = false;
 let destroyedDoc = false;
 let lastWebsocketConfig: unknown;
 let lastProviderConfig: unknown;
+let lastProviderInstance: { isAuthenticated: boolean } | undefined;
 
 vi.mock("@hocuspocus/provider", () => ({
   HocuspocusProviderWebsocket: class {
@@ -21,6 +22,7 @@ vi.mock("@hocuspocus/provider", () => ({
     }
   },
   HocuspocusProvider: class {
+    isAuthenticated = false;
     awareness = {
       setLocalStateField: (field: string, value: unknown) => {
         localState[field] = value;
@@ -28,6 +30,7 @@ vi.mock("@hocuspocus/provider", () => ({
     };
     constructor(config: unknown) {
       lastProviderConfig = config;
+      lastProviderInstance = this;
     }
     destroy() {
       destroyedProvider = true;
@@ -64,6 +67,46 @@ describe("announcePresence", () => {
     expect(destroyedProvider).toBe(true);
     expect(destroyedSocket).toBe(true);
     expect(destroyedDoc).toBe(true);
+  });
+
+  it("passes a token RESOLVER through to the provider (reconnects re-resolve; a frozen string goes stale)", () => {
+    const resolver = async () => "fresh-jwt";
+    announcePresence("doc-1", resolver);
+    expect((lastProviderConfig as { token: unknown }).token).toBe(resolver);
+  });
+
+  it("surfaces an auth rejection on stderr, marked cosmetic-only", () => {
+    const err = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    announcePresence("doc-1", "jwt-token");
+    (lastProviderConfig as { onAuthenticationFailed: (d: { reason: string }) => void }).onAuthenticationFailed({ reason: "permission-denied" });
+    expect(err).toHaveBeenCalledWith(expect.stringContaining("presence badge auth failed (permission-denied)"));
+    expect(err).toHaveBeenCalledWith(expect.stringContaining("cosmetic only"));
+    err.mockRestore();
+  });
+
+  it("reports a channel that never authenticates (the silent Unauthorized death — issue #88)", () => {
+    vi.useFakeTimers();
+    const err = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    announcePresence("doc-1", "jwt-token");
+    vi.advanceTimersByTime(15_000);
+    expect(err).toHaveBeenCalledWith(expect.stringContaining("did not authenticate"));
+    err.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it("stays silent when authenticated in time; destroy() cancels the pending check", () => {
+    vi.useFakeTimers();
+    const err = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    announcePresence("doc-1", "jwt-token");
+    lastProviderInstance!.isAuthenticated = true; // authenticated before the grace elapses
+    vi.advanceTimersByTime(15_000);
+    expect(err).not.toHaveBeenCalled();
+    const p2 = announcePresence("doc-2", "jwt-token");
+    p2.destroy(); // teardown before the grace elapses must cancel the report
+    vi.advanceTimersByTime(15_000);
+    expect(err).not.toHaveBeenCalled();
+    err.mockRestore();
+    vi.useRealTimers();
   });
 
   it("is best-effort: a construction failure returns a no-op handle instead of throwing", async () => {

--- a/packages/cli/test/presence.test.ts
+++ b/packages/cli/test/presence.test.ts
@@ -128,6 +128,7 @@ describe("announcePresence", () => {
     const err = vi.spyOn(process.stderr, "write").mockReturnValue(true);
     const p1 = announcePresence("doc-1", "jwt-token");
     lastProviderInstance!.isAuthenticated = true; // authenticated before the grace elapses
+    (lastProviderConfig as { onAuthenticated: () => void }).onAuthenticated(); // …which also clears the timer
     vi.advanceTimersByTime(AUTH_REPORT_DELAY_MS);
     expect(err).not.toHaveBeenCalled();
     const p2 = announcePresence("doc-2", "jwt-token");
@@ -135,6 +136,38 @@ describe("announcePresence", () => {
     vi.advanceTimersByTime(AUTH_REPORT_DELAY_MS);
     expect(err).not.toHaveBeenCalled();
     p1.destroy();
+    err.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it("corrects a false alarm: a slow-but-successful auth after the grace emits a recovery line", () => {
+    vi.useFakeTimers();
+    const err = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    const p = announcePresence("doc-1", "jwt-token");
+    vi.advanceTimersByTime(AUTH_REPORT_DELAY_MS); // grace elapses unauthenticated → report fires
+    expect(err).toHaveBeenCalledWith(expect.stringContaining("did not authenticate"));
+    lastProviderInstance!.isAuthenticated = true;
+    (lastProviderConfig as { onAuthenticated: () => void }).onAuthenticated(); // auth lands late
+    expect(err).toHaveBeenCalledWith(expect.stringContaining("authenticated after all"));
+    p.destroy();
+    err.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it("re-arms the check per reconnect: a silent death at hour 2 is still reported", () => {
+    vi.useFakeTimers();
+    const err = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    const p = announcePresence("doc-1", "jwt-token");
+    lastProviderInstance!.isAuthenticated = true;
+    (lastProviderConfig as { onAuthenticated: () => void }).onAuthenticated(); // initial connect: fine
+    vi.advanceTimersByTime(AUTH_REPORT_DELAY_MS);
+    expect(err).not.toHaveBeenCalled();
+    // Hub restart hours later: the provider reconnects but never re-authenticates (the 4401 death).
+    lastProviderInstance!.isAuthenticated = false;
+    (lastProviderConfig as { onOpen: () => void }).onOpen(); // reconnect re-arms its own grace window
+    vi.advanceTimersByTime(AUTH_REPORT_DELAY_MS);
+    expect(err).toHaveBeenCalledWith(expect.stringContaining("did not authenticate"));
+    p.destroy();
     err.mockRestore();
     vi.useRealTimers();
   });

--- a/packages/cli/test/presence.test.ts
+++ b/packages/cli/test/presence.test.ts
@@ -46,7 +46,10 @@ vi.mock("yjs", () => ({
   },
 }));
 
-import { announcePresence, presenceTokenResolver } from "../src/presence";
+import { announcePresence, presenceTokenResolver, AUTH_REPORT_DELAY_MS } from "../src/presence";
+
+/** A structurally valid JWT whose payload carries `exp` (epoch seconds) — enough for jwtExpMs. */
+const jwtWithExp = (expSec: number) => `h.${Buffer.from(JSON.stringify({ exp: expSec })).toString("base64url")}.sig`;
 
 describe("announcePresence", () => {
   it("publishes {kind:'agent', agentLocation:'local'} to the doc's awareness room", () => {
@@ -112,9 +115,10 @@ describe("announcePresence", () => {
   it("reports a channel that never authenticates (the silent Unauthorized death — issue #88)", () => {
     vi.useFakeTimers();
     const err = vi.spyOn(process.stderr, "write").mockReturnValue(true);
-    announcePresence("doc-1", "jwt-token");
-    vi.advanceTimersByTime(15_000);
+    const p = announcePresence("doc-1", "jwt-token");
+    vi.advanceTimersByTime(AUTH_REPORT_DELAY_MS);
     expect(err).toHaveBeenCalledWith(expect.stringContaining("did not authenticate"));
+    p.destroy();
     err.mockRestore();
     vi.useRealTimers();
   });
@@ -122,16 +126,43 @@ describe("announcePresence", () => {
   it("stays silent when authenticated in time; destroy() cancels the pending check", () => {
     vi.useFakeTimers();
     const err = vi.spyOn(process.stderr, "write").mockReturnValue(true);
-    announcePresence("doc-1", "jwt-token");
+    const p1 = announcePresence("doc-1", "jwt-token");
     lastProviderInstance!.isAuthenticated = true; // authenticated before the grace elapses
-    vi.advanceTimersByTime(15_000);
+    vi.advanceTimersByTime(AUTH_REPORT_DELAY_MS);
     expect(err).not.toHaveBeenCalled();
     const p2 = announcePresence("doc-2", "jwt-token");
     p2.destroy(); // teardown before the grace elapses must cancel the report
-    vi.advanceTimersByTime(15_000);
+    vi.advanceTimersByTime(AUTH_REPORT_DELAY_MS);
     expect(err).not.toHaveBeenCalled();
+    p1.destroy();
     err.mockRestore();
     vi.useRealTimers();
+  });
+
+  it("bounds the transient fallback by the cached JWT's expiry (no stale-token reconnect loop)", async () => {
+    // A prolonged refresh outage: mint keeps throwing. While the last good JWT is unexpired the
+    // fallback returns it; once it has expired, the resolver must reject rather than re-send it
+    // on every reconnect.
+    const fresh = jwtWithExp(Math.floor(Date.now() / 1000) + 3600); // valid for an hour
+    let now = Date.now();
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    try {
+      const resolve = presenceTokenResolver(fresh, async () => {
+        throw new Error("refresh outage");
+      });
+      await expect(resolve()).resolves.toBe(fresh); // unexpired → fallback holds
+      now += 2 * 3600 * 1000; // two hours later, still in the outage
+      await expect(resolve()).rejects.toThrow(/expired during a refresh outage/);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it("keeps the plain fallback for an opaque (non-JWT) token — expiry unreadable", async () => {
+    const resolve = presenceTokenResolver("opaque-token", async () => {
+      throw new Error("refresh outage");
+    });
+    await expect(resolve()).resolves.toBe("opaque-token");
   });
 
   it("is best-effort: a construction failure returns a no-op handle instead of throwing", async () => {


### PR DESCRIPTION
Part of #88 (the client-side, confirmed-harm half).

## Problem
`wait --remote`'s presence connection (the "agent · your machine" badge) is long-lived. When the collab hub closes it with `Unauthorized` (4401), `@hocuspocus/provider` logs a single console line — *"An authentication token is required, but you didn't send one. Won't try again."* — and sets `shouldConnect = false`: **it permanently stops reconnecting**. In a real session that dead-silent channel was misread as "sync is broken", and the agent deleted its local work.

Two defects, both fixed:
1. **Silence.** Rejected tokens now surface via `onAuthenticationFailed` on stderr, and a one-shot 15s "did not authenticate" check catches every silent-death variant (including the fatal Unauthorized close, which never reaches `onAuthenticationFailed`) without depending on hocuspocus internals. Both messages state explicitly that the channel is **cosmetic only; document edits sync on a separate channel** — the exact clarification whose absence caused the misdiagnosis.
2. **Frozen token.** Presence connected with a token string captured at attach. A wait spans hours and hub restarts; after the ~1h JWT expiry every reconnect re-sent a stale token. The provider accepts a resolver (`() => Promise<string>`), so `runRemote` now hands it `presenceTokenResolver`: re-mint via `remoteBackend` (lock-coordinated) on each reconnect; on a transient re-mint **throw**, reuse the last good token (presence must never break the wait); on a definitive sign-out (**null**), reject rather than re-send a stale token.

## Not addressed here (tracked in #88)
- The `.synced`-doesn't-track-proposals footgun that amplified the misdiagnosis.
- The exact trigger of the original 4401 close remains unproven (candidates in the issue); this PR makes any recurrence loud and self-describing instead of silent. Hub-side behavior is outside this repo's scope — the CLI must be robust against any Hocuspocus-compatible hub.

## Tests
`presence.test.ts`: token-resolver passthrough, the resolver's four transitions (re-mint → transient fallback → sign-out rejection → recovery), stderr on auth rejection (cosmetic-marked), the 15s never-authenticated report, silence when authenticated in time, destroy() cancels the pending check (9 tests). Typecheck + pre-commit coverage gate green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved presence authentication during reconnects by refreshing tokens automatically.
  * Preserved valid cached credentials during temporary authentication service failures.
  * Properly handled missing or expired credentials and reported authentication issues.
  * Added recovery for delayed authentication and improved reconnect reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->