### PR TITLE
feat(cli,app): upload pasted images to cloud storage instead of local .assets

### DIFF
--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -3,11 +3,13 @@
 import { app, BrowserWindow, dialog, ipcMain, nativeImage, shell } from "electron";
 import { APP_ICON_DATA_URL } from "./appIcon";
 import { execFile } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { basename, dirname, join, relative, resolve } from "node:path";
 import type { Acceptance, Cadence, SaveOptions, Settings } from "@inplan/renderer";
-import { isOnboarded, markOnboarded, parse, serialize, type Comment } from "@inplan/core/node";
+import { isOnboarded, markOnboarded, parse, readStatus, serialize, type Comment } from "@inplan/core/node";
 import { Session } from "./session";
 import { createI18nController } from "./i18nController";
 import { track, type TelemetryProps } from "./telemetry";
@@ -114,6 +116,36 @@ function runCli(args: string[], extraEnv?: Record<string, string>): Promise<{ co
       },
     );
   });
+}
+
+/** An image pasted/picked while the doc is live-connected to the cloud (Collaborate on Cloud):
+ *  hand the bytes to `inplan asset-upload` so they land in the cloud's `doc-images` bucket
+ *  directly, instead of writing them to a local `.assets/` folder that would need migrating
+ *  later. The bytes cross the process boundary via a temp file (IPC args are JSON-only) — this
+ *  function owns that file's whole lifecycle, cleaning it up whether the upload succeeds or not.
+ *  Returns null on any failure (network, auth, upload) so the caller falls back the same way a
+ *  local write failure does. */
+async function uploadAssetToCloud(docFile: string, bytes: ArrayBuffer, ext: string): Promise<{ relPath: string } | null> {
+  const tmp = join(tmpdir(), `inplan-asset-${randomUUID()}`);
+  try {
+    writeFileSync(tmp, Buffer.from(bytes));
+    const r = await runCli(["asset-upload", docFile, "--bytes-file", tmp, "--ext", ext]);
+    const out = JSON.parse(r.stdout.trim() || "{}") as { status?: string; relPath?: string };
+    if (out.status !== "uploaded" || !out.relPath) {
+      process.stderr.write(`[inplan] asset-upload failed: ${r.stderr.trim() || out.status || "unknown error"}\n`);
+      return null;
+    }
+    return { relPath: out.relPath };
+  } catch (e) {
+    process.stderr.write(`[inplan] asset-upload failed: ${(e as Error).message}\n`);
+    return null;
+  } finally {
+    try {
+      unlinkSync(tmp);
+    } catch {
+      /* best-effort cleanup — a leaked temp file is harmless */
+    }
+  }
 }
 
 /** Base URL of the cloud edition (inplan.ai), for the reachability probe + cloud links. */
@@ -543,11 +575,18 @@ function registerIpc(): void {
     }
     return { linkTarget: toPosix(relative(dirname(session.paths.file), abs)) };
   });
-  // An image (pasted or picked via the Source toolbar): written into a `<docname>.assets/`
-  // folder next to the doc (Typora-style), committed to git alongside it — never the sidecar
-  // dir, so the Markdown link it produces stays valid for anyone who clones the repo.
-  ipcMain.handle("asset:save", (_e, bytes: ArrayBuffer, ext: string) => {
+  // An image (pasted or picked via the Source toolbar). When the doc is live-connected to the
+  // cloud (Collaborate on Cloud), it goes straight to the cloud's doc-images bucket, so both
+  // sides see it immediately and no local-only image is ever left needing a later migration.
+  // Otherwise (the local-first default) it's written into a `<docname>.assets/` folder next to
+  // the doc (Typora-style), committed to git alongside it — never the sidecar dir, so the
+  // Markdown link it produces stays valid for anyone who clones the repo.
+  ipcMain.handle("asset:save", async (_e, bytes: ArrayBuffer, ext: string) => {
     if (!session) return null;
+    const status = readStatus(session.paths.statusPath);
+    if (status.location === "cloud" && status.cloudDocId) {
+      return uploadAssetToCloud(session.paths.file, bytes, ext);
+    }
     const docDir = dirname(session.paths.file);
     const assetsDir = join(docDir, `${basename(session.paths.file).replace(/\.md$/i, "")}.assets`);
     const safeExt = /^[a-z0-9]{1,5}$/i.test(ext) ? ext.toLowerCase() : "png";

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -6,8 +6,9 @@ import { createHash } from "node:crypto";
 import { createRequire } from "node:module";
 import { appendFileSync, copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { basename, dirname, extname, isAbsolute, join, relative, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import type { SupabaseClient } from "@supabase/supabase-js";
 import {
   type ControlChannel,
   CONTROL_LOG_VERSION,
@@ -28,6 +29,7 @@ import {
 import { agentAuthorFor } from "./agentAuthor";
 import { gitProvenance } from "./provenance";
 import { authedSession, clearAuth, currentUser, liveRemoteBackend, loadAuth, remoteBackend, saveAuth, type AuthFile } from "./cliAuth";
+import { SupabaseDocumentStore } from "@inplan/backend-supabase";
 import { LoginSessionExpiredError, clearPendingLogin, createLoginSession, loadPendingLogin, pollLoginSession, rendezvousLogin, type PendingLogin } from "./cliLogin";
 import { resolveIdentity, setManualProfile, writeLocalProfile } from "./cliProfile";
 import { checkForUpdate, selfUpdate, UPDATE_PKG, warnIfOutdated } from "./update";
@@ -1928,15 +1930,157 @@ export async function doUpload(file: string, args: string[]): Promise<void> {
     process.exit(1);
   }
 
+  // Migrate any pre-existing local images (pasted while the doc was still local, so they're
+  // relative links into a sibling `.assets/` folder) into the cloud bucket, and rewrite the body's
+  // links to the resulting public URLs — otherwise the doc arrives in the cloud with links into a
+  // folder that has no counterpart there. Applied to the file on disk too so the local copy's hash
+  // matches what's now stored in the cloud (status.lastSyncedHash below), keeping the next
+  // local⇄cloud reconcile check honest. Best-effort: a migration failure must not fail the promote
+  // itself — the doc is already created; the human can always fall back to re-pasting the images
+  // once collaborating in the cloud.
+  let finalBody = body;
+  try {
+    const migrated = await migrateLocalImages(body, dirname(file), s.db, pick.org_id, cloudDocId);
+    if (migrated.migrated > 0) {
+      finalBody = migrated.body;
+      writeFileSync(file, finalBody);
+      await new SupabaseDocumentStore(s.db, cloudDocId).saveDoc(finalBody);
+    }
+  } catch (e) {
+    process.stderr.write(`inplan upload: image migration failed (${e instanceof Error ? e.message : String(e)}) — the doc uploaded, but its local images weren't moved to the cloud\n`);
+  }
+
   const status: DocStatus = {
     location: "cloud",
     cloudDocId,
     originalPath: file,
-    lastSyncedHash: hashBody(body),
+    lastSyncedHash: hashBody(finalBody),
     ...(org?.slug ? { cloudLocator: { org: org.slug, repo, path } } : {}),
   };
   writeStatus(docPaths(file).statusPath, status);
   output({ status: "uploaded", cloudDocId, ...(org?.slug ? { locator: { org: org.slug, repo, path } } : {}) });
+}
+
+/** Extensions this uploader accepts, mapped to their Storage `Content-Type` — mirrors the cloud
+ *  web app's ASSET_MIME_BY_EXT and the `doc-images` bucket's allowed_mime_types (inplan-cloud's
+ *  `20260804000000_doc_images_bucket.sql`). Anything else falls back to png, same as the local
+ *  `asset:save` write path. */
+const ASSET_MIME_BY_EXT: Record<string, string> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  avif: "image/avif",
+  svg: "image/svg+xml",
+};
+const ASSET_BUCKET = "doc-images";
+
+/** Upload one image's bytes to the `doc-images` bucket at `orgId/docId/image-<stamp>[-n].<ext>`,
+ *  disambiguating on a name collision (409) — shared by `doAssetUpload` (a single live paste) and
+ *  {@link migrateLocalImages} (a promote-time batch). Returns the public URL, or null on a real
+ *  (non-collision) failure. */
+async function uploadAssetBytes(db: SupabaseClient, orgId: string, docId: string, bytes: Buffer, ext: string): Promise<string | null> {
+  // hasOwnProperty, not a truthy lookup — see the identical guard in the cloud web app's
+  // saveAsset (ASSET_MIME_BY_EXT[ext] is truthy for inherited Object.prototype names too).
+  const safeExt = Object.prototype.hasOwnProperty.call(ASSET_MIME_BY_EXT, ext) ? ext : "png";
+  const contentType = ASSET_MIME_BY_EXT[safeExt]!;
+  const stamp = new Date().toISOString().replace(/[^0-9]/g, "").slice(0, 14); // YYYYMMDDHHMMSS
+  for (let n = 0; n <= 5; n++) {
+    const name = n === 0 ? `image-${stamp}.${safeExt}` : `image-${stamp}-${n}.${safeExt}`;
+    const path = `${orgId}/${docId}/${name}`;
+    const { error } = await db.storage.from(ASSET_BUCKET).upload(path, bytes, { contentType });
+    if (!error) return db.storage.from(ASSET_BUCKET).getPublicUrl(path).data.publicUrl;
+    if (error.status !== 409) return null; // not a name collision — a real failure, don't retry
+  }
+  return null; // exhausted collision retries
+}
+
+/**
+ * Upload a pasted/picked image straight to the cloud `doc-images` bucket instead of writing it
+ * next to the local file — the desktop app calls this when it's live-connected to a cloud doc
+ * (Collaborate on Cloud), so a locally pasted image never needs a later migration. `--bytes-file`
+ * points at a temp file the caller (Electron main) wrote the raw bytes to; this command only
+ * reads it — the caller owns its lifecycle (creation + cleanup).
+ */
+export async function doAssetUpload(file: string, args: string[]): Promise<void> {
+  const status = readStatus(docPaths(file).statusPath);
+  if (status.location !== "cloud" || !status.cloudDocId) {
+    process.stderr.write("inplan asset-upload: document is not in the cloud\n");
+    process.exit(1);
+  }
+  const bytesFile = getFlag(args, "bytes-file");
+  if (!bytesFile) {
+    process.stderr.write("inplan asset-upload: usage: inplan asset-upload <file> --bytes-file <path> [--ext <ext>]\n");
+    process.exit(64);
+  }
+  const s = await authedSession();
+  if (!s) {
+    process.stderr.write("inplan: not logged in (or session expired) — run `inplan login`\n");
+    process.exit(1);
+  }
+  // The bucket's insert policy checks the path's org segment against `documents.org_id` itself
+  // (20260804000000_doc_images_bucket.sql), so this lookup doubles as the ownership check — an
+  // upload for a doc this session can't write to fails the RLS check with the wrong org anyway.
+  const { data: doc, error: docErr } = await s.db.from("documents").select("org_id").eq("id", status.cloudDocId).maybeSingle();
+  const orgId = (doc as { org_id?: string } | null)?.org_id;
+  if (docErr || !orgId) {
+    process.stderr.write(`inplan asset-upload: ${docErr?.message ?? "could not resolve the document's organization"}\n`);
+    process.exit(1);
+  }
+  const requestedExt = (getFlag(args, "ext") ?? "png").toLowerCase();
+  const bytes = readFileSync(bytesFile);
+  const relPath = await uploadAssetBytes(s.db, orgId, status.cloudDocId, bytes, requestedExt);
+  if (!relPath) {
+    process.stderr.write("inplan asset-upload: upload failed\n");
+    process.exit(1);
+  }
+  output({ status: "uploaded", relPath });
+}
+
+/** A Markdown image reference: `![alt](<dest>)` (the angle-bracket form the editor writes for
+ *  asset:save — needed because `<docname>.assets/…` can contain spaces) or the bare `![alt](dest)`
+ *  form (no unescaped whitespace/parens, which the bracket-less destination syntax can't carry). */
+const IMAGE_REF_RE = /!\[([^\]]*)\]\(\s*(?:<([^>]+)>|([^()\s]+))\s*\)/g;
+
+/** True for a relative path (not a URL) — mirrors the renderer's image-src resolver
+ *  (`markdown.ts`) so promote-time migration and live rendering agree on what counts as "local". */
+function isLocalRelativePath(dest: string): boolean {
+  return !/^[a-z][a-z0-9+.-]*:/i.test(dest) && !dest.startsWith("//") && !dest.startsWith("/");
+}
+
+/**
+ * Scan `body` for local relative image links, upload each referenced file (resolved against
+ * `docDir`) to the cloud `doc-images` bucket, and rewrite the links to the resulting public URLs.
+ * Run at promote time (`inplan upload`) so a doc pasted into while still local doesn't arrive in
+ * the cloud with links into a `.assets/` folder that has no counterpart there — otherwise the CLI
+ * command genuinely would be pointless, since nothing would ever call it for the images that
+ * matter most (the ones already in the doc when it's promoted). Best-effort per image: a missing
+ * file or a failed upload just leaves that one link untouched rather than losing the reference.
+ */
+async function migrateLocalImages(body: string, docDir: string, db: SupabaseClient, orgId: string, docId: string): Promise<{ body: string; migrated: number }> {
+  const replacements = new Map<string, string>(); // matched destination → new public URL
+  for (const m of body.matchAll(IMAGE_REF_RE)) {
+    const dest = m[2] ?? m[3] ?? "";
+    if (!dest || !isLocalRelativePath(dest) || replacements.has(dest)) continue;
+    const abs = resolve(docDir, dest);
+    if (!existsSync(abs)) continue; // already dangling — nothing to migrate
+    let bytes: Buffer;
+    try {
+      bytes = readFileSync(abs);
+    } catch {
+      continue;
+    }
+    const ext = extname(abs).slice(1).toLowerCase() || "png";
+    const url = await uploadAssetBytes(db, orgId, docId, bytes, ext);
+    if (url) replacements.set(dest, url);
+  }
+  if (replacements.size === 0) return { body, migrated: 0 };
+  const newBody = body.replace(IMAGE_REF_RE, (whole, _alt: string, bracketed?: string, bare?: string) => {
+    const url = replacements.get(bracketed ?? bare ?? "");
+    return url ? whole.replace(/\(\s*(?:<[^>]+>|[^()\s]+)\s*\)/, `(${url})`) : whole;
+  });
+  return { body: newBody, migrated: replacements.size };
 }
 
 /** `comment` (see ./commentAdd.ts) only knows how to rewrite a local file — reject it before
@@ -2041,7 +2185,7 @@ async function main(): Promise<void> {
       .filter(Boolean),
   );
 
-  if (!cmd || !["open", "wait", "signal", "message", "comment", "relay", "status", "promote", "demote", "upload"].includes(cmd)) {
+  if (!cmd || !["open", "wait", "signal", "message", "comment", "relay", "status", "promote", "demote", "upload", "asset-upload"].includes(cmd)) {
     process.stderr.write(
       "usage: inplan open  <file>   (create/open a local plan in the editor)\n" +
         "       inplan wait   <file|--remote DOC_ID> [--model NAME] [--cursor N] [--confirmed-comment-deletion=a,b] [--done] [--reload]\n" +
@@ -2053,6 +2197,7 @@ async function main(): Promise<void> {
         "       inplan upload  <file> [--org <slug>] [--repo <name>] [--path <p>] [--evict-lru]   (Collaborate on Cloud)\n" +
         "       inplan promote <file> --cloud-doc <docId> [--locator org/repo/path]\n" +
         "       inplan demote  <file> [--from-store]   (bring a cloud doc back to disk; --from-store accepts the server copy when the hub is unreadable)\n" +
+        "       inplan asset-upload <file> --bytes-file <path> [--ext <ext>]   (cloud doc: paste/pick an image straight to storage)\n" +
         "       inplan login   (opens the browser to sign in; or --url <url> --anon <key> --refresh <token> for scripts)\n" +
         "       inplan whoami | logout\n",
     );
@@ -2105,6 +2250,10 @@ async function main(): Promise<void> {
   }
   if (cmd === "demote") {
     await doDemote(file, args);
+    return;
+  }
+  if (cmd === "asset-upload") {
+    await doAssetUpload(file, args);
     return;
   }
 

--- a/packages/cli/test/assetUpload.test.ts
+++ b/packages/cli/test/assetUpload.test.ts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// `inplan asset-upload` is what the desktop app shells out to when it's live-connected to a
+// cloud doc (Collaborate on Cloud): it reads bytes from a temp file, resolves the doc's org via
+// the `documents` table, and uploads to the `doc-images` bucket — mirroring the cloud web app's
+// own saveAsset (same bucket, same org/doc path scheme, same 409-collision retry). Covers a
+// non-cloud doc, a missing --bytes-file, a logged-out session, a normal upload, a collision retry,
+// a hard storage failure, and the unknown-extension → png fallback — all over a mocked authed
+// session, no network.
+
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { docPaths, writeStatus } from "@inplan/core/node";
+
+let uploadResult: { error: { status: number; message: string } | null } = { error: null };
+let orgLookup: { data: unknown; error: unknown } = { data: { org_id: "org-1" }, error: null };
+let sessionPresent = true;
+const upload = vi.fn(async (_path: string, _bytes: unknown, _opts: unknown) => uploadResult);
+const getPublicUrl = vi.fn((path: string) => ({ data: { publicUrl: `https://cdn.test/doc-images/${path}` } }));
+
+function fakeDb() {
+  const q: Record<string, unknown> = {};
+  q.select = () => q;
+  q.eq = () => q;
+  q.maybeSingle = () => Promise.resolve(orgLookup);
+  return {
+    from: () => q,
+    storage: { from: () => ({ upload, getPublicUrl }) },
+  };
+}
+
+vi.mock("../src/cliAuth", () => ({
+  authedSession: vi.fn(async () => (sessionPresent ? { db: fakeDb(), session: { user: { id: "user-1" } } } : null)),
+}));
+
+import { doAssetUpload } from "../src/cli";
+
+let home: string;
+let file: string;
+let bytesFile: string;
+let out: string[];
+let exitCode: number | null;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "inplan-asset-upload-"));
+  process.env.INPLAN_SIDECAR_DIR = join(home, "sidecars");
+  file = join(home, "PLAN.md");
+  writeFileSync(file, "# My Plan\n\nbody\n");
+  bytesFile = join(home, "bytes.bin");
+  writeFileSync(bytesFile, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+  out = [];
+  exitCode = null;
+  vi.spyOn(process.stdout, "write").mockImplementation((s: string | Uint8Array) => {
+    out.push(String(s));
+    return true;
+  });
+  vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+    exitCode = code ?? 0;
+    throw new Error(`exit:${code}`); // halt the flow like the real process.exit
+  }) as never);
+  upload.mockClear();
+  getPublicUrl.mockClear();
+  uploadResult = { error: null };
+  orgLookup = { data: { org_id: "org-1" }, error: null };
+  sessionPresent = true;
+});
+afterEach(() => {
+  delete process.env.INPLAN_SIDECAR_DIR;
+  vi.restoreAllMocks();
+});
+
+const lastJson = () => JSON.parse(out.join("").trim().split("\n").pop()!);
+
+describe("inplan asset-upload → doc-images bucket", () => {
+  it("rejects a doc that isn't cloud-connected", async () => {
+    await expect(doAssetUpload(file, ["--bytes-file", bytesFile])).rejects.toThrow(/exit:1/);
+    expect(exitCode).toBe(1);
+    expect(upload).not.toHaveBeenCalled();
+  });
+
+  it("rejects a missing --bytes-file", async () => {
+    writeStatus(docPaths(file).statusPath, { location: "cloud", cloudDocId: "doc-9" });
+    await expect(doAssetUpload(file, [])).rejects.toThrow(/exit:64/);
+    expect(exitCode).toBe(64);
+  });
+
+  it("exits when not logged in", async () => {
+    writeStatus(docPaths(file).statusPath, { location: "cloud", cloudDocId: "doc-9" });
+    sessionPresent = false;
+    await expect(doAssetUpload(file, ["--bytes-file", bytesFile])).rejects.toThrow(/exit:1/);
+    expect(exitCode).toBe(1);
+  });
+
+  it("uploads to org/doc-scoped path and reports the public URL", async () => {
+    writeStatus(docPaths(file).statusPath, { location: "cloud", cloudDocId: "doc-9" });
+    await doAssetUpload(file, ["--bytes-file", bytesFile, "--ext", "png"]);
+    expect(upload).toHaveBeenCalledTimes(1);
+    const [path, , opts] = upload.mock.calls[0]!;
+    expect(path).toMatch(/^org-1\/doc-9\/image-\d{14}\.png$/);
+    expect(opts).toEqual({ contentType: "image/png" });
+    expect(lastJson()).toEqual({ status: "uploaded", relPath: `https://cdn.test/doc-images/${path}` });
+  });
+
+  it("falls back to png for an unrecognized extension", async () => {
+    writeStatus(docPaths(file).statusPath, { location: "cloud", cloudDocId: "doc-9" });
+    await doAssetUpload(file, ["--bytes-file", bytesFile, "--ext", "bmp"]);
+    const [path, , opts] = upload.mock.calls[0]!;
+    expect(path).toMatch(/\.png$/);
+    expect(opts).toEqual({ contentType: "image/png" });
+  });
+
+  it("retries past a name collision (409) then succeeds", async () => {
+    writeStatus(docPaths(file).statusPath, { location: "cloud", cloudDocId: "doc-9" });
+    upload.mockImplementationOnce(async () => ({ error: { status: 409, message: "duplicate" } })).mockImplementationOnce(async () => ({ error: null }));
+    await doAssetUpload(file, ["--bytes-file", bytesFile, "--ext", "png"]);
+    expect(upload).toHaveBeenCalledTimes(2);
+    expect(upload.mock.calls[1]![0]).toMatch(/-1\.png$/); // second attempt's disambiguated name
+    expect(lastJson()).toMatchObject({ status: "uploaded" });
+  });
+
+  it("exits non-zero on a hard storage failure (not a collision)", async () => {
+    writeStatus(docPaths(file).statusPath, { location: "cloud", cloudDocId: "doc-9" });
+    uploadResult = { error: { status: 403, message: "forbidden" } };
+    await expect(doAssetUpload(file, ["--bytes-file", bytesFile])).rejects.toThrow(/exit:1/);
+    expect(exitCode).toBe(1);
+    expect(upload).toHaveBeenCalledTimes(1); // no retry on a real failure
+    expect(out.join("")).not.toContain("uploaded");
+  });
+
+  it("exits when the document's org can't be resolved", async () => {
+    writeStatus(docPaths(file).statusPath, { location: "cloud", cloudDocId: "doc-9" });
+    orgLookup = { data: null, error: { message: "not found" } };
+    await expect(doAssetUpload(file, ["--bytes-file", bytesFile])).rejects.toThrow(/exit:1/);
+    expect(exitCode).toBe(1);
+    expect(upload).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/test/uploadImageMigration.test.ts
+++ b/packages/cli/test/uploadImageMigration.test.ts
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// `inplan upload` must migrate pre-existing LOCAL images (pasted while the doc was still local, so
+// they're relative links into a sibling `.assets/` folder) into the cloud `doc-images` bucket and
+// rewrite the body's links — otherwise a doc promoted to the cloud arrives with links into a folder
+// that has no counterpart there. Covers: a doc with a local image (migrated, both the local file
+// and the cloud row end up rewritten), a doc with no images (storage untouched), an already-absolute
+// image URL (left alone), and a dangling local link (left alone, no crash) — all over a mocked
+// authed session, no network.
+
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let rpcResult: { data: unknown; error: unknown } = { data: { status: "created", id: "doc-new" }, error: null };
+let memberships: { data: unknown; error: unknown } = { data: [{ org_id: "org-1", orgs: { slug: "acme", name: "Acme" } }], error: null };
+const rpc = vi.fn(async (_name: string, _params: Record<string, unknown>) => rpcResult);
+let uploadResult: { error: { status: number; message: string } | null } = { error: null };
+const upload = vi.fn(async (_path: string, _bytes: unknown, _opts: unknown) => uploadResult);
+const getPublicUrl = vi.fn((path: string) => ({ data: { publicUrl: `https://cdn.test/doc-images/${path}` } }));
+const update = vi.fn((_patch: Record<string, unknown>) => ({ eq: () => Promise.resolve({ error: null }) }));
+
+function fakeDb() {
+  const membershipsQ: Record<string, unknown> = {};
+  membershipsQ.select = () => membershipsQ;
+  membershipsQ.in = () => Promise.resolve(memberships);
+
+  const documentsQ: Record<string, unknown> = {};
+  documentsQ.select = () => documentsQ;
+  documentsQ.eq = () => documentsQ;
+  documentsQ.maybeSingle = () => Promise.resolve({ data: null, error: null });
+  documentsQ.update = update;
+
+  return {
+    from: (table: string) => (table === "memberships" ? membershipsQ : documentsQ),
+    rpc,
+    storage: { from: () => ({ upload, getPublicUrl }) },
+  };
+}
+
+vi.mock("../src/cliAuth", () => ({
+  authedSession: vi.fn(async () => ({ db: fakeDb(), session: { user: { id: "user-1" } } })),
+}));
+vi.mock("../src/provenance", () => ({
+  gitProvenance: () => ({ repo: "acme/plan", path: "docs/PLAN.md" }),
+}));
+
+import { doUpload } from "../src/cli";
+
+let home: string;
+let file: string;
+let out: string[];
+let exitCode: number | null;
+let errOut: string[];
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "inplan-upload-migrate-"));
+  process.env.INPLAN_SIDECAR_DIR = join(home, "sidecars");
+  file = join(home, "PLAN.md");
+  out = [];
+  errOut = [];
+  exitCode = null;
+  vi.spyOn(process.stdout, "write").mockImplementation((s: string | Uint8Array) => {
+    out.push(String(s));
+    return true;
+  });
+  vi.spyOn(process.stderr, "write").mockImplementation((s: string | Uint8Array) => {
+    errOut.push(String(s));
+    return true;
+  });
+  vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+    exitCode = code ?? 0;
+    throw new Error(`exit:${code}`);
+  }) as never);
+  rpc.mockClear();
+  upload.mockClear();
+  getPublicUrl.mockClear();
+  update.mockClear();
+  rpcResult = { data: { status: "created", id: "doc-new" }, error: null };
+  memberships = { data: [{ org_id: "org-1", orgs: { slug: "acme", name: "Acme" } }], error: null };
+  uploadResult = { error: null };
+});
+afterEach(() => {
+  delete process.env.INPLAN_SIDECAR_DIR;
+  vi.restoreAllMocks();
+});
+
+const lastJson = () => JSON.parse(out.join("").trim().split("\n").pop()!);
+
+describe("inplan upload → local image migration", () => {
+  it("uploads a local relative image, rewrites the link in both the local file and the cloud row", async () => {
+    mkdirSync(join(home, "PLAN.assets"), { recursive: true });
+    writeFileSync(join(home, "PLAN.assets", "image-1.png"), Buffer.from([1, 2, 3]));
+    writeFileSync(file, "# My Plan\n\n![](<PLAN.assets/image-1.png>)\n");
+
+    await doUpload(file, []);
+
+    expect(upload).toHaveBeenCalledTimes(1);
+    const [path] = upload.mock.calls[0]!;
+    expect(path).toMatch(/^org-1\/doc-new\/image-\d{14}\.png$/);
+
+    const url = `https://cdn.test/doc-images/${path}`;
+    expect(readFileSync(file, "utf8")).toContain(`![](${url})`);
+    expect(readFileSync(file, "utf8")).not.toContain("PLAN.assets");
+
+    expect(update).toHaveBeenCalledWith(expect.objectContaining({ body: expect.stringContaining(url) }));
+    expect(lastJson()).toMatchObject({ status: "uploaded", cloudDocId: "doc-new" });
+  });
+
+  it("a doc with no images never touches storage", async () => {
+    writeFileSync(file, "# My Plan\n\njust text\n");
+    await doUpload(file, []);
+    expect(upload).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+    expect(lastJson()).toMatchObject({ status: "uploaded" });
+  });
+
+  it("leaves an already-absolute image URL untouched", async () => {
+    writeFileSync(file, "# My Plan\n\n![](https://example.com/pic.png)\n");
+    await doUpload(file, []);
+    expect(upload).not.toHaveBeenCalled();
+    expect(readFileSync(file, "utf8")).toContain("https://example.com/pic.png");
+  });
+
+  it("leaves a dangling local link untouched (no crash) when the referenced file is missing", async () => {
+    writeFileSync(file, "# My Plan\n\n![](<PLAN.assets/missing.png>)\n");
+    await doUpload(file, []);
+    expect(upload).not.toHaveBeenCalled();
+    expect(readFileSync(file, "utf8")).toContain("PLAN.assets/missing.png");
+    expect(lastJson()).toMatchObject({ status: "uploaded" });
+  });
+
+  it("a storage failure during migration doesn't fail the promote itself", async () => {
+    mkdirSync(join(home, "PLAN.assets"), { recursive: true });
+    writeFileSync(join(home, "PLAN.assets", "image-1.png"), Buffer.from([1, 2, 3]));
+    writeFileSync(file, "# My Plan\n\n![](<PLAN.assets/image-1.png>)\n");
+    uploadResult = { error: { status: 500, message: "boom" } }; // a real (non-collision) failure — no retry
+
+    await doUpload(file, []);
+    expect(update).not.toHaveBeenCalled(); // nothing migrated → no cloud body rewrite
+    expect(readFileSync(file, "utf8")).toContain("PLAN.assets/image-1.png"); // local link left as-is
+    expect(lastJson()).toMatchObject({ status: "uploaded" }); // promote itself still succeeded
+  });
+});


### PR DESCRIPTION
## Summary
- `inplan asset-upload`: uploads image bytes straight to the `doc-images` bucket for a cloud-linked doc, mirroring the cloud web app's `saveAsset` (same bucket, org/doc path scheme, 409-collision retry).
- The desktop app's `asset:save` IPC handler routes through it whenever the doc is live-connected to the cloud (Collaborate on Cloud), so a pasted image never needs a later migration.
- `inplan upload` (promote) now migrates any images pasted while the doc was still local: it scans the body for local relative image links, uploads the referenced files, and rewrites the links in both the local file and the cloud row — otherwise a doc promoted after the fact arrives in the cloud with links into a `.assets/` folder that has no counterpart there.

## Test plan
- [x] `packages/cli/test/assetUpload.test.ts` — 8 cases (upload, extension fallback, 409-collision retry, hard failure, logged-out, non-cloud doc, org lookup failure)
- [x] `packages/cli/test/uploadImageMigration.test.ts` — 5 cases (migrates a local image, no-op with no images, leaves absolute URLs alone, leaves a dangling link alone, a storage failure doesn't fail the promote itself)
- [x] Verified end-to-end against the real cloud (Supabase Storage) with both single- and multi-image docs — uploaded images are publicly reachable and the rewritten links match the stored document body.
- [x] `npm run typecheck -w @inplan/cli -w @inplan/app` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/90?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for uploading images from cloud-linked documents.
  * Local images referenced during uploads are migrated to cloud storage and their Markdown links are updated to public URLs.
  * Added validation, MIME type detection, collision handling, and cleanup for asset uploads.
  * Uploads continue successfully when individual image migrations fail.

* **Bug Fixes**
  * Improved handling of missing image files, absolute URLs, and documents without images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->