### PR TITLE
feat(cli,app): upload pasted images to cloud storage instead of local .assets

### DIFF
--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -128,7 +128,9 @@ function runCli(args: string[], extraEnv?: Record<string, string>): Promise<{ co
 async function uploadAssetToCloud(docFile: string, bytes: ArrayBuffer, ext: string): Promise<{ relPath: string } | null> {
   const tmp = join(tmpdir(), `inplan-asset-${randomUUID()}`);
   try {
-    writeFileSync(tmp, Buffer.from(bytes));
+    // 0o600: the OS temp dir is shared system-wide — a permissive umask-derived mode would let
+    // another local user read the pasted image bytes before cleanup.
+    writeFileSync(tmp, Buffer.from(bytes), { mode: 0o600 });
     const r = await runCli(["asset-upload", docFile, "--bytes-file", tmp, "--ext", ext]);
     const out = JSON.parse(r.stdout.trim() || "{}") as { status?: string; relPath?: string };
     if (out.status !== "uploaded" || !out.relPath) {

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -99,7 +99,11 @@ interface ProfileSnapshot {
 /** Run an `inplan` subcommand under Electron's bundled Node, returning stdout JSON. `extraEnv`
  *  passes values that must NOT appear in argv (e.g. auth tokens, which `ps`/process listings would
  *  otherwise expose) — the CLI reads them from the environment. */
-function runCli(args: string[], extraEnv?: Record<string, string>): Promise<{ code: number; stdout: string; stderr: string }> {
+/** `timeoutMs` bounds how long the child may run before it's killed (SIGTERM) — most callers
+ *  (whoami, upload, token, …) are short one-shot round-trips and stay unbounded by omitting it;
+ *  a caller worth bounding (asset-upload, a network call the renderer is blocked waiting on)
+ *  passes one explicitly so a stalled network can't hang the caller forever. */
+function runCli(args: string[], extraEnv?: Record<string, string>, timeoutMs?: number): Promise<{ code: number; stdout: string; stderr: string }> {
   return new Promise((res) => {
     const cli = process.env.INPLAN_CLI;
     if (!cli) {
@@ -109,7 +113,7 @@ function runCli(args: string[], extraEnv?: Record<string, string>): Promise<{ co
     execFile(
       process.execPath,
       [cli, ...args],
-      { env: { ...process.env, ...extraEnv, ELECTRON_RUN_AS_NODE: "1" } }, // RUN_AS_NODE last: never overridable
+      { env: { ...process.env, ...extraEnv, ELECTRON_RUN_AS_NODE: "1" }, ...(timeoutMs ? { timeout: timeoutMs } : {}) }, // RUN_AS_NODE last: never overridable
       (err, stdout, stderr) => {
         const code = err && typeof (err as NodeJS.ErrnoException & { code?: number }).code === "number" ? Number((err as { code: number }).code) : err ? 1 : 0;
         res({ code, stdout, stderr });
@@ -125,13 +129,17 @@ function runCli(args: string[], extraEnv?: Record<string, string>): Promise<{ co
  *  function owns that file's whole lifecycle, cleaning it up whether the upload succeeds or not.
  *  Returns null on any failure (network, auth, upload) so the caller falls back the same way a
  *  local write failure does. */
+/** A stalled network must not hang the paste forever — bound the subprocess and let the existing
+ *  failure path (null → the renderer reports a failed paste) take over instead. */
+const ASSET_UPLOAD_TIMEOUT_MS = 30_000;
+
 async function uploadAssetToCloud(docFile: string, bytes: ArrayBuffer, ext: string): Promise<{ relPath: string } | null> {
   const tmp = join(tmpdir(), `inplan-asset-${randomUUID()}`);
   try {
     // 0o600: the OS temp dir is shared system-wide — a permissive umask-derived mode would let
     // another local user read the pasted image bytes before cleanup.
     writeFileSync(tmp, Buffer.from(bytes), { mode: 0o600 });
-    const r = await runCli(["asset-upload", docFile, "--bytes-file", tmp, "--ext", ext]);
+    const r = await runCli(["asset-upload", docFile, "--bytes-file", tmp, "--ext", ext], undefined, ASSET_UPLOAD_TIMEOUT_MS);
     const out = JSON.parse(r.stdout.trim() || "{}") as { status?: string; relPath?: string };
     if (out.status !== "uploaded" || !out.relPath) {
       process.stderr.write(`[inplan] asset-upload failed: ${r.stderr.trim() || out.status || "unknown error"}\n`);

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -3,11 +3,13 @@
 import { app, BrowserWindow, dialog, ipcMain, nativeImage, shell } from "electron";
 import { APP_ICON_DATA_URL } from "./appIcon";
 import { execFile } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { basename, dirname, join, relative, resolve } from "node:path";
 import type { Acceptance, Cadence, SaveOptions, Settings } from "@inplan/renderer";
-import { isOnboarded, markOnboarded, parse, serialize, type Comment } from "@inplan/core/node";
+import { isOnboarded, markOnboarded, parse, readStatus, serialize, type Comment } from "@inplan/core/node";
 import { Session } from "./session";
 import { createI18nController } from "./i18nController";
 import { track, type TelemetryProps } from "./telemetry";
@@ -114,6 +116,36 @@ function runCli(args: string[], extraEnv?: Record<string, string>): Promise<{ co
       },
     );
   });
+}
+
+/** An image pasted/picked while the doc is live-connected to the cloud (Collaborate on Cloud):
+ *  hand the bytes to `inplan asset-upload` so they land in the cloud's `doc-images` bucket
+ *  directly, instead of writing them to a local `.assets/` folder that would need migrating
+ *  later. The bytes cross the process boundary via a temp file (IPC args are JSON-only) — this
+ *  function owns that file's whole lifecycle, cleaning it up whether the upload succeeds or not.
+ *  Returns null on any failure (network, auth, upload) so the caller falls back the same way a
+ *  local write failure does. */
+async function uploadAssetToCloud(docFile: string, bytes: ArrayBuffer, ext: string): Promise<{ relPath: string } | null> {
+  const tmp = join(tmpdir(), `inplan-asset-${randomUUID()}`);
+  try {
+    writeFileSync(tmp, Buffer.from(bytes));
+    const r = await runCli(["asset-upload", docFile, "--bytes-file", tmp, "--ext", ext]);
+    const out = JSON.parse(r.stdout.trim() || "{}") as { status?: string; relPath?: string };
+    if (out.status !== "uploaded" || !out.relPath) {
+      process.stderr.write(`[inplan] asset-upload failed: ${r.stderr.trim() || out.status || "unknown error"}\n`);
+      return null;
+    }
+    return { relPath: out.relPath };
+  } catch (e) {
+    process.stderr.write(`[inplan] asset-upload failed: ${(e as Error).message}\n`);
+    return null;
+  } finally {
+    try {
+      unlinkSync(tmp);
+    } catch {
+      /* best-effort cleanup — a leaked temp file is harmless */
+    }
+  }
 }
 
 /** Base URL of the cloud edition (inplan.ai), for the reachability probe + cloud links. */
@@ -543,11 +575,18 @@ function registerIpc(): void {
     }
     return { linkTarget: toPosix(relative(dirname(session.paths.file), abs)) };
   });
-  // An image (pasted or picked via the Source toolbar): written into a `<docname>.assets/`
-  // folder next to the doc (Typora-style), committed to git alongside it — never the sidecar
-  // dir, so the Markdown link it produces stays valid for anyone who clones the repo.
-  ipcMain.handle("asset:save", (_e, bytes: ArrayBuffer, ext: string) => {
+  // An image (pasted or picked via the Source toolbar). When the doc is live-connected to the
+  // cloud (Collaborate on Cloud), it goes straight to the cloud's doc-images bucket, so both
+  // sides see it immediately and no local-only image is ever left needing a later migration.
+  // Otherwise (the local-first default) it's written into a `<docname>.assets/` folder next to
+  // the doc (Typora-style), committed to git alongside it — never the sidecar dir, so the
+  // Markdown link it produces stays valid for anyone who clones the repo.
+  ipcMain.handle("asset:save", async (_e, bytes: ArrayBuffer, ext: string) => {
     if (!session) return null;
+    const status = readStatus(session.paths.statusPath);
+    if (status.location === "cloud" && status.cloudDocId) {
+      return uploadAssetToCloud(session.paths.file, bytes, ext);
+    }
     const docDir = dirname(session.paths.file);
     const assetsDir = join(docDir, `${basename(session.paths.file).replace(/\.md$/i, "")}.assets`);
     const safeExt = /^[a-z0-9]{1,5}$/i.test(ext) ? ext.toLowerCase() : "png";

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1947,27 +1947,21 @@ export async function doUpload(file: string, args: string[]): Promise<void> {
   let finalBody = body;
   if (out0.status === "created") {
     try {
-      // Baseline for the optimistic-concurrency write below: the row's own `updated_at` right
-      // after creation. create_document's JSON result doesn't include it, so read it fresh.
-      const { data: freshRow, error: freshErr } = await s.db.from("documents").select("updated_at").eq("id", cloudDocId).maybeSingle();
-      const baselineUpdatedAt = (freshRow as { updated_at?: string } | null)?.updated_at;
-      if (freshErr || !baselineUpdatedAt) throw new Error(freshErr?.message ?? "could not read the document's updated_at baseline");
-
       const migrated = await migrateLocalImages(body, dirname(file), s.db, pick.org_id, cloudDocId);
       if (migrated.migrated > 0) {
-        // Optimistic concurrency: under the unified-Yjs model the collab hub can attach to this
-        // doc at any point after create_document returns (the row already exists, so a human
-        // could open it) and start materializing ITS OWN writes to documents.body — an
-        // unconditional write here would race it. Condition on `updated_at` being unchanged
-        // since our baseline; the hub's own writes bump it too (create_document's LRU comment:
-        // "autosaves advance it"), so if it moved, someone else touched the row first and this
-        // must NOT overwrite them (flagged in review: cubic-dev-ai on PR #91). No schema change
-        // needed — `updated_at` already exists; this is a plain conditional UPDATE.
+        // Optimistic concurrency, conditioned on CONTENT rather than time: under the unified-Yjs
+        // model the collab hub can attach to this doc at any point after create_document returns
+        // (the row already exists, so a human could open it) and start materializing ITS OWN
+        // writes to documents.body — an unconditional write here would race it. `.eq("body",
+        // body)` conditions on the exact original body this migration was derived from, so the
+        // write only commits if nothing else touched the row first. Unlike a timestamp baseline,
+        // this closes the create→baseline-read window (there's no separate baseline read to race)
+        // and is immune to client clock skew (flagged in review: melly-lgtm on PR #91).
         const { data: updatedRows, error: updateErr } = await s.db
           .from("documents")
           .update({ body: migrated.body, updated_at: new Date().toISOString() })
           .eq("id", cloudDocId)
-          .eq("updated_at", baselineUpdatedAt)
+          .eq("body", body)
           .select("id");
         if (updateErr) {
           await cleanupOrphanedUploads(s.db, migrated.uploadedPaths);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -29,7 +29,6 @@ import {
 import { agentAuthorFor } from "./agentAuthor";
 import { gitProvenance } from "./provenance";
 import { authedSession, clearAuth, currentUser, liveRemoteBackend, loadAuth, remoteBackend, saveAuth, type AuthFile } from "./cliAuth";
-import { SupabaseDocumentStore } from "@inplan/backend-supabase";
 import { LoginSessionExpiredError, clearPendingLogin, createLoginSession, loadPendingLogin, pollLoginSession, rendezvousLogin, type PendingLogin } from "./cliLogin";
 import { resolveIdentity, setManualProfile, writeLocalProfile } from "./cliProfile";
 import { checkForUpdate, selfUpdate, UPDATE_PKG, warnIfOutdated } from "./update";
@@ -1948,21 +1947,46 @@ export async function doUpload(file: string, args: string[]): Promise<void> {
   let finalBody = body;
   if (out0.status === "created") {
     try {
+      // Baseline for the optimistic-concurrency write below: the row's own `updated_at` right
+      // after creation. create_document's JSON result doesn't include it, so read it fresh.
+      const { data: freshRow, error: freshErr } = await s.db.from("documents").select("updated_at").eq("id", cloudDocId).maybeSingle();
+      const baselineUpdatedAt = (freshRow as { updated_at?: string } | null)?.updated_at;
+      if (freshErr || !baselineUpdatedAt) throw new Error(freshErr?.message ?? "could not read the document's updated_at baseline");
+
       const migrated = await migrateLocalImages(body, dirname(file), s.db, pick.org_id, cloudDocId);
       if (migrated.migrated > 0) {
-        // Cloud first, then local, then only NOW does `finalBody` (and so lastSyncedHash below)
-        // reflect the migrated body. If saveDoc throws, we never reach the local write or the
-        // reassignment — the local file and finalBody both stay at the ORIGINAL body, so the
-        // persisted hash always matches whatever the local file actually contains. The old
-        // local-first order could leave lastSyncedHash claiming sync (hash of the migrated body)
-        // while the cloud still held the pre-migration one, on nothing more than a failed cloud
-        // write (flagged in review: cubic-dev-ai + melly-lgtm on PR #91).
-        await new SupabaseDocumentStore(s.db, cloudDocId).saveDoc(migrated.body);
-        writeFileSync(file, migrated.body);
-        finalBody = migrated.body;
+        // Optimistic concurrency: under the unified-Yjs model the collab hub can attach to this
+        // doc at any point after create_document returns (the row already exists, so a human
+        // could open it) and start materializing ITS OWN writes to documents.body — an
+        // unconditional write here would race it. Condition on `updated_at` being unchanged
+        // since our baseline; the hub's own writes bump it too (create_document's LRU comment:
+        // "autosaves advance it"), so if it moved, someone else touched the row first and this
+        // must NOT overwrite them (flagged in review: cubic-dev-ai on PR #91). No schema change
+        // needed — `updated_at` already exists; this is a plain conditional UPDATE.
+        const { data: updatedRows, error: updateErr } = await s.db
+          .from("documents")
+          .update({ body: migrated.body, updated_at: new Date().toISOString() })
+          .eq("id", cloudDocId)
+          .eq("updated_at", baselineUpdatedAt)
+          .select("id");
+        if (updateErr) throw new Error(`cloud write failed: ${updateErr.message}`);
+        if (!updatedRows || updatedRows.length === 0) {
+          throw new Error("the document changed in the cloud while migrating images (a live session attached first) — not overwriting it; re-run `inplan upload` to retry");
+        }
+        // The cloud write succeeded — a failure past this point is a DIFFERENT failure (the
+        // images and the cloud body are already correct), so it must not be reported as "the
+        // cloud write failed", and finalBody must reflect whatever actually ends up on disk
+        // rather than what we merely intended to write (flagged in review: cubic-dev-ai on #91).
+        try {
+          writeFileSync(file, migrated.body);
+          finalBody = migrated.body;
+        } catch (e) {
+          finalBody = existsSync(file) ? readFileSync(file, "utf8") : body;
+          throw new Error(`the cloud copy was updated, but writing it back to the local file failed (${e instanceof Error ? e.message : String(e)}) — re-run \`inplan upload\` to pull the migrated body back down locally`);
+        }
       }
     } catch (e) {
-      process.stderr.write(`inplan upload: image migration failed (${e instanceof Error ? e.message : String(e)}) — the doc uploaded, but its local images weren't moved to the cloud\n`);
+      process.stderr.write(`inplan upload: image migration failed (${e instanceof Error ? e.message : String(e)})\n`);
     }
   }
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -6,8 +6,9 @@ import { createHash } from "node:crypto";
 import { createRequire } from "node:module";
 import { appendFileSync, copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { basename, dirname, extname, isAbsolute, join, relative, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import type { SupabaseClient } from "@supabase/supabase-js";
 import {
   type ControlChannel,
   CONTROL_LOG_VERSION,
@@ -28,6 +29,7 @@ import {
 import { agentAuthorFor } from "./agentAuthor";
 import { gitProvenance } from "./provenance";
 import { authedSession, clearAuth, currentUser, liveRemoteBackend, loadAuth, remoteBackend, saveAuth, type AuthFile } from "./cliAuth";
+import { SupabaseDocumentStore } from "@inplan/backend-supabase";
 import { LoginSessionExpiredError, clearPendingLogin, createLoginSession, loadPendingLogin, pollLoginSession, rendezvousLogin, type PendingLogin } from "./cliLogin";
 import { resolveIdentity, setManualProfile, writeLocalProfile } from "./cliProfile";
 import { checkForUpdate, selfUpdate, UPDATE_PKG, warnIfOutdated } from "./update";
@@ -1928,15 +1930,157 @@ export async function doUpload(file: string, args: string[]): Promise<void> {
     process.exit(1);
   }
 
+  // Migrate any pre-existing local images (pasted while the doc was still local, so they're
+  // relative links into a sibling `.assets/` folder) into the cloud bucket, and rewrite the body's
+  // links to the resulting public URLs — otherwise the doc arrives in the cloud with links into a
+  // folder that has no counterpart there. Applied to the file on disk too so the local copy's hash
+  // matches what's now stored in the cloud (status.lastSyncedHash below), keeping the next
+  // local⇄cloud reconcile check honest. Best-effort: a migration failure must not fail the promote
+  // itself — the doc is already created; the human can always fall back to re-pasting the images
+  // once collaborating in the cloud.
+  let finalBody = body;
+  try {
+    const migrated = await migrateLocalImages(body, dirname(file), s.db, pick.org_id, cloudDocId);
+    if (migrated.migrated > 0) {
+      finalBody = migrated.body;
+      writeFileSync(file, finalBody);
+      await new SupabaseDocumentStore(s.db, cloudDocId).saveDoc(finalBody);
+    }
+  } catch (e) {
+    process.stderr.write(`inplan upload: image migration failed (${e instanceof Error ? e.message : String(e)}) — the doc uploaded, but its local images weren't moved to the cloud\n`);
+  }
+
   const status: DocStatus = {
     location: "cloud",
     cloudDocId,
     originalPath: file,
-    lastSyncedHash: hashBody(body),
+    lastSyncedHash: hashBody(finalBody),
     ...(org?.slug ? { cloudLocator: { org: org.slug, repo, path } } : {}),
   };
   writeStatus(docPaths(file).statusPath, status);
   output({ status: "uploaded", cloudDocId, ...(org?.slug ? { locator: { org: org.slug, repo, path } } : {}) });
+}
+
+/** Extensions this uploader accepts, mapped to their Storage `Content-Type` — mirrors the cloud
+ *  web app's ASSET_MIME_BY_EXT and the `doc-images` bucket's allowed_mime_types (inplan-cloud's
+ *  `20260804000000_doc_images_bucket.sql`). Anything else falls back to png, same as the local
+ *  `asset:save` write path. */
+const ASSET_MIME_BY_EXT: Record<string, string> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  avif: "image/avif",
+  svg: "image/svg+xml",
+};
+const ASSET_BUCKET = "doc-images";
+
+/** Upload one image's bytes to the `doc-images` bucket at `orgId/docId/image-<stamp>[-n].<ext>`,
+ *  disambiguating on a name collision (409) — shared by `doAssetUpload` (a single live paste) and
+ *  {@link migrateLocalImages} (a promote-time batch). Returns the public URL, or null on a real
+ *  (non-collision) failure. */
+async function uploadAssetBytes(db: SupabaseClient, orgId: string, docId: string, bytes: Buffer, ext: string): Promise<string | null> {
+  // hasOwnProperty, not a truthy lookup — see the identical guard in the cloud web app's
+  // saveAsset (ASSET_MIME_BY_EXT[ext] is truthy for inherited Object.prototype names too).
+  const safeExt = Object.prototype.hasOwnProperty.call(ASSET_MIME_BY_EXT, ext) ? ext : "png";
+  const contentType = ASSET_MIME_BY_EXT[safeExt]!;
+  const stamp = new Date().toISOString().replace(/[^0-9]/g, "").slice(0, 14); // YYYYMMDDHHMMSS
+  for (let n = 0; n <= 5; n++) {
+    const name = n === 0 ? `image-${stamp}.${safeExt}` : `image-${stamp}-${n}.${safeExt}`;
+    const path = `${orgId}/${docId}/${name}`;
+    const { error } = await db.storage.from(ASSET_BUCKET).upload(path, bytes, { contentType });
+    if (!error) return db.storage.from(ASSET_BUCKET).getPublicUrl(path).data.publicUrl;
+    if (error.status !== 409) return null; // not a name collision — a real failure, don't retry
+  }
+  return null; // exhausted collision retries
+}
+
+/**
+ * Upload a pasted/picked image straight to the cloud `doc-images` bucket instead of writing it
+ * next to the local file — the desktop app calls this when it's live-connected to a cloud doc
+ * (Collaborate on Cloud), so a locally pasted image never needs a later migration. `--bytes-file`
+ * points at a temp file the caller (Electron main) wrote the raw bytes to; this command only
+ * reads it — the caller owns its lifecycle (creation + cleanup).
+ */
+export async function doAssetUpload(file: string, args: string[]): Promise<void> {
+  const status = readStatus(docPaths(file).statusPath);
+  if (status.location !== "cloud" || !status.cloudDocId) {
+    process.stderr.write("inplan asset-upload: document is not in the cloud\n");
+    process.exit(1);
+  }
+  const bytesFile = getFlag(args, "bytes-file");
+  if (!bytesFile) {
+    process.stderr.write("inplan asset-upload: usage: inplan asset-upload <file> --bytes-file <path> [--ext <ext>]\n");
+    process.exit(64);
+  }
+  const s = await authedSession();
+  if (!s) {
+    process.stderr.write("inplan: not logged in (or session expired) — run `inplan login`\n");
+    process.exit(1);
+  }
+  // The bucket's insert policy checks the path's org segment against `documents.org_id` itself
+  // (20260804000000_doc_images_bucket.sql), so this lookup doubles as the ownership check — an
+  // upload for a doc this session can't write to fails the RLS check with the wrong org anyway.
+  const { data: doc, error: docErr } = await s.db.from("documents").select("org_id").eq("id", status.cloudDocId).maybeSingle();
+  const orgId = (doc as { org_id?: string } | null)?.org_id;
+  if (docErr || !orgId) {
+    process.stderr.write(`inplan asset-upload: ${docErr?.message ?? "could not resolve the document's organization"}\n`);
+    process.exit(1);
+  }
+  const requestedExt = (getFlag(args, "ext") ?? "png").toLowerCase();
+  const bytes = readFileSync(bytesFile);
+  const relPath = await uploadAssetBytes(s.db, orgId, status.cloudDocId, bytes, requestedExt);
+  if (!relPath) {
+    process.stderr.write("inplan asset-upload: upload failed\n");
+    process.exit(1);
+  }
+  output({ status: "uploaded", relPath });
+}
+
+/** A Markdown image reference: `![alt](<dest>)` (the angle-bracket form the editor writes for
+ *  asset:save — needed because `<docname>.assets/…` can contain spaces) or the bare `![alt](dest)`
+ *  form (no unescaped whitespace/parens, which the bracket-less destination syntax can't carry). */
+const IMAGE_REF_RE = /!\[([^\]]*)\]\(\s*(?:<([^>]+)>|([^()\s]+))\s*\)/g;
+
+/** True for a relative path (not a URL) — mirrors the renderer's image-src resolver
+ *  (`markdown.ts`) so promote-time migration and live rendering agree on what counts as "local". */
+function isLocalRelativePath(dest: string): boolean {
+  return !/^[a-z][a-z0-9+.-]*:/i.test(dest) && !dest.startsWith("//") && !dest.startsWith("/");
+}
+
+/**
+ * Scan `body` for local relative image links, upload each referenced file (resolved against
+ * `docDir`) to the cloud `doc-images` bucket, and rewrite the links to the resulting public URLs.
+ * Run at promote time (`inplan upload`) so a doc pasted into while still local doesn't arrive in
+ * the cloud with links into a `.assets/` folder that has no counterpart there — otherwise the CLI
+ * command genuinely would be pointless, since nothing would ever call it for the images that
+ * matter most (the ones already in the doc when it's promoted). Best-effort per image: a missing
+ * file or a failed upload just leaves that one link untouched rather than losing the reference.
+ */
+async function migrateLocalImages(body: string, docDir: string, db: SupabaseClient, orgId: string, docId: string): Promise<{ body: string; migrated: number }> {
+  const replacements = new Map<string, string>(); // matched destination → new public URL
+  for (const m of body.matchAll(IMAGE_REF_RE)) {
+    const dest = m[2] ?? m[3] ?? "";
+    if (!dest || !isLocalRelativePath(dest) || replacements.has(dest)) continue;
+    const abs = resolve(docDir, dest);
+    if (!existsSync(abs)) continue; // already dangling — nothing to migrate
+    let bytes: Buffer;
+    try {
+      bytes = readFileSync(abs);
+    } catch {
+      continue;
+    }
+    const ext = extname(abs).slice(1).toLowerCase() || "png";
+    const url = await uploadAssetBytes(db, orgId, docId, bytes, ext);
+    if (url) replacements.set(dest, url);
+  }
+  if (replacements.size === 0) return { body, migrated: 0 };
+  const newBody = body.replace(IMAGE_REF_RE, (whole, _alt: string, bracketed?: string, bare?: string) => {
+    const url = replacements.get(bracketed ?? bare ?? "");
+    return url ? whole.replace(/\(\s*(?:<[^>]+>|[^()\s]+)\s*\)/, `(${url})`) : whole;
+  });
+  return { body: newBody, migrated: replacements.size };
 }
 
 /** `comment` (see ./commentAdd.ts) only knows how to rewrite a local file — reject it before
@@ -2041,7 +2185,7 @@ async function main(): Promise<void> {
       .filter(Boolean),
   );
 
-  if (!cmd || !["open", "wait", "signal", "message", "comment", "relay", "status", "promote", "demote", "upload"].includes(cmd)) {
+  if (!cmd || !["open", "wait", "signal", "message", "comment", "relay", "status", "promote", "demote", "upload", "asset-upload"].includes(cmd)) {
     process.stderr.write(
       "usage: inplan open  <file>   (create/open a local plan in the editor)\n" +
         "       inplan wait   <file|--remote DOC_ID> [--model NAME] [--cursor N] [--confirmed-comment-deletion=a,b] [--done] [--reload]\n" +
@@ -2053,6 +2197,7 @@ async function main(): Promise<void> {
         "       inplan upload  <file> [--org <slug>] [--repo <name>] [--path <p>] [--evict-lru]   (Collaborate on Cloud)\n" +
         "       inplan promote <file> --cloud-doc <docId> [--locator org/repo/path]\n" +
         "       inplan demote  <file> [--from-store]   (bring a cloud doc back to disk; --from-store accepts the server copy when the hub is unreadable)\n" +
+        "       inplan asset-upload <file> --bytes-file <path> [--ext <ext>]   (cloud doc: paste/pick an image straight to storage)\n" +
         "       inplan login   (opens the browser to sign in; or --url <url> --anon <key> --refresh <token> for scripts)\n" +
         "       inplan whoami | logout\n",
     );
@@ -2105,6 +2250,10 @@ async function main(): Promise<void> {
   }
   if (cmd === "demote") {
     await doDemote(file, args);
+    return;
+  }
+  if (cmd === "asset-upload") {
+    await doAssetUpload(file, args);
     return;
   }
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1938,16 +1938,25 @@ export async function doUpload(file: string, args: string[]): Promise<void> {
   // local⇄cloud reconcile check honest. Best-effort: a migration failure must not fail the promote
   // itself — the doc is already created; the human can always fall back to re-pasting the images
   // once collaborating in the cloud.
+  //
+  // Only for a brand-new row (out0.status === "created"): under the unified-Yjs model the collab
+  // hub is the SOLE writer of `documents.body` (materialized from the live CRDT) once a doc has
+  // ever been touched there. A freshly-created row has no hub session yet, so writing its body
+  // here is safe; re-running `upload` against an EXISTING doc (out0.status === "exists") must
+  // never do this write — it would race the hub and can silently clobber edits made in the cloud
+  // that this local file hasn't pulled (flagged in review: cubic-dev-ai + melly-lgtm on PR #91).
   let finalBody = body;
-  try {
-    const migrated = await migrateLocalImages(body, dirname(file), s.db, pick.org_id, cloudDocId);
-    if (migrated.migrated > 0) {
-      finalBody = migrated.body;
-      writeFileSync(file, finalBody);
-      await new SupabaseDocumentStore(s.db, cloudDocId).saveDoc(finalBody);
+  if (out0.status === "created") {
+    try {
+      const migrated = await migrateLocalImages(body, dirname(file), s.db, pick.org_id, cloudDocId);
+      if (migrated.migrated > 0) {
+        finalBody = migrated.body;
+        writeFileSync(file, finalBody);
+        await new SupabaseDocumentStore(s.db, cloudDocId).saveDoc(finalBody);
+      }
+    } catch (e) {
+      process.stderr.write(`inplan upload: image migration failed (${e instanceof Error ? e.message : String(e)}) — the doc uploaded, but its local images weren't moved to the cloud\n`);
     }
-  } catch (e) {
-    process.stderr.write(`inplan upload: image migration failed (${e instanceof Error ? e.message : String(e)}) — the doc uploaded, but its local images weren't moved to the cloud\n`);
   }
 
   const status: DocStatus = {
@@ -2103,9 +2112,13 @@ async function migrateLocalImages(body: string, docDir: string, db: SupabaseClie
     if (url) replacements.set(dest, url);
   }
   if (replacements.size === 0) return { body, migrated: 0 };
-  const newBody = body.replace(IMAGE_REF_RE, (whole, _alt: string, bracketed?: string, bare?: string) => {
+  // Rebuild from the captured groups rather than doing regex surgery on `whole`: alt text can
+  // itself contain parens (`![a (x) b](img.png)`), and a second "find the first (...)" pass over
+  // the whole match would rewrite the URL into the alt text's parens instead of the destination,
+  // corrupting the link and leaving the real destination still pointing at the local file.
+  const newBody = body.replace(IMAGE_REF_RE, (whole, alt: string, bracketed?: string, bare?: string) => {
     const url = replacements.get(bracketed ?? bare ?? "");
-    return url ? whole.replace(/\(\s*(?:<[^>]+>|[^()\s]+)\s*\)/, `(${url})`) : whole;
+    return url ? `![${alt}](${url})` : whole;
   });
   return { body: newBody, migrated: replacements.size };
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { execFileSync, spawn, spawnSync } from "node:child_process";
-import { createHash } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import { createRequire } from "node:module";
 import { appendFileSync, copyFileSync, existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
@@ -2002,8 +2002,15 @@ async function uploadAssetBytes(db: SupabaseClient, orgId: string, docId: string
   const safeExt = Object.prototype.hasOwnProperty.call(ASSET_MIME_BY_EXT, ext) ? ext : "png";
   const contentType = ASSET_MIME_BY_EXT[safeExt]!;
   const stamp = new Date().toISOString().replace(/[^0-9]/g, "").slice(0, 14); // YYYYMMDDHHMMSS
+  // An unguessable per-attempt suffix, not just a small counter: `stamp` only has 1s resolution,
+  // so a batch (migrateLocalImages promoting several pre-existing images at once) can easily put
+  // more than a handful of uploads in the same second — a fixed n<=5 counter-only name would run
+  // out of retries and silently strand the 7th+ image as a still-local, still-broken-in-the-cloud
+  // link (flagged in review: coderabbitai on PR #91). The loop remains only as a defensive
+  // fallback for the now-vanishingly-rare case of two random suffixes actually colliding.
   for (let n = 0; n <= 5; n++) {
-    const name = n === 0 ? `image-${stamp}.${safeExt}` : `image-${stamp}-${n}.${safeExt}`;
+    const suffix = randomBytes(4).toString("hex");
+    const name = `image-${stamp}-${suffix}.${safeExt}`;
     const path = `${orgId}/${docId}/${name}`;
     const { error } = await db.storage.from(ASSET_BUCKET).upload(path, bytes, { contentType });
     if (!error) return db.storage.from(ASSET_BUCKET).getPublicUrl(path).data.publicUrl;

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -2096,6 +2096,44 @@ function isLocalRelativePath(dest: string): boolean {
   return !/^[a-z][a-z0-9+.-]*:/i.test(dest) && !dest.startsWith("//") && !dest.startsWith("/");
 }
 
+/** `[start, end)` byte ranges of `body` that are inside a fenced code block (``` or ~~~, either
+ *  character repeated 3+ times to open, closed by a line starting with 3+ of the SAME character)
+ *  or an inline code span (`` `...` ``). An `![](...)` written as a documentation/example inside
+ *  either is a code sample, not a real asset reference, and must never be read off disk, uploaded,
+ *  or rewritten (flagged in review: cubic-dev-ai on PR #91). Not a full CommonMark parser — good
+ *  enough to keep migration from treating example text as real links. */
+function codeRanges(body: string): Array<[number, number]> {
+  const ranges: Array<[number, number]> = [];
+  const fenceRe = /^(`{3,}|~{3,})/;
+  let offset = 0;
+  let fenceChar: string | null = null;
+  let fenceLen = 0;
+  let fenceStart = 0;
+  for (const line of body.split("\n")) {
+    const m = fenceRe.exec(line.trimStart());
+    if (fenceChar) {
+      if (m && m[1]![0] === fenceChar && m[1]!.length >= fenceLen) {
+        ranges.push([fenceStart, offset + line.length]);
+        fenceChar = null;
+      }
+    } else if (m) {
+      fenceChar = m[1]![0]!;
+      fenceLen = m[1]!.length;
+      fenceStart = offset;
+    }
+    offset += line.length + 1; // + the \n split() consumed
+  }
+  if (fenceChar) ranges.push([fenceStart, body.length]); // an unterminated fence runs to EOF
+  // Inline spans, outside any fence already captured above — CommonMark's exact backtick-count
+  // matching isn't needed here, only "don't treat this as a real link".
+  for (const m of body.matchAll(/`[^`\n]*`/g)) ranges.push([m.index, m.index + m[0].length]);
+  return ranges;
+}
+
+function inRange(ranges: Array<[number, number]>, index: number): boolean {
+  return ranges.some(([start, end]) => index >= start && index < end);
+}
+
 /**
  * Scan `body` for local relative image links, upload each referenced file (resolved against
  * `docDir`) to the cloud `doc-images` bucket, and rewrite the links to the resulting public URLs.
@@ -2106,7 +2144,12 @@ function isLocalRelativePath(dest: string): boolean {
  * file or a failed upload just leaves that one link untouched rather than losing the reference.
  */
 async function migrateLocalImages(body: string, docDir: string, db: SupabaseClient, orgId: string, docId: string): Promise<{ body: string; migrated: number }> {
-  const replacements = new Map<string, string>(); // matched destination → new public URL
+  const excluded = codeRanges(body); // fenced/inline code — example text, never a real asset
+  // Matches to actually migrate, keyed by their position (not just their destination string) —
+  // position-keying is what lets the rewrite pass below leave a CODE EXAMPLE alone even when it
+  // happens to name the exact same path as a real, migrated image elsewhere in the doc.
+  const migrations = new Map<number, { dest: string; url: string }>();
+  const uploadedUrlByDest = new Map<string, string>(); // dest → url, so a repeated real ref reuses one upload
   // A doc body isn't trusted-solely-authored input (cloned repos, collaborators, agents write
   // it), so a crafted `../../.ssh/id_ed25519`-style link must not let this read a file outside
   // the doc's own directory and publish it to the (public) bucket. Resolve symlinks on the root
@@ -2121,7 +2164,12 @@ async function migrateLocalImages(body: string, docDir: string, db: SupabaseClie
   }
   for (const m of body.matchAll(IMAGE_REF_RE)) {
     const dest = m[2] ?? m[3] ?? "";
-    if (!dest || !isLocalRelativePath(dest) || replacements.has(dest)) continue;
+    if (!dest || inRange(excluded, m.index) || !isLocalRelativePath(dest)) continue;
+    const cached = uploadedUrlByDest.get(dest);
+    if (cached) {
+      migrations.set(m.index, { dest, url: cached });
+      continue;
+    }
     const abs = resolve(docDir, dest);
     if (!existsSync(abs)) continue; // already dangling — nothing to migrate
     // Containment: resolve symlinks on this side too, so a symlink that LOOKS like it's inside
@@ -2147,18 +2195,26 @@ async function migrateLocalImages(body: string, docDir: string, db: SupabaseClie
       continue;
     }
     const url = await uploadAssetBytes(db, orgId, docId, bytes, ext);
-    if (url) replacements.set(dest, url);
+    if (!url) continue;
+    uploadedUrlByDest.set(dest, url);
+    migrations.set(m.index, { dest, url });
   }
-  if (replacements.size === 0) return { body, migrated: 0 };
-  // Rebuild from the captured groups rather than doing regex surgery on `whole`: alt text can
-  // itself contain parens (`![a (x) b](img.png)`), and a second "find the first (...)" pass over
-  // the whole match would rewrite the URL into the alt text's parens instead of the destination,
-  // corrupting the link and leaving the real destination still pointing at the local file.
-  const newBody = body.replace(IMAGE_REF_RE, (whole, alt: string, bracketed?: string, bare?: string) => {
-    const url = replacements.get(bracketed ?? bare ?? "");
-    return url ? `![${alt}](${url})` : whole;
-  });
-  return { body: newBody, migrated: replacements.size };
+  if (migrations.size === 0) return { body, migrated: 0 };
+  // Rebuild by position rather than a global body.replace: alt text can itself contain parens
+  // (`![a (x) b](img.png)`), so regex surgery on the whole match would rewrite the URL into the
+  // alt text's parens instead of the destination; and a string-keyed replace would also rewrite a
+  // CODE EXAMPLE that happens to name the same path as a real migrated image. Walking the same
+  // matchAll positions used above keeps both cases correct.
+  let newBody = "";
+  let cursor = 0;
+  for (const m of body.matchAll(IMAGE_REF_RE)) {
+    const hit = migrations.get(m.index);
+    newBody += body.slice(cursor, m.index);
+    newBody += hit ? `![${m[1]}](${hit.url})` : m[0];
+    cursor = m.index + m[0].length;
+  }
+  newBody += body.slice(cursor);
+  return { body: newBody, migrated: migrations.size };
 }
 
 /** `comment` (see ./commentAdd.ts) only knows how to rewrite a local file — reject it before

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1950,9 +1950,16 @@ export async function doUpload(file: string, args: string[]): Promise<void> {
     try {
       const migrated = await migrateLocalImages(body, dirname(file), s.db, pick.org_id, cloudDocId);
       if (migrated.migrated > 0) {
+        // Cloud first, then local, then only NOW does `finalBody` (and so lastSyncedHash below)
+        // reflect the migrated body. If saveDoc throws, we never reach the local write or the
+        // reassignment — the local file and finalBody both stay at the ORIGINAL body, so the
+        // persisted hash always matches whatever the local file actually contains. The old
+        // local-first order could leave lastSyncedHash claiming sync (hash of the migrated body)
+        // while the cloud still held the pre-migration one, on nothing more than a failed cloud
+        // write (flagged in review: cubic-dev-ai + melly-lgtm on PR #91).
+        await new SupabaseDocumentStore(s.db, cloudDocId).saveDoc(migrated.body);
+        writeFileSync(file, migrated.body);
         finalBody = migrated.body;
-        writeFileSync(file, finalBody);
-        await new SupabaseDocumentStore(s.db, cloudDocId).saveDoc(finalBody);
       }
     } catch (e) {
       process.stderr.write(`inplan upload: image migration failed (${e instanceof Error ? e.message : String(e)}) — the doc uploaded, but its local images weren't moved to the cloud\n`);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -2060,18 +2060,45 @@ function isLocalRelativePath(dest: string): boolean {
  */
 async function migrateLocalImages(body: string, docDir: string, db: SupabaseClient, orgId: string, docId: string): Promise<{ body: string; migrated: number }> {
   const replacements = new Map<string, string>(); // matched destination → new public URL
+  // A doc body isn't trusted-solely-authored input (cloned repos, collaborators, agents write
+  // it), so a crafted `../../.ssh/id_ed25519`-style link must not let this read a file outside
+  // the doc's own directory and publish it to the (public) bucket. Resolve symlinks on the root
+  // once, up front — a missing docDir (shouldn't happen; the doc file itself was just read) means
+  // nothing here can be verified as contained, so no image gets migrated rather than trusting an
+  // unresolved path.
+  let docDirReal: string;
+  try {
+    docDirReal = realpathSync(docDir);
+  } catch {
+    return { body, migrated: 0 };
+  }
   for (const m of body.matchAll(IMAGE_REF_RE)) {
     const dest = m[2] ?? m[3] ?? "";
     if (!dest || !isLocalRelativePath(dest) || replacements.has(dest)) continue;
     const abs = resolve(docDir, dest);
     if (!existsSync(abs)) continue; // already dangling — nothing to migrate
+    // Containment: resolve symlinks on this side too, so a symlink that LOOKS like it's inside
+    // docDir can't point at a file outside it.
+    let absReal: string;
+    try {
+      absReal = realpathSync(abs);
+    } catch {
+      continue;
+    }
+    const rel = relative(docDirReal, absReal);
+    if (rel === "" || rel.startsWith("..") || isAbsolute(rel)) continue;
+    // Only a recognized image extension — never fall back to png here. Unlike the live-paste path
+    // (doAssetUpload), where the bytes are known to be an image the user just picked, this reads
+    // an arbitrary file off disk; an unrecognized extension is a reason to skip it, not to guess
+    // and publish it as one anyway.
+    const ext = extname(abs).slice(1).toLowerCase();
+    if (!Object.prototype.hasOwnProperty.call(ASSET_MIME_BY_EXT, ext)) continue;
     let bytes: Buffer;
     try {
       bytes = readFileSync(abs);
     } catch {
       continue;
     }
-    const ext = extname(abs).slice(1).toLowerCase() || "png";
     const url = await uploadAssetBytes(db, orgId, docId, bytes, ext);
     if (url) replacements.set(dest, url);
   }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1975,18 +1975,40 @@ export async function doUpload(file: string, args: string[]): Promise<void> {
         }
         if (!updatedRows || updatedRows.length === 0) {
           await cleanupOrphanedUploads(s.db, migrated.uploadedPaths);
-          throw new Error("the document changed in the cloud while migrating images (a live session attached first) — not overwriting it; re-run `inplan upload` to retry");
+          // A re-run of `upload` against this now-`created` doc resolves to `status: "exists"`,
+          // and the whole migration block above is gated to `status: "created"` only — so a retry
+          // cannot actually re-attempt this migration. Say what's actually true instead of
+          // promising a retry that doesn't happen (flagged in review: cubic-dev-ai on PR #91).
+          throw new Error(
+            "the document changed in the cloud while migrating images (a live session attached first) — not overwriting it; the local images were not migrated, re-paste them once you're collaborating on this doc in the cloud",
+          );
         }
         // The cloud write succeeded — a failure past this point is a DIFFERENT failure (the
         // images and the cloud body are already correct), so it must not be reported as "the
         // cloud write failed", and finalBody must reflect whatever actually ends up on disk
         // rather than what we merely intended to write (flagged in review: cubic-dev-ai on #91).
+        //
+        // `migrated.body` is derived from the `body` snapshot read at the very top of doUpload —
+        // before create_document, the baseline read, and every network upload. If the local file
+        // was edited during that window, writing the stale snapshot back would silently discard
+        // those edits. Compare against what's actually on disk right now and skip the write (the
+        // cloud copy already has the correct image links; only the local file needs reconciling)
+        // rather than clobbering unrelated changes (flagged in review: cubic-dev-ai on PR #91).
+        const onDiskNow = existsSync(file) ? readFileSync(file, "utf8") : null;
+        if (onDiskNow !== null && onDiskNow !== body) {
+          finalBody = onDiskNow;
+          throw new Error(
+            "the local file changed while migrating images, so it was left untouched to avoid discarding those edits — the cloud copy already has the migrated image links; open this doc in the editor to reconcile",
+          );
+        }
         try {
           writeFileSync(file, migrated.body);
           finalBody = migrated.body;
         } catch (e) {
           finalBody = existsSync(file) ? readFileSync(file, "utf8") : body;
-          throw new Error(`the cloud copy was updated, but writing it back to the local file failed (${e instanceof Error ? e.message : String(e)}) — re-run \`inplan upload\` to pull the migrated body back down locally`);
+          throw new Error(
+            `the cloud copy was updated, but writing it back to the local file failed (${e instanceof Error ? e.message : String(e)}) — the local file is now stale; open this doc in the editor (or re-run \`inplan wait\`) to pull the migrated body back down`,
+          );
         }
       }
     } catch (e) {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1969,8 +1969,12 @@ export async function doUpload(file: string, args: string[]): Promise<void> {
           .eq("id", cloudDocId)
           .eq("updated_at", baselineUpdatedAt)
           .select("id");
-        if (updateErr) throw new Error(`cloud write failed: ${updateErr.message}`);
+        if (updateErr) {
+          await cleanupOrphanedUploads(s.db, migrated.uploadedPaths);
+          throw new Error(`cloud write failed: ${updateErr.message}`);
+        }
         if (!updatedRows || updatedRows.length === 0) {
+          await cleanupOrphanedUploads(s.db, migrated.uploadedPaths);
           throw new Error("the document changed in the cloud while migrating images (a live session attached first) — not overwriting it; re-run `inplan upload` to retry");
         }
         // The cloud write succeeded — a failure past this point is a DIFFERENT failure (the
@@ -2018,9 +2022,10 @@ const ASSET_BUCKET = "doc-images";
 
 /** Upload one image's bytes to the `doc-images` bucket at `orgId/docId/image-<stamp>[-n].<ext>`,
  *  disambiguating on a name collision (409) — shared by `doAssetUpload` (a single live paste) and
- *  {@link migrateLocalImages} (a promote-time batch). Returns the public URL, or null on a real
+ *  {@link migrateLocalImages} (a promote-time batch). Returns the storage path (needed to clean up
+ *  an orphaned upload if the caller's body commit doesn't land) and public URL, or null on a real
  *  (non-collision) failure. */
-async function uploadAssetBytes(db: SupabaseClient, orgId: string, docId: string, bytes: Buffer, ext: string): Promise<string | null> {
+async function uploadAssetBytes(db: SupabaseClient, orgId: string, docId: string, bytes: Buffer, ext: string): Promise<{ path: string; url: string } | null> {
   // hasOwnProperty, not a truthy lookup — see the identical guard in the cloud web app's
   // saveAsset (ASSET_MIME_BY_EXT[ext] is truthy for inherited Object.prototype names too).
   const safeExt = Object.prototype.hasOwnProperty.call(ASSET_MIME_BY_EXT, ext) ? ext : "png";
@@ -2037,10 +2042,24 @@ async function uploadAssetBytes(db: SupabaseClient, orgId: string, docId: string
     const name = `image-${stamp}-${suffix}.${safeExt}`;
     const path = `${orgId}/${docId}/${name}`;
     const { error } = await db.storage.from(ASSET_BUCKET).upload(path, bytes, { contentType });
-    if (!error) return db.storage.from(ASSET_BUCKET).getPublicUrl(path).data.publicUrl;
+    if (!error) return { path, url: db.storage.from(ASSET_BUCKET).getPublicUrl(path).data.publicUrl };
     if (error.status !== 409) return null; // not a name collision — a real failure, don't retry
   }
   return null; // exhausted collision retries
+}
+
+/** Best-effort delete of images that {@link migrateLocalImages} already uploaded but whose body
+ *  commit didn't land (lost the CAS race, or the update itself failed) — otherwise they'd sit in
+ *  the bucket forever, unreferenced by any document (flagged in review: cubic-dev-ai on PR #91).
+ *  Never throws: this runs while already handling one failure, and a cleanup error here must not
+ *  mask or replace it — a stranded object is a much smaller problem than losing the real error. */
+async function cleanupOrphanedUploads(db: SupabaseClient, paths: string[]): Promise<void> {
+  if (paths.length === 0) return;
+  try {
+    await db.storage.from(ASSET_BUCKET).remove(paths);
+  } catch {
+    // best-effort — swallow
+  }
 }
 
 /**
@@ -2077,12 +2096,12 @@ export async function doAssetUpload(file: string, args: string[]): Promise<void>
   }
   const requestedExt = (getFlag(args, "ext") ?? "png").toLowerCase();
   const bytes = readFileSync(bytesFile);
-  const relPath = await uploadAssetBytes(s.db, orgId, status.cloudDocId, bytes, requestedExt);
-  if (!relPath) {
+  const uploaded = await uploadAssetBytes(s.db, orgId, status.cloudDocId, bytes, requestedExt);
+  if (!uploaded) {
     process.stderr.write("inplan asset-upload: upload failed\n");
     process.exit(1);
   }
-  output({ status: "uploaded", relPath });
+  output({ status: "uploaded", relPath: uploaded.url });
 }
 
 /** A Markdown image reference: `![alt](<dest>)` (the angle-bracket form the editor writes for
@@ -2143,13 +2162,20 @@ function inRange(ranges: Array<[number, number]>, index: number): boolean {
  * matter most (the ones already in the doc when it's promoted). Best-effort per image: a missing
  * file or a failed upload just leaves that one link untouched rather than losing the reference.
  */
-async function migrateLocalImages(body: string, docDir: string, db: SupabaseClient, orgId: string, docId: string): Promise<{ body: string; migrated: number }> {
+async function migrateLocalImages(
+  body: string,
+  docDir: string,
+  db: SupabaseClient,
+  orgId: string,
+  docId: string,
+): Promise<{ body: string; migrated: number; uploadedPaths: string[] }> {
   const excluded = codeRanges(body); // fenced/inline code — example text, never a real asset
   // Matches to actually migrate, keyed by their position (not just their destination string) —
   // position-keying is what lets the rewrite pass below leave a CODE EXAMPLE alone even when it
   // happens to name the exact same path as a real, migrated image elsewhere in the doc.
   const migrations = new Map<number, { dest: string; url: string }>();
-  const uploadedUrlByDest = new Map<string, string>(); // dest → url, so a repeated real ref reuses one upload
+  const uploadedByDest = new Map<string, { path: string; url: string }>(); // dest → upload, so a repeated real ref reuses one
+  const uploadedPaths: string[] = []; // every bucket object actually created — the caller cleans these up on a failed body commit
   // A doc body isn't trusted-solely-authored input (cloned repos, collaborators, agents write
   // it), so a crafted `../../.ssh/id_ed25519`-style link must not let this read a file outside
   // the doc's own directory and publish it to the (public) bucket. Resolve symlinks on the root
@@ -2160,14 +2186,14 @@ async function migrateLocalImages(body: string, docDir: string, db: SupabaseClie
   try {
     docDirReal = realpathSync(docDir);
   } catch {
-    return { body, migrated: 0 };
+    return { body, migrated: 0, uploadedPaths };
   }
   for (const m of body.matchAll(IMAGE_REF_RE)) {
     const dest = m[2] ?? m[3] ?? "";
     if (!dest || inRange(excluded, m.index) || !isLocalRelativePath(dest)) continue;
-    const cached = uploadedUrlByDest.get(dest);
+    const cached = uploadedByDest.get(dest);
     if (cached) {
-      migrations.set(m.index, { dest, url: cached });
+      migrations.set(m.index, { dest, url: cached.url });
       continue;
     }
     const abs = resolve(docDir, dest);
@@ -2194,12 +2220,13 @@ async function migrateLocalImages(body: string, docDir: string, db: SupabaseClie
     } catch {
       continue;
     }
-    const url = await uploadAssetBytes(db, orgId, docId, bytes, ext);
-    if (!url) continue;
-    uploadedUrlByDest.set(dest, url);
-    migrations.set(m.index, { dest, url });
+    const uploaded = await uploadAssetBytes(db, orgId, docId, bytes, ext);
+    if (!uploaded) continue;
+    uploadedByDest.set(dest, uploaded);
+    uploadedPaths.push(uploaded.path);
+    migrations.set(m.index, { dest, url: uploaded.url });
   }
-  if (migrations.size === 0) return { body, migrated: 0 };
+  if (migrations.size === 0) return { body, migrated: 0, uploadedPaths };
   // Rebuild by position rather than a global body.replace: alt text can itself contain parens
   // (`![a (x) b](img.png)`), so regex surgery on the whole match would rewrite the URL into the
   // alt text's parens instead of the destination; and a string-keyed replace would also rewrite a
@@ -2214,7 +2241,7 @@ async function migrateLocalImages(body: string, docDir: string, db: SupabaseClie
     cursor = m.index + m[0].length;
   }
   newBody += body.slice(cursor);
-  return { body: newBody, migrated: migrations.size };
+  return { body: newBody, migrated: migrations.size, uploadedPaths };
 }
 
 /** `comment` (see ./commentAdd.ts) only knows how to rewrite a local file — reject it before

--- a/packages/cli/test/assetUpload.test.ts
+++ b/packages/cli/test/assetUpload.test.ts
@@ -99,7 +99,7 @@ describe("inplan asset-upload → doc-images bucket", () => {
     await doAssetUpload(file, ["--bytes-file", bytesFile, "--ext", "png"]);
     expect(upload).toHaveBeenCalledTimes(1);
     const [path, , opts] = upload.mock.calls[0]!;
-    expect(path).toMatch(/^org-1\/doc-9\/image-\d{14}\.png$/);
+    expect(path).toMatch(/^org-1\/doc-9\/image-\d{14}-[0-9a-f]{8}\.png$/);
     expect(opts).toEqual({ contentType: "image/png" });
     expect(lastJson()).toEqual({ status: "uploaded", relPath: `https://cdn.test/doc-images/${path}` });
   });
@@ -117,7 +117,10 @@ describe("inplan asset-upload → doc-images bucket", () => {
     upload.mockImplementationOnce(async () => ({ error: { status: 409, message: "duplicate" } })).mockImplementationOnce(async () => ({ error: null }));
     await doAssetUpload(file, ["--bytes-file", bytesFile, "--ext", "png"]);
     expect(upload).toHaveBeenCalledTimes(2);
-    expect(upload.mock.calls[1]![0]).toMatch(/-1\.png$/); // second attempt's disambiguated name
+    // Each attempt carries its own unguessable suffix (not a sequential counter), so a retry
+    // after a collision lands on a genuinely different path rather than a predictable "-1".
+    expect(upload.mock.calls[1]![0]).toMatch(/^org-1\/doc-9\/image-\d{14}-[0-9a-f]{8}\.png$/);
+    expect(upload.mock.calls[1]![0]).not.toBe(upload.mock.calls[0]![0]);
     expect(lastJson()).toMatchObject({ status: "uploaded" });
   });
 

--- a/packages/cli/test/assetUpload.test.ts
+++ b/packages/cli/test/assetUpload.test.ts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// `inplan asset-upload` is what the desktop app shells out to when it's live-connected to a
+// cloud doc (Collaborate on Cloud): it reads bytes from a temp file, resolves the doc's org via
+// the `documents` table, and uploads to the `doc-images` bucket — mirroring the cloud web app's
+// own saveAsset (same bucket, same org/doc path scheme, same 409-collision retry). Covers a
+// non-cloud doc, a missing --bytes-file, a logged-out session, a normal upload, a collision retry,
+// a hard storage failure, and the unknown-extension → png fallback — all over a mocked authed
+// session, no network.
+
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { docPaths, writeStatus } from "@inplan/core/node";
+
+let uploadResult: { error: { status: number; message: string } | null } = { error: null };
+let orgLookup: { data: unknown; error: unknown } = { data: { org_id: "org-1" }, error: null };
+let sessionPresent = true;
+const upload = vi.fn(async (_path: string, _bytes: unknown, _opts: unknown) => uploadResult);
+const getPublicUrl = vi.fn((path: string) => ({ data: { publicUrl: `https://cdn.test/doc-images/${path}` } }));
+
+function fakeDb() {
+  const q: Record<string, unknown> = {};
+  q.select = () => q;
+  q.eq = () => q;
+  q.maybeSingle = () => Promise.resolve(orgLookup);
+  return {
+    from: () => q,
+    storage: { from: () => ({ upload, getPublicUrl }) },
+  };
+}
+
+vi.mock("../src/cliAuth", () => ({
+  authedSession: vi.fn(async () => (sessionPresent ? { db: fakeDb(), session: { user: { id: "user-1" } } } : null)),
+}));
+
+import { doAssetUpload } from "../src/cli";
+
+let home: string;
+let file: string;
+let bytesFile: string;
+let out: string[];
+let exitCode: number | null;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "inplan-asset-upload-"));
+  process.env.INPLAN_SIDECAR_DIR = join(home, "sidecars");
+  file = join(home, "PLAN.md");
+  writeFileSync(file, "# My Plan\n\nbody\n");
+  bytesFile = join(home, "bytes.bin");
+  writeFileSync(bytesFile, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+  out = [];
+  exitCode = null;
+  vi.spyOn(process.stdout, "write").mockImplementation((s: string | Uint8Array) => {
+    out.push(String(s));
+    return true;
+  });
+  vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+    exitCode = code ?? 0;
+    throw new Error(`exit:${code}`); // halt the flow like the real process.exit
+  }) as never);
+  upload.mockClear();
+  getPublicUrl.mockClear();
+  uploadResult = { error: null };
+  orgLookup = { data: { org_id: "org-1" }, error: null };
+  sessionPresent = true;
+});
+afterEach(() => {
+  delete process.env.INPLAN_SIDECAR_DIR;
+  vi.restoreAllMocks();
+});
+
+const lastJson = () => JSON.parse(out.join("").trim().split("\n").pop()!);
+
+describe("inplan asset-upload → doc-images bucket", () => {
+  it("rejects a doc that isn't cloud-connected", async () => {
+    await expect(doAssetUpload(file, ["--bytes-file", bytesFile])).rejects.toThrow(/exit:1/);
+    expect(exitCode).toBe(1);
+    expect(upload).not.toHaveBeenCalled();
+  });
+
+  it("rejects a missing --bytes-file", async () => {
+    writeStatus(docPaths(file).statusPath, { location: "cloud", cloudDocId: "doc-9" });
+    await expect(doAssetUpload(file, [])).rejects.toThrow(/exit:64/);
+    expect(exitCode).toBe(64);
+  });
+
+  it("exits when not logged in", async () => {
+    writeStatus(docPaths(file).statusPath, { location: "cloud", cloudDocId: "doc-9" });
+    sessionPresent = false;
+    await expect(doAssetUpload(file, ["--bytes-file", bytesFile])).rejects.toThrow(/exit:1/);
+    expect(exitCode).toBe(1);
+  });
+
+  it("uploads to org/doc-scoped path and reports the public URL", async () => {
+    writeStatus(docPaths(file).statusPath, { location: "cloud", cloudDocId: "doc-9" });
+    await doAssetUpload(file, ["--bytes-file", bytesFile, "--ext", "png"]);
+    expect(upload).toHaveBeenCalledTimes(1);
+    const [path, , opts] = upload.mock.calls[0]!;
+    expect(path).toMatch(/^org-1\/doc-9\/image-\d{14}\.png$/);
+    expect(opts).toEqual({ contentType: "image/png" });
+    expect(lastJson()).toEqual({ status: "uploaded", relPath: `https://cdn.test/doc-images/${path}` });
+  });
+
+  it("falls back to png for an unrecognized extension", async () => {
+    writeStatus(docPaths(file).statusPath, { location: "cloud", cloudDocId: "doc-9" });
+    await doAssetUpload(file, ["--bytes-file", bytesFile, "--ext", "bmp"]);
+    const [path, , opts] = upload.mock.calls[0]!;
+    expect(path).toMatch(/\.png$/);
+    expect(opts).toEqual({ contentType: "image/png" });
+  });
+
+  it("retries past a name collision (409) then succeeds", async () => {
+    writeStatus(docPaths(file).statusPath, { location: "cloud", cloudDocId: "doc-9" });
+    upload.mockImplementationOnce(async () => ({ error: { status: 409, message: "duplicate" } })).mockImplementationOnce(async () => ({ error: null }));
+    await doAssetUpload(file, ["--bytes-file", bytesFile, "--ext", "png"]);
+    expect(upload).toHaveBeenCalledTimes(2);
+    expect(upload.mock.calls[1]![0]).toMatch(/-1\.png$/); // second attempt's disambiguated name
+    expect(lastJson()).toMatchObject({ status: "uploaded" });
+  });
+
+  it("exits non-zero on a hard storage failure (not a collision)", async () => {
+    writeStatus(docPaths(file).statusPath, { location: "cloud", cloudDocId: "doc-9" });
+    uploadResult = { error: { status: 403, message: "forbidden" } };
+    await expect(doAssetUpload(file, ["--bytes-file", bytesFile])).rejects.toThrow(/exit:1/);
+    expect(exitCode).toBe(1);
+    expect(upload).toHaveBeenCalledTimes(1); // no retry on a real failure
+    expect(out.join("")).not.toContain("uploaded");
+  });
+
+  it("exits when the document's org can't be resolved", async () => {
+    writeStatus(docPaths(file).statusPath, { location: "cloud", cloudDocId: "doc-9" });
+    orgLookup = { data: null, error: { message: "not found" } };
+    await expect(doAssetUpload(file, ["--bytes-file", bytesFile])).rejects.toThrow(/exit:1/);
+    expect(exitCode).toBe(1);
+    expect(upload).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/test/uploadImageMigration.test.ts
+++ b/packages/cli/test/uploadImageMigration.test.ts
@@ -318,4 +318,48 @@ describe("inplan upload → local image migration", () => {
     const rewritten = readFileSync(file, "utf8");
     expect(rewritten).not.toContain("PLAN.assets"); // none left dangling locally
   });
+
+  it("never uploads or rewrites an image reference inside a fenced code block", async () => {
+    mkdirSync(join(home, "PLAN.assets"), { recursive: true });
+    writeFileSync(join(home, "PLAN.assets", "image-1.png"), Buffer.from([1, 2, 3]));
+    const original = "# My Plan\n\nHow to embed an image:\n\n```markdown\n![](<PLAN.assets/image-1.png>)\n```\n";
+    writeFileSync(file, original);
+
+    await doUpload(file, []);
+
+    expect(upload).not.toHaveBeenCalled();
+    expect(readFileSync(file, "utf8")).toBe(original);
+  });
+
+  it("never uploads or rewrites an image reference inside inline code", async () => {
+    mkdirSync(join(home, "PLAN.assets"), { recursive: true });
+    writeFileSync(join(home, "PLAN.assets", "image-1.png"), Buffer.from([1, 2, 3]));
+    const original = "# My Plan\n\nWrite it as `![](<PLAN.assets/image-1.png>)` in your doc.\n";
+    writeFileSync(file, original);
+
+    await doUpload(file, []);
+
+    expect(upload).not.toHaveBeenCalled();
+    expect(readFileSync(file, "utf8")).toBe(original);
+  });
+
+  it("migrates a real image but leaves a code example naming the exact same path alone", async () => {
+    mkdirSync(join(home, "PLAN.assets"), { recursive: true });
+    writeFileSync(join(home, "PLAN.assets", "image-1.png"), Buffer.from([1, 2, 3]));
+    writeFileSync(
+      file,
+      "# My Plan\n\n" +
+        "![](<PLAN.assets/image-1.png>)\n\n" +
+        "Written as: `![](<PLAN.assets/image-1.png>)`\n",
+    );
+
+    await doUpload(file, []);
+
+    expect(upload).toHaveBeenCalledTimes(1); // only the real reference triggers an upload
+    const [path] = upload.mock.calls[0]!;
+    const url = `https://cdn.test/doc-images/${path}`;
+    const rewritten = readFileSync(file, "utf8");
+    expect(rewritten).toContain(`![](${url})`); // the real reference is rewritten
+    expect(rewritten).toContain("`![](<PLAN.assets/image-1.png>)`"); // the code example is untouched
+  });
 });

--- a/packages/cli/test/uploadImageMigration.test.ts
+++ b/packages/cli/test/uploadImageMigration.test.ts
@@ -20,7 +20,8 @@ const rpc = vi.fn(async (_name: string, _params: Record<string, unknown>) => rpc
 let uploadResult: { error: { status: number; message: string } | null } = { error: null };
 const upload = vi.fn(async (_path: string, _bytes: unknown, _opts: unknown) => uploadResult);
 const getPublicUrl = vi.fn((path: string) => ({ data: { publicUrl: `https://cdn.test/doc-images/${path}` } }));
-const update = vi.fn((_patch: Record<string, unknown>) => ({ eq: () => Promise.resolve({ error: null }) }));
+let updateError: { message: string } | null = null;
+const update = vi.fn((_patch: Record<string, unknown>) => ({ eq: () => Promise.resolve({ error: updateError }) }));
 
 function fakeDb() {
   const membershipsQ: Record<string, unknown> = {};
@@ -82,6 +83,7 @@ beforeEach(() => {
   memberships = { data: [{ org_id: "org-1", orgs: { slug: "acme", name: "Acme" } }], error: null };
   uploadResult = { error: null };
   existingDocId = null;
+  updateError = null;
 });
 afterEach(() => {
   delete process.env.INPLAN_SIDECAR_DIR;
@@ -198,5 +200,22 @@ describe("inplan upload → local image migration", () => {
     expect(update).not.toHaveBeenCalled();
     expect(readFileSync(file, "utf8")).toContain("PLAN.assets/image-1.png"); // left as-is, not "fixed"
     expect(lastJson()).toMatchObject({ status: "uploaded", cloudDocId: "doc-existing" });
+  });
+
+  it("leaves the local file untouched when the cloud write fails, so lastSyncedHash never lies", async () => {
+    mkdirSync(join(home, "PLAN.assets"), { recursive: true });
+    writeFileSync(join(home, "PLAN.assets", "image-1.png"), Buffer.from([1, 2, 3]));
+    const original = "# My Plan\n\n![](<PLAN.assets/image-1.png>)\n";
+    writeFileSync(file, original);
+    updateError = { message: "boom" }; // the image uploads fine; the cloud body write fails
+
+    await doUpload(file, []);
+
+    expect(upload).toHaveBeenCalledTimes(1); // the image itself did upload
+    expect(update).toHaveBeenCalledTimes(1); // the cloud write was attempted (and failed)
+    // Cloud-first ordering: since the cloud write failed, the local file must NOT have been
+    // rewritten either — otherwise lastSyncedHash (computed from whatever's now on disk) would
+    // match a body the cloud never actually received.
+    expect(readFileSync(file, "utf8")).toBe(original);
   });
 });

--- a/packages/cli/test/uploadImageMigration.test.ts
+++ b/packages/cli/test/uploadImageMigration.test.ts
@@ -20,18 +20,40 @@ const rpc = vi.fn(async (_name: string, _params: Record<string, unknown>) => rpc
 let uploadResult: { error: { status: number; message: string } | null } = { error: null };
 const upload = vi.fn(async (_path: string, _bytes: unknown, _opts: unknown) => uploadResult);
 const getPublicUrl = vi.fn((path: string) => ({ data: { publicUrl: `https://cdn.test/doc-images/${path}` } }));
+
+// The optimistic-concurrency write: `.update(patch).eq("id", …).eq("updated_at", baseline).select("id")`.
+// `updateMatches` simulates whether the CAS condition matched (true = nobody else touched the row
+// since the baseline read; false = something changed the row first — the "lost the race" case).
 let updateError: { message: string } | null = null;
-const update = vi.fn((_patch: Record<string, unknown>) => ({ eq: () => Promise.resolve({ error: updateError }) }));
+let updateMatches = true;
+const update = vi.fn((_patch: Record<string, unknown>) => {
+  const chain = {
+    eq: vi.fn(() => chain),
+    select: vi.fn(() => Promise.resolve(updateError ? { data: null, error: updateError } : { data: updateMatches ? [{ id: "doc-new" }] : [], error: null })),
+  };
+  return chain;
+});
+
+// The baseline `updated_at` read right after create_document — the value the CAS write above
+// conditions on.
+let baselineUpdatedAt = "2026-01-01T00:00:00.000Z";
 
 function fakeDb() {
   const membershipsQ: Record<string, unknown> = {};
   membershipsQ.select = () => membershipsQ;
   membershipsQ.in = () => Promise.resolve(memberships);
 
+  let lastSelectCols = "";
   const documentsQ: Record<string, unknown> = {};
-  documentsQ.select = () => documentsQ;
+  documentsQ.select = (cols: string) => {
+    lastSelectCols = cols;
+    return documentsQ;
+  };
   documentsQ.eq = () => documentsQ;
-  documentsQ.maybeSingle = () => Promise.resolve({ data: existingDocId ? { id: existingDocId } : null, error: null });
+  documentsQ.maybeSingle = () =>
+    Promise.resolve(
+      lastSelectCols === "updated_at" ? { data: { updated_at: baselineUpdatedAt }, error: null } : { data: existingDocId ? { id: existingDocId } : null, error: null },
+    );
   documentsQ.update = update;
 
   return {
@@ -47,6 +69,25 @@ vi.mock("../src/cliAuth", () => ({
 vi.mock("../src/provenance", () => ({
   gitProvenance: () => ({ repo: "acme/plan", path: "docs/PLAN.md" }),
 }));
+
+// Lets exactly one test simulate the LOCAL file write failing (disk full, permissions, …) right
+// after the cloud write already succeeded — a real `writeFileSync` failure mode that's otherwise
+// impractical to trigger from a test. Passes through to the real implementation for every other
+// call (including this file's own test-setup writes), so it's a no-op unless armed.
+const fsFailure = vi.hoisted(() => ({ path: null as string | null }));
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    writeFileSync: (path: unknown, ...rest: unknown[]) => {
+      if (fsFailure.path && path === fsFailure.path) {
+        fsFailure.path = null; // one-shot
+        throw new Error("disk full");
+      }
+      return (actual.writeFileSync as (...a: unknown[]) => void)(path, ...rest);
+    },
+  };
+});
 
 import { doUpload } from "../src/cli";
 
@@ -84,6 +125,9 @@ beforeEach(() => {
   uploadResult = { error: null };
   existingDocId = null;
   updateError = null;
+  updateMatches = true;
+  baselineUpdatedAt = "2026-01-01T00:00:00.000Z";
+  fsFailure.path = null;
 });
 afterEach(() => {
   delete process.env.INPLAN_SIDECAR_DIR;
@@ -216,6 +260,40 @@ describe("inplan upload → local image migration", () => {
     // Cloud-first ordering: since the cloud write failed, the local file must NOT have been
     // rewritten either — otherwise lastSyncedHash (computed from whatever's now on disk) would
     // match a body the cloud never actually received.
+    expect(readFileSync(file, "utf8")).toBe(original);
+  });
+
+  it("does not overwrite the cloud body when it changed since the baseline read (lost the CAS race)", async () => {
+    mkdirSync(join(home, "PLAN.assets"), { recursive: true });
+    writeFileSync(join(home, "PLAN.assets", "image-1.png"), Buffer.from([1, 2, 3]));
+    const original = "# My Plan\n\n![](<PLAN.assets/image-1.png>)\n";
+    writeFileSync(file, original);
+    // Simulate the collab hub attaching and writing the row between our baseline read and our
+    // conditional UPDATE: the CAS `.eq("updated_at", baseline)` matches zero rows.
+    updateMatches = false;
+
+    await doUpload(file, []);
+
+    expect(upload).toHaveBeenCalledTimes(1); // the image itself still uploads fine
+    expect(update).toHaveBeenCalledTimes(1); // the conditional write was attempted
+    // Lost the race: must not claim success by touching the local file or the hash.
+    expect(readFileSync(file, "utf8")).toBe(original);
+    expect(lastJson()).toMatchObject({ status: "uploaded" }); // the promote itself still succeeded
+  });
+
+  it("re-reads whatever's actually on disk when the cloud write succeeds but the local write fails", async () => {
+    mkdirSync(join(home, "PLAN.assets"), { recursive: true });
+    writeFileSync(join(home, "PLAN.assets", "image-1.png"), Buffer.from([1, 2, 3]));
+    const original = "# My Plan\n\n![](<PLAN.assets/image-1.png>)\n";
+    writeFileSync(file, original);
+    fsFailure.path = file; // the cloud write succeeds; writing the migrated body back locally fails
+
+    await doUpload(file, []);
+
+    expect(update).toHaveBeenCalledTimes(1); // the cloud DID get the migrated body
+    // The local file was never actually rewritten (the write threw), so it must still read as the
+    // original — proving finalBody was re-derived from the real file content, not just assumed to
+    // be the migrated body because the write was "supposed to" succeed.
     expect(readFileSync(file, "utf8")).toBe(original);
   });
 

--- a/packages/cli/test/uploadImageMigration.test.ts
+++ b/packages/cli/test/uploadImageMigration.test.ts
@@ -21,6 +21,9 @@ const rpc = vi.fn(async (_name: string, _params: Record<string, unknown>) => rpc
 let uploadResult: { error: { status: number; message: string } | null } = { error: null };
 const upload = vi.fn(async (_path: string, _bytes: unknown, _opts: unknown) => uploadResult);
 const getPublicUrl = vi.fn((path: string) => ({ data: { publicUrl: `https://cdn.test/doc-images/${path}` } }));
+// Cleanup for images uploaded but then orphaned by a body commit that didn't land (lost the CAS
+// race, or the update itself errored) — asserted directly in those two tests below.
+const remove = vi.fn(async (_paths: string[]) => ({ data: null, error: null }));
 
 // The optimistic-concurrency write: `.update(patch).eq("id", …).eq("updated_at", baseline).select("id")`.
 // `updateMatches` simulates whether the CAS condition matched (true = nobody else touched the row
@@ -68,7 +71,7 @@ function fakeDb() {
   return {
     from: (table: string) => (table === "memberships" ? membershipsQ : documentsQ),
     rpc,
-    storage: { from: () => ({ upload, getPublicUrl }) },
+    storage: { from: () => ({ upload, getPublicUrl, remove }) },
   };
 }
 
@@ -129,6 +132,7 @@ beforeEach(() => {
   upload.mockClear();
   getPublicUrl.mockClear();
   update.mockClear();
+  remove.mockClear();
   rpcResult = { data: { status: "created", id: "doc-new" }, error: null };
   memberships = { data: [{ org_id: "org-1", orgs: { slug: "acme", name: "Acme" } }], error: null };
   uploadResult = { error: null };
@@ -273,6 +277,10 @@ describe("inplan upload → local image migration", () => {
     // match a body the cloud never actually received.
     expect(readFileSync(file, "utf8")).toBe(original);
     expect(lastSyncedHash()).toBe(hashBody(original));
+    // The body commit never landed, so the image that already made it into the bucket is now
+    // unreferenced by any document — it must be cleaned up rather than left stranded there.
+    const [uploadedPath] = upload.mock.calls[0]!;
+    expect(remove).toHaveBeenCalledWith([uploadedPath]);
   });
 
   it("does not overwrite the cloud body when it changed since the baseline read (lost the CAS race)", async () => {
@@ -298,6 +306,10 @@ describe("inplan upload → local image migration", () => {
     expect(readFileSync(file, "utf8")).toBe(original);
     expect(lastSyncedHash()).toBe(hashBody(original));
     expect(lastJson()).toMatchObject({ status: "uploaded" }); // the promote itself still succeeded
+    // The image already made it into the bucket before the race was lost — it's now unreferenced
+    // by any document (the winning writer's body doesn't know about it) and must be cleaned up.
+    const [uploadedPath] = upload.mock.calls[0]!;
+    expect(remove).toHaveBeenCalledWith([uploadedPath]);
   });
 
   it("re-reads whatever's actually on disk when the cloud write succeeds but the local write fails", async () => {
@@ -315,6 +327,9 @@ describe("inplan upload → local image migration", () => {
     // be the migrated body because the write was "supposed to" succeed.
     expect(readFileSync(file, "utf8")).toBe(original);
     expect(lastSyncedHash()).toBe(hashBody(original));
+    // The cloud write DID succeed here — the image is correctly referenced by the cloud body, so
+    // it must not be cleaned up (only the local file, not the upload, is what's stale).
+    expect(remove).not.toHaveBeenCalled();
   });
 
   it("migrates more than 6 same-second images without exhausting the retry budget", async () => {

--- a/packages/cli/test/uploadImageMigration.test.ts
+++ b/packages/cli/test/uploadImageMigration.test.ts
@@ -15,6 +15,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 let rpcResult: { data: unknown; error: unknown } = { data: { status: "created", id: "doc-new" }, error: null };
 let memberships: { data: unknown; error: unknown } = { data: [{ org_id: "org-1", orgs: { slug: "acme", name: "Acme" } }], error: null };
+let existingDocId: string | null = null; // the "exists" (re-upload) path's lookup result
 const rpc = vi.fn(async (_name: string, _params: Record<string, unknown>) => rpcResult);
 let uploadResult: { error: { status: number; message: string } | null } = { error: null };
 const upload = vi.fn(async (_path: string, _bytes: unknown, _opts: unknown) => uploadResult);
@@ -29,7 +30,7 @@ function fakeDb() {
   const documentsQ: Record<string, unknown> = {};
   documentsQ.select = () => documentsQ;
   documentsQ.eq = () => documentsQ;
-  documentsQ.maybeSingle = () => Promise.resolve({ data: null, error: null });
+  documentsQ.maybeSingle = () => Promise.resolve({ data: existingDocId ? { id: existingDocId } : null, error: null });
   documentsQ.update = update;
 
   return {
@@ -80,6 +81,7 @@ beforeEach(() => {
   rpcResult = { data: { status: "created", id: "doc-new" }, error: null };
   memberships = { data: [{ org_id: "org-1", orgs: { slug: "acme", name: "Acme" } }], error: null };
   uploadResult = { error: null };
+  existingDocId = null;
 });
 afterEach(() => {
   delete process.env.INPLAN_SIDECAR_DIR;
@@ -165,5 +167,36 @@ describe("inplan upload → local image migration", () => {
     await doUpload(file, []);
     expect(upload).not.toHaveBeenCalled();
     expect(readFileSync(file, "utf8")).toContain("PLAN.assets/id_ed25519");
+  });
+
+  it("rewrites the URL, not parenthesized alt text, into the link", async () => {
+    mkdirSync(join(home, "PLAN.assets"), { recursive: true });
+    writeFileSync(join(home, "PLAN.assets", "image-1.png"), Buffer.from([1, 2, 3]));
+    writeFileSync(file, "# My Plan\n\n![a (x) b](<PLAN.assets/image-1.png>)\n");
+
+    await doUpload(file, []);
+
+    const [path] = upload.mock.calls[0]!;
+    const url = `https://cdn.test/doc-images/${path}`;
+    const rewritten = readFileSync(file, "utf8");
+    expect(rewritten).toContain(`![a (x) b](${url})`); // alt text preserved verbatim, destination replaced
+    expect(rewritten).not.toContain("PLAN.assets"); // the real destination didn't stay local
+  });
+
+  it("never writes documents.body on a re-upload of an already-existing doc, even with a local image", async () => {
+    mkdirSync(join(home, "PLAN.assets"), { recursive: true });
+    writeFileSync(join(home, "PLAN.assets", "image-1.png"), Buffer.from([1, 2, 3]));
+    writeFileSync(file, "# My Plan\n\n![](<PLAN.assets/image-1.png>)\n");
+    rpcResult = { data: { status: "exists" }, error: null };
+    existingDocId = "doc-existing";
+
+    await doUpload(file, []);
+
+    // Under the unified-Yjs model the collab hub is the sole writer of documents.body once a doc
+    // exists — migrating (and so writing the body) here would race it and can clobber live edits.
+    expect(upload).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+    expect(readFileSync(file, "utf8")).toContain("PLAN.assets/image-1.png"); // left as-is, not "fixed"
+    expect(lastJson()).toMatchObject({ status: "uploaded", cloudDocId: "doc-existing" });
   });
 });

--- a/packages/cli/test/uploadImageMigration.test.ts
+++ b/packages/cli/test/uploadImageMigration.test.ts
@@ -312,6 +312,30 @@ describe("inplan upload → local image migration", () => {
     expect(remove).toHaveBeenCalledWith([uploadedPath]);
   });
 
+  it("does not clobber a local edit made while the migration was in flight, even though the cloud write succeeded", async () => {
+    mkdirSync(join(home, "PLAN.assets"), { recursive: true });
+    writeFileSync(join(home, "PLAN.assets", "image-1.png"), Buffer.from([1, 2, 3]));
+    const original = "# My Plan\n\n![](<PLAN.assets/image-1.png>)\n";
+    writeFileSync(file, original);
+    const editedLocally = "# My Plan (edited while uploading)\n\n![](<PLAN.assets/image-1.png>)\n";
+    // Simulate a human editing the file during the network round-trip (between the `body` snapshot
+    // doUpload started from and the write-back below) — the upload call is the last async hop
+    // before that write-back, so mutating the file here reproduces the race window.
+    upload.mockImplementationOnce(async () => {
+      writeFileSync(file, editedLocally);
+      return uploadResult;
+    });
+
+    await doUpload(file, []);
+
+    expect(update).toHaveBeenCalledTimes(1); // the cloud DID get the migrated body — it's correct
+    // The stale, snapshot-derived migrated body must NOT overwrite the newer local edit.
+    expect(readFileSync(file, "utf8")).toBe(editedLocally);
+    // lastSyncedHash reflects what's actually on disk (the edit), not the migrated snapshot that
+    // was never written — otherwise the next reconcile check would wrongly believe they match.
+    expect(lastSyncedHash()).toBe(hashBody(editedLocally));
+  });
+
   it("re-reads whatever's actually on disk when the cloud write succeeds but the local write fails", async () => {
     mkdirSync(join(home, "PLAN.assets"), { recursive: true });
     writeFileSync(join(home, "PLAN.assets", "image-1.png"), Buffer.from([1, 2, 3]));

--- a/packages/cli/test/uploadImageMigration.test.ts
+++ b/packages/cli/test/uploadImageMigration.test.ts
@@ -12,6 +12,7 @@ import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, relative } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { docPaths, hashBody, readStatus } from "@inplan/core/node";
 
 let rpcResult: { data: unknown; error: unknown } = { data: { status: "created", id: "doc-new" }, error: null };
 let memberships: { data: unknown; error: unknown } = { data: [{ org_id: "org-1", orgs: { slug: "acme", name: "Acme" } }], error: null };
@@ -24,11 +25,19 @@ const getPublicUrl = vi.fn((path: string) => ({ data: { publicUrl: `https://cdn.
 // The optimistic-concurrency write: `.update(patch).eq("id", …).eq("updated_at", baseline).select("id")`.
 // `updateMatches` simulates whether the CAS condition matched (true = nobody else touched the row
 // since the baseline read; false = something changed the row first — the "lost the race" case).
+// `updateEqCalls` records each `.eq(column, value)` the production code actually issued, so a test
+// can assert the CAS predicates themselves are present — not just that the mock's canned result
+// (which `updateMatches` controls directly) got returned. Without this, a regression that silently
+// dropped `.eq("updated_at", …)` from the real code would still pass the "lost the race" test.
 let updateError: { message: string } | null = null;
 let updateMatches = true;
+let updateEqCalls: Array<[string, unknown]> = [];
 const update = vi.fn((_patch: Record<string, unknown>) => {
   const chain = {
-    eq: vi.fn(() => chain),
+    eq: vi.fn((column: string, value: unknown) => {
+      updateEqCalls.push([column, value]);
+      return chain;
+    }),
     select: vi.fn(() => Promise.resolve(updateError ? { data: null, error: updateError } : { data: updateMatches ? [{ id: "doc-new" }] : [], error: null })),
   };
   return chain;
@@ -126,6 +135,7 @@ beforeEach(() => {
   existingDocId = null;
   updateError = null;
   updateMatches = true;
+  updateEqCalls = [];
   baselineUpdatedAt = "2026-01-01T00:00:00.000Z";
   fsFailure.path = null;
 });
@@ -135,6 +145,7 @@ afterEach(() => {
 });
 
 const lastJson = () => JSON.parse(out.join("").trim().split("\n").pop()!);
+const lastSyncedHash = () => readStatus(docPaths(file).statusPath).lastSyncedHash;
 
 describe("inplan upload → local image migration", () => {
   it("uploads a local relative image, rewrites the link in both the local file and the cloud row", async () => {
@@ -261,6 +272,7 @@ describe("inplan upload → local image migration", () => {
     // rewritten either — otherwise lastSyncedHash (computed from whatever's now on disk) would
     // match a body the cloud never actually received.
     expect(readFileSync(file, "utf8")).toBe(original);
+    expect(lastSyncedHash()).toBe(hashBody(original));
   });
 
   it("does not overwrite the cloud body when it changed since the baseline read (lost the CAS race)", async () => {
@@ -276,8 +288,15 @@ describe("inplan upload → local image migration", () => {
 
     expect(upload).toHaveBeenCalledTimes(1); // the image itself still uploads fine
     expect(update).toHaveBeenCalledTimes(1); // the conditional write was attempted
+    // Assert the CAS predicates THEMSELVES were issued — not just that the mock's canned "lost the
+    // race" result came back (which updateMatches controls directly regardless of what the
+    // production code actually asked for). Catches a regression that silently drops the
+    // updated_at condition, which would make every write unconditional again.
+    expect(updateEqCalls).toContainEqual(["id", "doc-new"]);
+    expect(updateEqCalls).toContainEqual(["updated_at", baselineUpdatedAt]);
     // Lost the race: must not claim success by touching the local file or the hash.
     expect(readFileSync(file, "utf8")).toBe(original);
+    expect(lastSyncedHash()).toBe(hashBody(original));
     expect(lastJson()).toMatchObject({ status: "uploaded" }); // the promote itself still succeeded
   });
 
@@ -295,6 +314,7 @@ describe("inplan upload → local image migration", () => {
     // original — proving finalBody was re-derived from the real file content, not just assumed to
     // be the migrated body because the write was "supposed to" succeed.
     expect(readFileSync(file, "utf8")).toBe(original);
+    expect(lastSyncedHash()).toBe(hashBody(original));
   });
 
   it("migrates more than 6 same-second images without exhausting the retry budget", async () => {

--- a/packages/cli/test/uploadImageMigration.test.ts
+++ b/packages/cli/test/uploadImageMigration.test.ts
@@ -25,13 +25,14 @@ const getPublicUrl = vi.fn((path: string) => ({ data: { publicUrl: `https://cdn.
 // race, or the update itself errored) — asserted directly in those two tests below.
 const remove = vi.fn(async (_paths: string[]) => ({ data: null, error: null }));
 
-// The optimistic-concurrency write: `.update(patch).eq("id", …).eq("updated_at", baseline).select("id")`.
+// The optimistic-concurrency write: `.update(patch).eq("id", …).eq("body", originalBody).select("id")`.
 // `updateMatches` simulates whether the CAS condition matched (true = nobody else touched the row
-// since the baseline read; false = something changed the row first — the "lost the race" case).
-// `updateEqCalls` records each `.eq(column, value)` the production code actually issued, so a test
-// can assert the CAS predicates themselves are present — not just that the mock's canned result
-// (which `updateMatches` controls directly) got returned. Without this, a regression that silently
-// dropped `.eq("updated_at", …)` from the real code would still pass the "lost the race" test.
+// since the migration's `body` snapshot; false = something changed the row first — the "lost the
+// race" case). `updateEqCalls` records each `.eq(column, value)` the production code actually
+// issued, so a test can assert the CAS predicates themselves are present — not just that the
+// mock's canned result (which `updateMatches` controls directly) got returned. Without this, a
+// regression that silently dropped `.eq("body", …)` from the real code would still pass the
+// "lost the race" test.
 let updateError: { message: string } | null = null;
 let updateMatches = true;
 let updateEqCalls: Array<[string, unknown]> = [];
@@ -46,26 +47,15 @@ const update = vi.fn((_patch: Record<string, unknown>) => {
   return chain;
 });
 
-// The baseline `updated_at` read right after create_document — the value the CAS write above
-// conditions on.
-let baselineUpdatedAt = "2026-01-01T00:00:00.000Z";
-
 function fakeDb() {
   const membershipsQ: Record<string, unknown> = {};
   membershipsQ.select = () => membershipsQ;
   membershipsQ.in = () => Promise.resolve(memberships);
 
-  let lastSelectCols = "";
   const documentsQ: Record<string, unknown> = {};
-  documentsQ.select = (cols: string) => {
-    lastSelectCols = cols;
-    return documentsQ;
-  };
+  documentsQ.select = () => documentsQ;
   documentsQ.eq = () => documentsQ;
-  documentsQ.maybeSingle = () =>
-    Promise.resolve(
-      lastSelectCols === "updated_at" ? { data: { updated_at: baselineUpdatedAt }, error: null } : { data: existingDocId ? { id: existingDocId } : null, error: null },
-    );
+  documentsQ.maybeSingle = () => Promise.resolve({ data: existingDocId ? { id: existingDocId } : null, error: null });
   documentsQ.update = update;
 
   return {
@@ -140,7 +130,6 @@ beforeEach(() => {
   updateError = null;
   updateMatches = true;
   updateEqCalls = [];
-  baselineUpdatedAt = "2026-01-01T00:00:00.000Z";
   fsFailure.path = null;
 });
 afterEach(() => {
@@ -283,13 +272,14 @@ describe("inplan upload → local image migration", () => {
     expect(remove).toHaveBeenCalledWith([uploadedPath]);
   });
 
-  it("does not overwrite the cloud body when it changed since the baseline read (lost the CAS race)", async () => {
+  it("does not overwrite the cloud body when it changed since the migration's body snapshot (lost the CAS race)", async () => {
     mkdirSync(join(home, "PLAN.assets"), { recursive: true });
     writeFileSync(join(home, "PLAN.assets", "image-1.png"), Buffer.from([1, 2, 3]));
     const original = "# My Plan\n\n![](<PLAN.assets/image-1.png>)\n";
     writeFileSync(file, original);
-    // Simulate the collab hub attaching and writing the row between our baseline read and our
-    // conditional UPDATE: the CAS `.eq("updated_at", baseline)` matches zero rows.
+    // Simulate the collab hub attaching and writing the row after doUpload read its `body`
+    // snapshot but before this conditional UPDATE: the CAS `.eq("body", original)` matches zero
+    // rows because the row's body no longer equals what the migration started from.
     updateMatches = false;
 
     await doUpload(file, []);
@@ -299,9 +289,9 @@ describe("inplan upload → local image migration", () => {
     // Assert the CAS predicates THEMSELVES were issued — not just that the mock's canned "lost the
     // race" result came back (which updateMatches controls directly regardless of what the
     // production code actually asked for). Catches a regression that silently drops the
-    // updated_at condition, which would make every write unconditional again.
+    // body condition, which would make every write unconditional again.
     expect(updateEqCalls).toContainEqual(["id", "doc-new"]);
-    expect(updateEqCalls).toContainEqual(["updated_at", baselineUpdatedAt]);
+    expect(updateEqCalls).toContainEqual(["body", original]);
     // Lost the race: must not claim success by touching the local file or the hash.
     expect(readFileSync(file, "utf8")).toBe(original);
     expect(lastSyncedHash()).toBe(hashBody(original));

--- a/packages/cli/test/uploadImageMigration.test.ts
+++ b/packages/cli/test/uploadImageMigration.test.ts
@@ -102,7 +102,7 @@ describe("inplan upload → local image migration", () => {
 
     expect(upload).toHaveBeenCalledTimes(1);
     const [path] = upload.mock.calls[0]!;
-    expect(path).toMatch(/^org-1\/doc-new\/image-\d{14}\.png$/);
+    expect(path).toMatch(/^org-1\/doc-new\/image-\d{14}-[0-9a-f]{8}\.png$/);
 
     const url = `https://cdn.test/doc-images/${path}`;
     expect(readFileSync(file, "utf8")).toContain(`![](${url})`);
@@ -217,5 +217,27 @@ describe("inplan upload → local image migration", () => {
     // rewritten either — otherwise lastSyncedHash (computed from whatever's now on disk) would
     // match a body the cloud never actually received.
     expect(readFileSync(file, "utf8")).toBe(original);
+  });
+
+  it("migrates more than 6 same-second images without exhausting the retry budget", async () => {
+    // Regression for the old scheme, where every image in the same second shared ONE base name
+    // (`image-<second>`) and only n<=5 disambiguating retries existed — a 7th image in the same
+    // second had nowhere left to go and stayed a dangling local link. Each upload now carries its
+    // own unguessable suffix, so a same-second batch never depends on the retry loop at all.
+    mkdirSync(join(home, "PLAN.assets"), { recursive: true });
+    const n = 7;
+    const lines = Array.from({ length: n }, (_, i) => {
+      writeFileSync(join(home, "PLAN.assets", `image-${i}.png`), Buffer.from([i]));
+      return `![](<PLAN.assets/image-${i}.png>)`;
+    });
+    writeFileSync(file, `# My Plan\n\n${lines.join("\n\n")}\n`);
+
+    await doUpload(file, []);
+
+    expect(upload).toHaveBeenCalledTimes(n);
+    const paths = upload.mock.calls.map((c) => c[0] as string);
+    expect(new Set(paths).size).toBe(n); // every image landed on a distinct path
+    const rewritten = readFileSync(file, "utf8");
+    expect(rewritten).not.toContain("PLAN.assets"); // none left dangling locally
   });
 });

--- a/packages/cli/test/uploadImageMigration.test.ts
+++ b/packages/cli/test/uploadImageMigration.test.ts
@@ -10,7 +10,7 @@
 
 import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 let rpcResult: { data: unknown; error: unknown } = { data: { status: "created", id: "doc-new" }, error: null };
@@ -141,5 +141,29 @@ describe("inplan upload → local image migration", () => {
     expect(update).not.toHaveBeenCalled(); // nothing migrated → no cloud body rewrite
     expect(readFileSync(file, "utf8")).toContain("PLAN.assets/image-1.png"); // local link left as-is
     expect(lastJson()).toMatchObject({ status: "uploaded" }); // promote itself still succeeded
+  });
+
+  it("never reads or uploads a file outside the doc's own directory (path traversal)", async () => {
+    // A sibling directory to `home` (the doc's own dir) — a `../` link must not escape into it.
+    const outside = mkdtempSync(join(tmpdir(), "inplan-upload-migrate-outside-"));
+    const secretFile = join(outside, "secret.png");
+    writeFileSync(secretFile, Buffer.from("not actually yours"));
+    const rel = relative(home, secretFile).replace(/\\/g, "/");
+    expect(rel.startsWith("..")).toBe(true); // sanity: this really is outside the doc's dir
+    writeFileSync(file, `# My Plan\n\n![](<${rel}>)\n`);
+
+    await doUpload(file, []);
+    expect(upload).not.toHaveBeenCalled(); // never read, never uploaded
+    expect(readFileSync(file, "utf8")).toContain(rel); // link left untouched — not "fixed" into a URL
+  });
+
+  it("skips a local file whose extension isn't a recognized image type (no png fallback)", async () => {
+    mkdirSync(join(home, "PLAN.assets"), { recursive: true });
+    writeFileSync(join(home, "PLAN.assets", "id_ed25519"), "not an image, definitely not");
+    writeFileSync(file, "# My Plan\n\n![](<PLAN.assets/id_ed25519>)\n");
+
+    await doUpload(file, []);
+    expect(upload).not.toHaveBeenCalled();
+    expect(readFileSync(file, "utf8")).toContain("PLAN.assets/id_ed25519");
   });
 });

--- a/packages/cli/test/uploadImageMigration.test.ts
+++ b/packages/cli/test/uploadImageMigration.test.ts
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// `inplan upload` must migrate pre-existing LOCAL images (pasted while the doc was still local, so
+// they're relative links into a sibling `.assets/` folder) into the cloud `doc-images` bucket and
+// rewrite the body's links — otherwise a doc promoted to the cloud arrives with links into a folder
+// that has no counterpart there. Covers: a doc with a local image (migrated, both the local file
+// and the cloud row end up rewritten), a doc with no images (storage untouched), an already-absolute
+// image URL (left alone), and a dangling local link (left alone, no crash) — all over a mocked
+// authed session, no network.
+
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let rpcResult: { data: unknown; error: unknown } = { data: { status: "created", id: "doc-new" }, error: null };
+let memberships: { data: unknown; error: unknown } = { data: [{ org_id: "org-1", orgs: { slug: "acme", name: "Acme" } }], error: null };
+const rpc = vi.fn(async (_name: string, _params: Record<string, unknown>) => rpcResult);
+let uploadResult: { error: { status: number; message: string } | null } = { error: null };
+const upload = vi.fn(async (_path: string, _bytes: unknown, _opts: unknown) => uploadResult);
+const getPublicUrl = vi.fn((path: string) => ({ data: { publicUrl: `https://cdn.test/doc-images/${path}` } }));
+const update = vi.fn((_patch: Record<string, unknown>) => ({ eq: () => Promise.resolve({ error: null }) }));
+
+function fakeDb() {
+  const membershipsQ: Record<string, unknown> = {};
+  membershipsQ.select = () => membershipsQ;
+  membershipsQ.in = () => Promise.resolve(memberships);
+
+  const documentsQ: Record<string, unknown> = {};
+  documentsQ.select = () => documentsQ;
+  documentsQ.eq = () => documentsQ;
+  documentsQ.maybeSingle = () => Promise.resolve({ data: null, error: null });
+  documentsQ.update = update;
+
+  return {
+    from: (table: string) => (table === "memberships" ? membershipsQ : documentsQ),
+    rpc,
+    storage: { from: () => ({ upload, getPublicUrl }) },
+  };
+}
+
+vi.mock("../src/cliAuth", () => ({
+  authedSession: vi.fn(async () => ({ db: fakeDb(), session: { user: { id: "user-1" } } })),
+}));
+vi.mock("../src/provenance", () => ({
+  gitProvenance: () => ({ repo: "acme/plan", path: "docs/PLAN.md" }),
+}));
+
+import { doUpload } from "../src/cli";
+
+let home: string;
+let file: string;
+let out: string[];
+let exitCode: number | null;
+let errOut: string[];
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "inplan-upload-migrate-"));
+  process.env.INPLAN_SIDECAR_DIR = join(home, "sidecars");
+  file = join(home, "PLAN.md");
+  out = [];
+  errOut = [];
+  exitCode = null;
+  vi.spyOn(process.stdout, "write").mockImplementation((s: string | Uint8Array) => {
+    out.push(String(s));
+    return true;
+  });
+  vi.spyOn(process.stderr, "write").mockImplementation((s: string | Uint8Array) => {
+    errOut.push(String(s));
+    return true;
+  });
+  vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+    exitCode = code ?? 0;
+    throw new Error(`exit:${code}`);
+  }) as never);
+  rpc.mockClear();
+  upload.mockClear();
+  getPublicUrl.mockClear();
+  update.mockClear();
+  rpcResult = { data: { status: "created", id: "doc-new" }, error: null };
+  memberships = { data: [{ org_id: "org-1", orgs: { slug: "acme", name: "Acme" } }], error: null };
+  uploadResult = { error: null };
+});
+afterEach(() => {
+  delete process.env.INPLAN_SIDECAR_DIR;
+  vi.restoreAllMocks();
+});
+
+const lastJson = () => JSON.parse(out.join("").trim().split("\n").pop()!);
+
+describe("inplan upload → local image migration", () => {
+  it("uploads a local relative image, rewrites the link in both the local file and the cloud row", async () => {
+    mkdirSync(join(home, "PLAN.assets"), { recursive: true });
+    writeFileSync(join(home, "PLAN.assets", "image-1.png"), Buffer.from([1, 2, 3]));
+    writeFileSync(file, "# My Plan\n\n![](<PLAN.assets/image-1.png>)\n");
+
+    await doUpload(file, []);
+
+    expect(upload).toHaveBeenCalledTimes(1);
+    const [path] = upload.mock.calls[0]!;
+    expect(path).toMatch(/^org-1\/doc-new\/image-\d{14}\.png$/);
+
+    const url = `https://cdn.test/doc-images/${path}`;
+    expect(readFileSync(file, "utf8")).toContain(`![](${url})`);
+    expect(readFileSync(file, "utf8")).not.toContain("PLAN.assets");
+
+    expect(update).toHaveBeenCalledWith(expect.objectContaining({ body: expect.stringContaining(url) }));
+    expect(lastJson()).toMatchObject({ status: "uploaded", cloudDocId: "doc-new" });
+  });
+
+  it("a doc with no images never touches storage", async () => {
+    writeFileSync(file, "# My Plan\n\njust text\n");
+    await doUpload(file, []);
+    expect(upload).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+    expect(lastJson()).toMatchObject({ status: "uploaded" });
+  });
+
+  it("leaves an already-absolute image URL untouched", async () => {
+    writeFileSync(file, "# My Plan\n\n![](https://example.com/pic.png)\n");
+    await doUpload(file, []);
+    expect(upload).not.toHaveBeenCalled();
+    expect(readFileSync(file, "utf8")).toContain("https://example.com/pic.png");
+  });
+
+  it("leaves a dangling local link untouched (no crash) when the referenced file is missing", async () => {
+    writeFileSync(file, "# My Plan\n\n![](<PLAN.assets/missing.png>)\n");
+    await doUpload(file, []);
+    expect(upload).not.toHaveBeenCalled();
+    expect(readFileSync(file, "utf8")).toContain("PLAN.assets/missing.png");
+    expect(lastJson()).toMatchObject({ status: "uploaded" });
+  });
+
+  it("a storage failure during migration doesn't fail the promote itself", async () => {
+    mkdirSync(join(home, "PLAN.assets"), { recursive: true });
+    writeFileSync(join(home, "PLAN.assets", "image-1.png"), Buffer.from([1, 2, 3]));
+    writeFileSync(file, "# My Plan\n\n![](<PLAN.assets/image-1.png>)\n");
+    uploadResult = { error: { status: 500, message: "boom" } }; // a real (non-collision) failure — no retry
+
+    await doUpload(file, []);
+    expect(update).not.toHaveBeenCalled(); // nothing migrated → no cloud body rewrite
+    expect(readFileSync(file, "utf8")).toContain("PLAN.assets/image-1.png"); // local link left as-is
+    expect(lastJson()).toMatchObject({ status: "uploaded" }); // promote itself still succeeded
+  });
+});

--- a/packages/renderer/src/App.tsx
+++ b/packages/renderer/src/App.tsx
@@ -712,16 +712,24 @@ export function App(props: EditorProps = {}): JSX.Element {
   // raw bytes to the host, which writes them next to the open doc (e.g.
   // `<docname>.assets/image-...png`) and returns the relative link to embed. Absent `saveAsset`
   // (a host with nowhere to write a sibling file, e.g. a cloud doc) ⇒ no-op.
-  const onPickImage = useCallback(async (bytes: ArrayBuffer, mime: string): Promise<string | null> => {
-    const saveAsset = hostApi().saveAsset;
-    if (!saveAsset) return null;
-    // Not just `mime.split("/")[1]`: some subtypes aren't valid filename extensions on their own
-    // (e.g. "svg+xml"), and the host's asset:save rejects anything that doesn't look like one —
-    // silently falling back to ".png" on an SVG's actual bytes, breaking the image.
-    const ext = IMAGE_EXT_BY_MIME[mime] ?? "png";
-    const saved = await saveAsset(bytes, ext);
-    return saved?.relPath ?? null;
-  }, []);
+  const onPickImage = useCallback(
+    async (bytes: ArrayBuffer, mime: string): Promise<string | null> => {
+      const saveAsset = hostApi().saveAsset;
+      if (!saveAsset) return null;
+      // Not just `mime.split("/")[1]`: some subtypes aren't valid filename extensions on their own
+      // (e.g. "svg+xml"), and the host's asset:save rejects anything that doesn't look like one —
+      // silently falling back to ".png" on an SVG's actual bytes, breaking the image.
+      const ext = IMAGE_EXT_BY_MIME[mime] ?? "png";
+      const saved = await saveAsset(bytes, ext);
+      // `saveAsset` resolving to null is a real failure (e.g. the cloud upload rejected, or the
+      // local write threw) — every caller (source-paste, preview-paste, toolbar file picker)
+      // routes through here, so surfacing it once in this shared spot covers all three, instead
+      // of it disappearing into main-process stderr with nothing visible in the editor.
+      if (!saved) setStatus(t("msg.imagePasteFailed"));
+      return saved?.relPath ?? null;
+    },
+    [t],
+  );
 
   // Pasting an image directly into the (read-only) preview: insert the link on a new line
   // right after the active (blue-highlighted) block — its data-end-line, not just data-line, so

--- a/packages/renderer/test/App.pasteImage.test.tsx
+++ b/packages/renderer/test/App.pasteImage.test.tsx
@@ -68,4 +68,15 @@ describe("App onPasteImage wiring", () => {
 
     expect(onPasteImage).toBeUndefined();
   });
+
+  it("reports a failed save (host resolves null, e.g. a cloud upload rejected) instead of leaving the paste silently dropped", async () => {
+    const saveAsset = vi.fn(async () => null);
+    (window as unknown as { api: { saveAsset: unknown } }).api.saveAsset = saveAsset;
+    await mountApp();
+
+    const result = await onPasteImage!(new ArrayBuffer(3), "image/png");
+
+    expect(result).toBeNull();
+    await waitFor(() => expect(document.body.textContent).toContain("couldn't paste image"));
+  });
 });

--- a/packages/renderer/test/App.previewPasteImage.test.tsx
+++ b/packages/renderer/test/App.previewPasteImage.test.tsx
@@ -158,6 +158,19 @@ describe("preview pane image paste", () => {
     expect(document.querySelector(".ap-rendered")!.innerHTML).toBe(before);
   });
 
+  it("when the host resolves null instead of throwing (e.g. a cloud upload rejected), still reports it — not just a caught exception", async () => {
+    (window as unknown as { api: { saveAsset: unknown } }).api.saveAsset = vi.fn(async () => null);
+    await mountApp();
+    const rendered = document.querySelector(".ap-rendered")!;
+    const before = document.querySelector(".ap-rendered")!.innerHTML;
+
+    await act(async () => firePasteImage(rendered, PNG));
+    await waitFor(() => expect(document.body.textContent).toContain("couldn't paste image"));
+
+    // No image link was inserted — the doc is untouched.
+    expect(document.querySelector(".ap-rendered")!.innerHTML).toBe(before);
+  });
+
   it("does not apply the image link to a doc the user navigated to WHILE the save was still in flight", async () => {
     let resolveSave!: (v: { relPath: string }) => void;
     const session = createMemoryApi({ content: DOC }) as unknown as {


### PR DESCRIPTION
## Summary
- `inplan asset-upload`: uploads image bytes straight to the `doc-images` bucket for a cloud-linked doc, mirroring the cloud web app's `saveAsset` (same bucket, org/doc path scheme, 409-collision retry).
- The desktop app's `asset:save` IPC handler routes through it whenever the doc is live-connected to the cloud (Collaborate on Cloud), so a pasted image never needs a later migration.
- `inplan upload` (promote) now migrates any images pasted while the doc was still local: it scans the body for local relative image links, uploads the referenced files, and rewrites the links in both the local file and the cloud row — otherwise a doc promoted after the fact arrives in the cloud with links into a `.assets/` folder that has no counterpart there.

## Test plan
- [x] `packages/cli/test/assetUpload.test.ts` — 8 cases (upload, extension fallback, 409-collision retry, hard failure, logged-out, non-cloud doc, org lookup failure)
- [x] `packages/cli/test/uploadImageMigration.test.ts` — 5 cases (migrates a local image, no-op with no images, leaves absolute URLs alone, leaves a dangling link alone, a storage failure doesn't fail the promote itself)
- [x] Verified end-to-end against the real cloud (Supabase Storage) with both single- and multi-image docs — uploaded images are publicly reachable and the rewritten links match the stored document body.
- [x] `npm run typecheck -w @inplan/cli -w @inplan/app` clean.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/91?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cloud image uploads for documents connected to the cloud.
  * Local image references are migrated to public URLs during document uploads.
  * Added support for common image formats, with PNG fallback for unknown extensions.
  * Added collision handling and cleanup for temporary upload files.

* **Bug Fixes**
  * Uploads continue safely when individual image migrations fail.
  * Local documents retain their existing asset-storage behavior.
  * Image paste failures now display an error without changing the document.

* **Tests**
  * Expanded coverage for uploads, authentication, failures, collisions, and URL rewriting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->