### PR TITLE
CLI: durable landing signal for review-mode proposals

### DIFF
--- a/packages/cli/src/applyEdit.ts
+++ b/packages/cli/src/applyEdit.ts
@@ -46,24 +46,37 @@ export async function applyGatedEdit(
     // doc, so there's no .md to revert.
     try {
       await store.setProposed(current);
-      // File path only: revert the working file to canonical INSIDE the same failure envelope —
-      // if this revert rejects, the park sequence is incomplete (no event appended below), so the
-      // caller must degrade exactly as for a failed push rather than crash with no status.
-      if (!gate) await store.saveDoc(canonicalText);
     } catch {
-      // The park sequence did not complete: keep the working copy as it stands (for a failed push
-      // it is the ONLY copy of the edit — reverting would destroy it silently), log no event
-      // (the log must not claim a park the sequence didn't finish), and let the caller report the
-      // degradation. The next run re-detects the divergence and retries the park idempotently.
+      // The push failed, so nothing is proposed anywhere: keep the working copy as the ONLY copy
+      // (skipping the revert below — reverting would destroy the edit silently), log no event,
+      // and let the caller report the degradation. The next run re-detects the divergence and
+      // retries the park idempotently.
       return { proposed: false, parkFailed: true };
     }
-    await channel.append({
-      actor: "agent",
-      type: LogEventType.AgentRevisionProposed,
-      // The hash identifies WHICH proposal this event parked, so a later resolution can bind
-      // decision events to this exact proposal (not merely the doc's latest park).
-      payload: { bytes: utf8Bytes(current), hash: hashBody(current) },
-    });
+    // From here the park is REAL — the store holds the proposal (and on the remote path the
+    // durable record is already on disk). Every failure below is local housekeeping and must not
+    // be reported as a failed park: claiming "FAILED, will be re-pushed" for a proposal the human
+    // can already see in their editor is the same class of false signal #88 exists to kill.
+    if (!gate) {
+      try {
+        await store.saveDoc(canonicalText);
+      } catch {
+        /* Failed revert: the working copy keeps the edit, where the hydration hash-mismatch guard
+           protects it; the next turn re-parks the identical text as a no-op. */
+      }
+    }
+    try {
+      await channel.append({
+        actor: "agent",
+        type: LogEventType.AgentRevisionProposed,
+        // The hash identifies WHICH proposal this event parked, so a later resolution can bind
+        // decision events to this exact proposal (not merely the doc's latest park).
+        payload: { bytes: utf8Bytes(current), hash: hashBody(current) },
+      });
+    } catch {
+      /* The park stands without its event; resolution falls back to its lesser anchors (last
+         park event, then timestamps), which is exactly what those fallbacks exist for. */
+    }
     return { proposed: true };
   } else if (ev.changed) {
     // Auto-accept (auto mode, or review mode with comment-only changes): advance the base. On the

--- a/packages/cli/src/applyEdit.ts
+++ b/packages/cli/src/applyEdit.ts
@@ -7,6 +7,7 @@
 import { type ControlChannel, type DocumentStore, LogEventType } from "@inplan/core/node";
 import type { AgentEditEvaluation } from "./gate";
 import type { PluginGate } from "./pluginGate";
+import { utf8Bytes } from "./remoteDocState";
 
 /**
  * When `gate` is non-null an entitled plugin owns the document, so we push the accepted text into
@@ -42,7 +43,7 @@ export async function applyGatedEdit(
     // doc, so there's no .md to revert.
     await store.setProposed(current);
     if (!gate) await store.saveDoc(canonicalText);
-    await channel.append({ actor: "agent", type: LogEventType.AgentRevisionProposed, payload: { bytes: current.length } });
+    await channel.append({ actor: "agent", type: LogEventType.AgentRevisionProposed, payload: { bytes: utf8Bytes(current) } });
     return { proposed: true };
   } else if (ev.changed) {
     // Auto-accept (auto mode, or review mode with comment-only changes): advance the base. On the
@@ -52,7 +53,7 @@ export async function applyGatedEdit(
       await store.setCanonical(current);
       await store.clearProposed();
     }
-    await channel.append({ actor: "agent", type: LogEventType.DocumentEdited, payload: { bytes: current.length } });
+    await channel.append({ actor: "agent", type: LogEventType.DocumentEdited, payload: { bytes: utf8Bytes(current) } });
   }
   return { proposed: false };
 }

--- a/packages/cli/src/applyEdit.ts
+++ b/packages/cli/src/applyEdit.ts
@@ -51,6 +51,13 @@ export async function applyGatedEdit(
       // (skipping the revert below — reverting would destroy the edit silently), log no event,
       // and let the caller report the degradation. The next run re-detects the divergence and
       // retries the park idempotently.
+      //
+      // CONTRACT for composite stores: a `setProposed` rejection must mean NOTHING was committed.
+      // A store that pushes remotely and then persists locally (runRemote's gateStore) must
+      // contain its post-commit failures itself — the cloud proposal is live and the human can
+      // see it, so surfacing that partial failure here would misreport a real park as a failed
+      // push. The gateStore does exactly that: it swallows the local record-write failure and
+      // relies on slot reconciliation at the next attach.
       return { proposed: false, parkFailed: true };
     }
     // From here the park is REAL — the store holds the proposal (and on the remote path the

--- a/packages/cli/src/applyEdit.ts
+++ b/packages/cli/src/applyEdit.ts
@@ -4,7 +4,7 @@
 // edit lands in the file model or a runtime plugin's document. Split out of cli.ts so it's
 // unit-testable without running the CLI's top-level main().
 
-import { type ControlChannel, type DocumentStore, LogEventType } from "@inplan/core/node";
+import { type ControlChannel, type DocumentStore, LogEventType, hashBody } from "@inplan/core/node";
 import type { AgentEditEvaluation } from "./gate";
 import type { PluginGate } from "./pluginGate";
 import { utf8Bytes } from "./remoteDocState";
@@ -46,15 +46,24 @@ export async function applyGatedEdit(
     // doc, so there's no .md to revert.
     try {
       await store.setProposed(current);
+      // File path only: revert the working file to canonical INSIDE the same failure envelope —
+      // if this revert rejects, the park sequence is incomplete (no event appended below), so the
+      // caller must degrade exactly as for a failed push rather than crash with no status.
+      if (!gate) await store.saveDoc(canonicalText);
     } catch {
-      // The push failed, so nothing is proposed anywhere: keep the working copy as the ONLY copy
-      // (skipping the revert below — reverting here would destroy the edit silently), log no
-      // event, and let the caller report the degradation. The next run re-detects the divergence
-      // and retries the park.
+      // The park sequence did not complete: keep the working copy as it stands (for a failed push
+      // it is the ONLY copy of the edit — reverting would destroy it silently), log no event
+      // (the log must not claim a park the sequence didn't finish), and let the caller report the
+      // degradation. The next run re-detects the divergence and retries the park idempotently.
       return { proposed: false, parkFailed: true };
     }
-    if (!gate) await store.saveDoc(canonicalText);
-    await channel.append({ actor: "agent", type: LogEventType.AgentRevisionProposed, payload: { bytes: utf8Bytes(current) } });
+    await channel.append({
+      actor: "agent",
+      type: LogEventType.AgentRevisionProposed,
+      // The hash identifies WHICH proposal this event parked, so a later resolution can bind
+      // decision events to this exact proposal (not merely the doc's latest park).
+      payload: { bytes: utf8Bytes(current), hash: hashBody(current) },
+    });
     return { proposed: true };
   } else if (ev.changed) {
     // Auto-accept (auto mode, or review mode with comment-only changes): advance the base. On the

--- a/packages/cli/src/applyEdit.ts
+++ b/packages/cli/src/applyEdit.ts
@@ -17,14 +17,17 @@ import { utf8Bytes } from "./remoteDocState";
  *
  * Returns whether the edit was PARKED as a proposal (#88) — the caller surfaces that fact
  * (wait output + stderr + the durable proposal record) so an agent auditing "did my edit
- * land?" never mistakes a parked proposal for a sync failure.
+ * land?" never mistakes a parked proposal for a sync failure. `parkFailed` reports the
+ * inverse hazard: the park never reached the store, so nothing was proposed — the edit is
+ * kept in the working copy (deliberately NOT reverted) and no event is appended; the caller
+ * degrades the turn instead of crashing with no status.
  */
 export async function applyGatedEdit(
   store: DocumentStore,
   channel: ControlChannel,
   ev: AgentEditEvaluation,
   ctx: { current: string; canonicalText: string; quarantine: boolean; gate: PluginGate | null },
-): Promise<{ proposed: boolean }> {
+): Promise<{ proposed: boolean; parkFailed?: boolean }> {
   const { current, canonicalText, quarantine, gate } = ctx;
   if (ev.removedIds.length > 0) {
     // Confirmed deletions: drop the orphaned comment objects. On the plugin path push the result
@@ -41,7 +44,15 @@ export async function applyGatedEdit(
     // sidecar is file-based either way; on the file path also revert the working file to canonical
     // (the human's accept later writes canonical). On the plugin path the plugin owns the working
     // doc, so there's no .md to revert.
-    await store.setProposed(current);
+    try {
+      await store.setProposed(current);
+    } catch {
+      // The push failed, so nothing is proposed anywhere: keep the working copy as the ONLY copy
+      // (skipping the revert below — reverting here would destroy the edit silently), log no
+      // event, and let the caller report the degradation. The next run re-detects the divergence
+      // and retries the park.
+      return { proposed: false, parkFailed: true };
+    }
     if (!gate) await store.saveDoc(canonicalText);
     await channel.append({ actor: "agent", type: LogEventType.AgentRevisionProposed, payload: { bytes: utf8Bytes(current) } });
     return { proposed: true };

--- a/packages/cli/src/applyEdit.ts
+++ b/packages/cli/src/applyEdit.ts
@@ -13,13 +13,17 @@ import type { PluginGate } from "./pluginGate";
  * the plugin (never touching the `.md`); otherwise we advance the file + persisted canonical (or
  * quarantine a Review-mode body change as a `.proposed.md` for the human to accept). The matching
  * `DocumentEdited` / `AgentRevisionProposed` event is logged either way.
+ *
+ * Returns whether the edit was PARKED as a proposal (#88) — the caller surfaces that fact
+ * (wait output + stderr + the durable proposal record) so an agent auditing "did my edit
+ * land?" never mistakes a parked proposal for a sync failure.
  */
 export async function applyGatedEdit(
   store: DocumentStore,
   channel: ControlChannel,
   ev: AgentEditEvaluation,
   ctx: { current: string; canonicalText: string; quarantine: boolean; gate: PluginGate | null },
-): Promise<void> {
+): Promise<{ proposed: boolean }> {
   const { current, canonicalText, quarantine, gate } = ctx;
   if (ev.removedIds.length > 0) {
     // Confirmed deletions: drop the orphaned comment objects. On the plugin path push the result
@@ -39,6 +43,7 @@ export async function applyGatedEdit(
     await store.setProposed(current);
     if (!gate) await store.saveDoc(canonicalText);
     await channel.append({ actor: "agent", type: LogEventType.AgentRevisionProposed, payload: { bytes: current.length } });
+    return { proposed: true };
   } else if (ev.changed) {
     // Auto-accept (auto mode, or review mode with comment-only changes): advance the base. On the
     // plugin path that means pushing into the plugin's doc; otherwise advance the persisted canonical.
@@ -49,4 +54,5 @@ export async function applyGatedEdit(
     }
     await channel.append({ actor: "agent", type: LogEventType.DocumentEdited, payload: { bytes: current.length } });
   }
+  return { proposed: false };
 }

--- a/packages/cli/src/applyEdit.ts
+++ b/packages/cli/src/applyEdit.ts
@@ -27,7 +27,7 @@ export async function applyGatedEdit(
   channel: ControlChannel,
   ev: AgentEditEvaluation,
   ctx: { current: string; canonicalText: string; quarantine: boolean; gate: PluginGate | null },
-): Promise<{ proposed: boolean; parkFailed?: boolean }> {
+): Promise<{ proposed: boolean; parkFailed?: boolean; eventLogged?: boolean }> {
   const { current, canonicalText, quarantine, gate } = ctx;
   if (ev.removedIds.length > 0) {
     // Confirmed deletions: drop the orphaned comment objects. On the plugin path push the result
@@ -81,8 +81,11 @@ export async function applyGatedEdit(
         payload: { bytes: utf8Bytes(current), hash: hashBody(current) },
       });
     } catch {
-      /* The park stands without its event; resolution falls back to its lesser anchors (last
-         park event, then timestamps), which is exactly what those fallbacks exist for. */
+      // The park stands without its event; resolution falls back to its lesser anchors, which is
+      // exactly what those fallbacks exist for. Report it, though: the event is also what nudges
+      // a live editor to show the review panel, so the caller should tell the agent the proposal
+      // may stay invisible to the human until their editor next reloads.
+      return { proposed: true, eventLogged: false };
     }
     return { proposed: true };
   } else if (ev.changed) {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -39,7 +39,7 @@ import { addComment, AddCommentError } from "./commentAdd";
 import { docPaths, sidecarRoot, type DocPaths } from "./paths";
 import { loadPluginGate, loadPluginGateOutcome, resolveHubUrl, type PluginAbsenceReason, type PluginGate } from "./pluginGate";
 import { demoteSource, shouldHydrateWorkFile, pendingRequiresReplay, postTurnAction, trackGateDegradations, type WaitOutcome } from "./liveSync";
-import { RemoteDocState, resolutionFromEvents, utf8Bytes } from "./remoteDocState";
+import { RemoteDocState, needsReparkFromSlot, resolutionFromEvents, utf8Bytes } from "./remoteDocState";
 import { announcePresence, presenceTokenResolver } from "./presence";
 import { awaitReopen, wakePredicate, waitForActions } from "./wait";
 import { versionFromModule } from "./version";
@@ -1155,16 +1155,27 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
     // (accepted / partially_accepted / rejected), so "did my edit land?" stays answerable from
     // disk even though agent_revision_proposed left the wait output long ago. A transient slot
     // read failure just retries next run; the record stays pending.
+    // Reconcile with the CLOUD slot first (#88): the slot is the authoritative side of a park, so
+    // a proposal it holds that this machine has no live record of (a crash between the confirmed
+    // push and the record publish, a re-park after a finalization) is re-parked from the slot's
+    // own text, recreating the truthful pending record. Then resolve a pending record whose slot
+    // has emptied: the decision events name the outcome; when none is readable yet, the record
+    // waits one more run (a slot-clear can race ahead of its decision event) before degrading to
+    // 'decided'. A transient slot read failure skips both — retry next run.
+    const slot = await live.store.getProposed().catch(() => undefined);
+    if (typeof slot === "string" && needsReparkFromSlot(rds.latestProposal(), slot)) {
+      rds.parkProposal(slot);
+    }
     const parkedEarlier = rds.pendingProposal();
-    if (parkedEarlier) {
-      const slot = await live.store.getProposed().catch(() => undefined);
-      if (slot === null) {
-        try {
-          const { entries } = await live.channel.readSince(0);
-          rds.resolveProposal(resolutionFromEvents(entries, parkedEarlier));
-        } catch {
-          /* transient history read failure: leave the record pending and retry next run */
-        }
+    if (parkedEarlier && slot === null) {
+      try {
+        const { entries } = await live.channel.readSince(0);
+        const outcome = resolutionFromEvents(entries, parkedEarlier);
+        if (outcome !== "decided") rds.resolveProposal(outcome);
+        else if (parkedEarlier.awaitingOutcomeSince) rds.resolveProposal("decided");
+        else rds.noteOutcomeMissing();
+      } catch {
+        /* transient history read failure: leave the record pending and retry next run */
       }
     }
 
@@ -1195,17 +1206,21 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
       backup: (c, m) => localStore.backup(c, m),
       getProposed: () => live.store.getProposed(),
       setProposed: async (c) => {
-        // The durable record is written ONLY after a confirmed push, and BOTH steps count as the
-        // park: a failed push leaves the working copy as the only copy of the edit, and a failed
-        // record write (push ok, fs error) leaves this machine without its recovery signal — in
-        // either case the post-turn path must keep-local instead of re-syncing the copy away, so
-        // both flag the turn as a degraded write.
+        // Only a failed PUSH is a failed park (the edit's sole copy stays local; the post-turn
+        // path must keep-local). A failed local record write after a confirmed push is NOT — the
+        // proposal is live in the cloud, the human can already see it, and the record is
+        // reconciled from the slot at the next attach; masquerading it as a failed push would
+        // deny a park that actually happened.
         try {
           await live.store.setProposed(c);
-          rds.parkProposal(c);
         } catch (e) {
           hubParkFailed = true;
           throw e;
+        }
+        try {
+          rds.parkProposal(c);
+        } catch (e) {
+          process.stderr.write(`inplan: could not write the local proposal record (${String(e)}); the proposal is live in the cloud and the record will be reconciled on the next run\n`);
         }
       },
       clearProposed: () => live.store.clearProposed(),

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1217,7 +1217,17 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
         if (displaced && outcome === null) {
           rds.noteOutcomeMissing(); // defer both the finalization and the repark one run
         } else {
-          if (displaced && outcome) justFinalized = rds.resolveProposal(outcome) !== null;
+          if (displaced && outcome) {
+            const finalized = rds.resolveProposal(outcome);
+            // Corpse-restore for the DISPLACED record must run HERE, against the record we just
+            // finalized: parking the slot's content below makes latestProposal() the NEW pending
+            // record, so the generic check after this block could never match — leaving a stale
+            // working copy that next turn would quarantine and push OVER the slot's proposal.
+            if (finalized && !rds.replayPending() && isDecidedProposalCorpse(finalized, rds.readWorkFile())) {
+              rds.writeWorkFile(canonical);
+              rds.recordSynced(canonical);
+            }
+          }
           rds.parkProposal(slot);
         }
       } catch (e) {
@@ -1302,6 +1312,15 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
     const onSaveLocallyGate = localFile
       ? async (info: { proposal?: { state: "pending_review" | "park_failed"; bytes: number; hash: string } }) => {
           const body = await gate.readCanonical();
+          // The handoff writes CANONICAL to the local file. A working copy diverging from the
+          // last sync at this moment holds an edit that never reached the hub (e.g. this turn's
+          // park failed) — it stays in the remote sidecar, where nothing will replay it once the
+          // doc is local. Not silently: say where it is, and the moved_local output already
+          // carries the park_failed signal via `info`.
+          const leftover = rds.readWorkFile();
+          if (leftover !== null && hashBody(leftover) !== (rds.hydrateInput().syncedHash ?? "") && parse(leftover).body !== parse(body).body) {
+            process.stderr.write(`inplan: the doc moved local, but an unpushed edit remains at ${workFile} — merge it into ${localFile} by hand if you still want it.\n`);
+          }
           writeFileSync(localFile, body);
           writeStatus(docPaths(localFile).statusPath, { location: "local", originalPath: localFile, lastSyncedHash: hashBody(body) });
           const pid = spawnApp(localFile);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1168,10 +1168,11 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
     // Working doc stays on the local file, but Review-mode PROPOSALS persist to the CLOUD doc's
     // proposal store (via live.store) — otherwise a parked proposal would sit in this machine's
     // sidecar, invisible to the human in the web editor who's meant to accept/reject it. The
-    // wrapper also captures the parked text so the healthy-turn path below can write the durable
-    // proposal record BEFORE the re-sync overwrites the working copy (#88).
+    // wrapper writes the durable proposal record (#88) the moment the cloud push confirms — at
+    // park time, not at turn end — so a waiter killed mid-wait (SIGTERM, network death) still
+    // leaves the record + text on disk, and it exists long before the end-of-turn re-sync
+    // overwrites the working copy.
     const localStore = fsBackend(workFile).store;
-    let parkedThisTurn: string | null = null;
     const gateStore: DocumentStore = {
       loadDoc: () => localStore.loadDoc(),
       saveDoc: (c) => localStore.saveDoc(c),
@@ -1181,12 +1182,9 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
       getProposed: () => live.store.getProposed(),
       setProposed: async (c) => {
         await live.store.setProposed(c);
-        parkedThisTurn = c;
+        rds.parkProposal(c);
       },
-      clearProposed: async () => {
-        await live.store.clearProposed();
-        parkedThisTurn = null;
-      },
+      clearProposed: () => live.store.clearProposed(),
     };
     // Save-local handoff on the gate path reads the HUB canonical (the source of truth here);
     // live.store isn't updated by gate.applyRevision, so reading it would write a stale doc. If
@@ -1239,15 +1237,12 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
       }
       process.stderr.write("inplan: hub was unavailable this turn — keeping local edits (will sync next turn)\n");
     } else {
-      // Turn applied to the hub. FIRST persist any proposal parked this turn (#88): the re-sync
-      // below overwrites the working copy with the pre-edit canonical while the proposal is still
-      // pending, so without this record the agent's text would exist only in the cloud slot with
-      // no local trace — the exact shape of the 2026-08-11 work-deletion. The record makes the
-      // park auditable turns later and the text recoverable from `.proposed.md`.
-      if (parkedThisTurn !== null) rds.parkProposal(parkedThisTurn);
-      // The working copy is now consistent with the hub for the agent's part, so record its hash
-      // (this makes a FAILED re-sync below self-heal: next run sees a matching hash and safely
-      // hydrates). Then re-sync the copy to the latest canonical (folding in the human's
+      // Turn applied to the hub. Any proposal parked this turn already has its durable record on
+      // disk (written at park time by the gateStore wrapper above), so the re-sync below can
+      // safely overwrite the working copy — the parked text stays recoverable from `.proposed.md`,
+      // unlike the 2026-08-11 incident where this overwrite destroyed the only local copy. Record
+      // the working copy's hash (this makes a FAILED re-sync self-heal: next run sees a matching
+      // hash and safely hydrates), then re-sync to the latest canonical (folding in the human's
       // just-taken turn) so the agent's NEXT turn builds on it, and clear pending.
       rds.clearReplayPending();
       rds.recordSynced(rds.readWorkFile() ?? "");

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -482,8 +482,11 @@ export async function waitCycle(backend: WaitBackend, explicitCursor: number | n
   const debounceMs = Number(process.env.INPLAN_DEBOUNCE_MS ?? 3000);
   const pollMs = Number(process.env.INPLAN_POLL_MS ?? 200);
   // Test knob, same family as the two above: how long a continuous poll-failure streak runs
-  // before the wait gives up (waitForActions' errorGraceMs; default 5 min in wait.ts).
-  const errorGraceMs = process.env.INPLAN_ERROR_GRACE_MS ? Number(process.env.INPLAN_ERROR_GRACE_MS) : undefined;
+  // before the wait gives up (waitForActions' errorGraceMs; default 5 min in wait.ts). Validated:
+  // a NaN or negative value would make the grace comparison never fire and the wait poll forever,
+  // so anything unparseable falls back to the default instead of being passed through.
+  const errorGraceParsed = Number(process.env.INPLAN_ERROR_GRACE_MS);
+  const errorGraceMs = process.env.INPLAN_ERROR_GRACE_MS && Number.isFinite(errorGraceParsed) && errorGraceParsed >= 0 ? errorGraceParsed : undefined;
 
   let waitCursor = cursor;
   let historyForMode = history;
@@ -1157,7 +1160,7 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
       const slot = await live.store.getProposed().catch(() => undefined);
       if (slot === null) {
         const { entries } = await live.channel.readSince(0);
-        rds.resolveProposal(resolutionFromEvents(entries, parkedEarlier.at));
+        rds.resolveProposal(resolutionFromEvents(entries, parkedEarlier));
       }
     }
 
@@ -1188,16 +1191,18 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
       backup: (c, m) => localStore.backup(c, m),
       getProposed: () => live.store.getProposed(),
       setProposed: async (c) => {
-        // The durable record is written ONLY after a confirmed push. A failed push flags the turn
-        // (applyGatedEdit degrades; the post-turn path below must keep-local, or the re-sync would
-        // destroy the working copy — at that point the only copy of the edit anywhere).
+        // The durable record is written ONLY after a confirmed push, and BOTH steps count as the
+        // park: a failed push leaves the working copy as the only copy of the edit, and a failed
+        // record write (push ok, fs error) leaves this machine without its recovery signal — in
+        // either case the post-turn path must keep-local instead of re-syncing the copy away, so
+        // both flag the turn as a degraded write.
         try {
           await live.store.setProposed(c);
+          rds.parkProposal(c);
         } catch (e) {
           hubParkFailed = true;
           throw e;
         }
-        rds.parkProposal(c);
       },
       clearProposed: () => live.store.clearProposed(),
     };

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -438,7 +438,7 @@ export async function waitCycle(backend: WaitBackend, explicitCursor: number | n
     // contradict each other about whether agent_revision_proposed was logged.
     process.stderr.write(
       applied.eventLogged === false
-        ? "inplan: review mode — your edit was parked as a proposal, but its notification event could NOT be logged: the proposal is safe in the cloud, and the human's editor may not show it until they reload. Not a sync failure.\n"
+        ? "inplan: review mode — your edit was parked as a proposal, but its notification event could NOT be logged: the proposal is safely stored, and the human's editor may not show it until they reload. Not a sync failure.\n"
         : "inplan: review mode — your edit was parked as a proposal (agent_revision_proposed); the canonical body is unchanged until the human accepts. This is normal, not a sync failure.\n",
     );
   }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -39,7 +39,7 @@ import { addComment, AddCommentError } from "./commentAdd";
 import { docPaths, sidecarRoot, type DocPaths } from "./paths";
 import { loadPluginGate, loadPluginGateOutcome, resolveHubUrl, type PluginAbsenceReason, type PluginGate } from "./pluginGate";
 import { demoteSource, shouldHydrateWorkFile, pendingRequiresReplay, postTurnAction, trackGateDegradations, type WaitOutcome } from "./liveSync";
-import { RemoteDocState, needsReparkFromSlot, resolutionFromEvents, utf8Bytes } from "./remoteDocState";
+import { RemoteDocState, needsReparkFromSlot, resolutionFromEvents, utf8Bytes, type ProposalOutcome } from "./remoteDocState";
 import { announcePresence, presenceTokenResolver } from "./presence";
 import { awaitReopen, wakePredicate, waitForActions } from "./wait";
 import { versionFromModule } from "./version";
@@ -440,6 +440,9 @@ export async function waitCycle(backend: WaitBackend, explicitCursor: number | n
   }
   if (applied.parkFailed) {
     process.stderr.write("inplan: pushing your edit as a review proposal FAILED — the edit is kept in the working copy and will be re-pushed on the next run.\n");
+  }
+  if (applied.eventLogged === false) {
+    process.stderr.write("inplan: the proposal was parked, but its notification event could not be logged — the human's editor may not show it until they reload. The proposal itself is safe.\n");
   }
   // Rides every terminal output below, so the agent sees the park no matter how the wait ends —
   // including wait_failed and superseded, where mistaking a parked edit for a failed sync is
@@ -1164,7 +1167,30 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
     // 'decided'. A transient slot read failure skips both — retry next run.
     const slot = await live.store.getProposed().catch(() => undefined);
     if (typeof slot === "string" && needsReparkFromSlot(rds.latestProposal(), slot)) {
-      rds.parkProposal(slot);
+      try {
+        // A pending record the slot no longer matches was DISPLACED while we were away — but not
+        // necessarily superseded: the human may have decided it before another machine parked the
+        // slot's new content. Resolve it from the decision events FIRST, so a real acceptance is
+        // never mislabeled; only when no decision is readable does 'superseded' apply (the slot's
+        // replacement content is itself the proof of displacement, so no grace is owed here).
+        const displaced = rds.pendingProposal();
+        if (displaced) {
+          let outcome: ProposalOutcome = "superseded";
+          try {
+            const { entries } = await live.channel.readSince(0);
+            const resolved = resolutionFromEvents(entries, displaced);
+            if (resolved !== "decided") outcome = resolved;
+          } catch {
+            /* events unreadable — displacement is still certain, so 'superseded' stands */
+          }
+          rds.resolveProposal(outcome);
+        }
+        rds.parkProposal(slot);
+      } catch (e) {
+        // Local persistence trouble must not stop the attach: the cloud proposal stays live and
+        // reconciliation retries on the next run.
+        process.stderr.write(`inplan: could not reconcile the local proposal record (${String(e)}); continuing — it will retry next run\n`);
+      }
     }
     const parkedEarlier = rds.pendingProposal();
     if (parkedEarlier && slot === null) {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -39,7 +39,7 @@ import { addComment, AddCommentError } from "./commentAdd";
 import { docPaths, sidecarRoot, type DocPaths } from "./paths";
 import { loadPluginGate, loadPluginGateOutcome, resolveHubUrl, type PluginAbsenceReason, type PluginGate } from "./pluginGate";
 import { demoteSource, shouldHydrateWorkFile, pendingRequiresReplay, postTurnAction, trackGateDegradations, type WaitOutcome } from "./liveSync";
-import { RemoteDocState, resolutionFromEvents } from "./remoteDocState";
+import { RemoteDocState, resolutionFromEvents, utf8Bytes } from "./remoteDocState";
 import { announcePresence, presenceTokenResolver } from "./presence";
 import { awaitReopen, wakePredicate, waitForActions } from "./wait";
 import { versionFromModule } from "./version";
@@ -437,8 +437,10 @@ export async function waitCycle(backend: WaitBackend, explicitCursor: number | n
       "inplan: review mode — your edit was parked as a proposal (agent_revision_proposed); the canonical body is unchanged until the human accepts. This is normal, not a sync failure.\n",
     );
   }
-  // Rides every turn-end output below, so the agent sees the park no matter how the wait ends.
-  const proposalOut = applied.proposed ? { proposal: { state: "pending_review" as const, bytes: current.length, hash: hashBody(current) } } : {};
+  // Rides every terminal output below, so the agent sees the park no matter how the wait ends —
+  // including wait_failed and superseded, where mistaking a parked edit for a failed sync is
+  // exactly the misread this field exists to prevent.
+  const proposalOut = applied.proposed ? { proposal: { state: "pending_review" as const, bytes: utf8Bytes(current), hash: hashBody(current) } } : {};
 
   // Signal the agent has (re)engaged this round so the editor can clear its
   // "Agent is thinking…" indicator even when the agent made no body change.
@@ -473,6 +475,9 @@ export async function waitCycle(backend: WaitBackend, explicitCursor: number | n
 
   const debounceMs = Number(process.env.INPLAN_DEBOUNCE_MS ?? 3000);
   const pollMs = Number(process.env.INPLAN_POLL_MS ?? 200);
+  // Test knob, same family as the two above: how long a continuous poll-failure streak runs
+  // before the wait gives up (waitForActions' errorGraceMs; default 5 min in wait.ts).
+  const errorGraceMs = process.env.INPLAN_ERROR_GRACE_MS ? Number(process.env.INPLAN_ERROR_GRACE_MS) : undefined;
 
   let waitCursor = cursor;
   let historyForMode = history;
@@ -482,7 +487,7 @@ export async function waitCycle(backend: WaitBackend, explicitCursor: number | n
     // (history is re-read on resume), so a mode switched just before the reload is honoured.
     const mode = modeFrom(historyForMode);
     const isActionable = wakePredicate(mode.wake);
-    const result = await waitForActions({ channel, cursor: waitCursor, debounceMs, pollMs, isActionable, token: lockToken });
+    const result = await waitForActions({ channel, cursor: waitCursor, debounceMs, pollMs, isActionable, token: lockToken, ...(errorGraceMs !== undefined ? { errorGraceMs } : {}) });
 
     // The wait gave up after a streak of failed polls — an expired session is the common cause.
     // Report it as a status the agent can act on and exit non-zero. It used to reach here as an
@@ -490,7 +495,7 @@ export async function waitCycle(backend: WaitBackend, explicitCursor: number | n
     if (result.failed) {
       backend.logExit("poll_failed");
       process.stderr.write(`inplan: lost contact with the document (${result.failed.message}).\n  If your session expired, run \`inplan login\` and re-attach.\n`);
-      output({ status: "wait_failed", message: result.failed.message });
+      output({ status: "wait_failed", message: result.failed.message, ...proposalOut });
       exitAfterFlush(EXIT_WAIT_FAILED);
       return "exiting";
     }
@@ -499,7 +504,7 @@ export async function waitCycle(backend: WaitBackend, explicitCursor: number | n
     // advancing the cursor (the live waiter handles it).
     if (result.superseded) {
       backend.logExit("superseded");
-      output({ status: "superseded" });
+      output({ status: "superseded", ...proposalOut });
       return "ok";
     }
 
@@ -557,7 +562,7 @@ export async function waitCycle(backend: WaitBackend, explicitCursor: number | n
       const reopen = await awaitReopen(channel, result.cursor, { token: lockToken });
       if (reopen.kind === "superseded") {
         backend.logExit("superseded");
-        output({ status: "superseded" });
+        output({ status: "superseded", ...proposalOut });
         return "ok";
       }
       if (reopen.kind === "completed") {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -339,8 +339,9 @@ export interface WaitBackend {
   logExit(reason: string): void;
   /** Handle a `save_locally_requested` directive (cloud→local handoff). When set
    *  and that event wakes the wait, this runs instead of the normal status output
-   *  and is responsible for emitting its own result. Absent on the desktop. */
-  onSaveLocally?: () => Promise<void>;
+   *  and is responsible for emitting its own result — including the turn's landing
+   *  signal, passed through `info`, so the handoff can't hide a parked proposal. */
+  onSaveLocally?: (info: { proposal?: { state: "pending_review"; bytes: number; hash: string } }) => Promise<void>;
 }
 
 /** Local sidecar-file backend for a document on disk. */
@@ -437,10 +438,15 @@ export async function waitCycle(backend: WaitBackend, explicitCursor: number | n
       "inplan: review mode — your edit was parked as a proposal (agent_revision_proposed); the canonical body is unchanged until the human accepts. This is normal, not a sync failure.\n",
     );
   }
+  if (applied.parkFailed) {
+    process.stderr.write("inplan: pushing your edit as a review proposal FAILED — the edit is kept in the working copy and will be re-pushed on the next run.\n");
+  }
   // Rides every terminal output below, so the agent sees the park no matter how the wait ends —
   // including wait_failed and superseded, where mistaking a parked edit for a failed sync is
   // exactly the misread this field exists to prevent.
-  const proposalOut = applied.proposed ? { proposal: { state: "pending_review" as const, bytes: utf8Bytes(current), hash: hashBody(current) } } : {};
+  const proposalOut: { proposal?: { state: "pending_review"; bytes: number; hash: string } } = applied.proposed
+    ? { proposal: { state: "pending_review", bytes: utf8Bytes(current), hash: hashBody(current) } }
+    : {};
 
   // Signal the agent has (re)engaged this round so the editor can clear its
   // "Agent is thinking…" indicator even when the agent made no body change.
@@ -516,7 +522,7 @@ export async function waitCycle(backend: WaitBackend, explicitCursor: number | n
     // would be lost. On success the doc becomes local, so the cloud cursor is moot.
     if (backend.onSaveLocally && result.entries.some((e) => e.type === LogEventType.SaveLocallyRequested)) {
       backend.logExit("save_locally");
-      await backend.onSaveLocally();
+      await backend.onSaveLocally(proposalOut);
       return "ok";
     }
 
@@ -1173,6 +1179,7 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
     // leaves the record + text on disk, and it exists long before the end-of-turn re-sync
     // overwrites the working copy.
     const localStore = fsBackend(workFile).store;
+    let hubParkFailed = false;
     const gateStore: DocumentStore = {
       loadDoc: () => localStore.loadDoc(),
       saveDoc: (c) => localStore.saveDoc(c),
@@ -1181,7 +1188,15 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
       backup: (c, m) => localStore.backup(c, m),
       getProposed: () => live.store.getProposed(),
       setProposed: async (c) => {
-        await live.store.setProposed(c);
+        // The durable record is written ONLY after a confirmed push. A failed push flags the turn
+        // (applyGatedEdit degrades; the post-turn path below must keep-local, or the re-sync would
+        // destroy the working copy — at that point the only copy of the edit anywhere).
+        try {
+          await live.store.setProposed(c);
+        } catch (e) {
+          hubParkFailed = true;
+          throw e;
+        }
         rds.parkProposal(c);
       },
       clearProposed: () => live.store.clearProposed(),
@@ -1190,12 +1205,12 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
     // live.store isn't updated by gate.applyRevision, so reading it would write a stale doc. If
     // the hub read fails we throw BEFORE writing status, so the doc isn't switched to local.
     const onSaveLocallyGate = localFile
-      ? async () => {
+      ? async (info: { proposal?: { state: "pending_review"; bytes: number; hash: string } }) => {
           const body = await gate.readCanonical();
           writeFileSync(localFile, body);
           writeStatus(docPaths(localFile).statusPath, { location: "local", originalPath: localFile, lastSyncedHash: hashBody(body) });
           const pid = spawnApp(localFile);
-          output({ status: "moved_local", path: localFile, reopened: pid !== null });
+          output({ status: "moved_local", path: localFile, reopened: pid !== null, ...info });
         }
       : undefined;
 
@@ -1223,7 +1238,11 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
       tracked.gate, // …and accepted edits apply through the hub, not the store.
     );
 
-    const action = postTurnAction(outcome, { readFailed: tracked.readFailed(), writeFailed: tracked.writeFailed() });
+    // A failed park counts as a write failure: the edit exists ONLY in the working copy, so the
+    // healthy-path re-sync below would destroy it, and `.pending` must protect it until the next
+    // run's quarantine re-parks it.
+    const degraded = { readFailed: tracked.readFailed(), writeFailed: tracked.writeFailed() || hubParkFailed };
+    const action = postTurnAction(outcome, degraded);
     if (action === "stop") return; // a fail-fast exit is pending — never touch the working copy
 
     if (action === "keep-local") {
@@ -1232,7 +1251,7 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
       // revision persisted off-hub that must be replayed. A read-only failure leaves the working
       // copy either unchanged (clean) or hash-diverged (agent edited); both are handled by the
       // start-of-turn hydration check, and a spurious `.pending` would wrongly skip it next run.
-      if (pendingRequiresReplay({ readFailed: tracked.readFailed(), writeFailed: tracked.writeFailed() })) {
+      if (pendingRequiresReplay(degraded)) {
         rds.markReplayPending();
       }
       process.stderr.write("inplan: hub was unavailable this turn — keeping local edits (will sync next turn)\n");

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1159,8 +1159,12 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
     if (parkedEarlier) {
       const slot = await live.store.getProposed().catch(() => undefined);
       if (slot === null) {
-        const { entries } = await live.channel.readSince(0);
-        rds.resolveProposal(resolutionFromEvents(entries, parkedEarlier));
+        try {
+          const { entries } = await live.channel.readSince(0);
+          rds.resolveProposal(resolutionFromEvents(entries, parkedEarlier));
+        } catch {
+          /* transient history read failure: leave the record pending and retry next run */
+        }
       }
     }
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -434,15 +434,16 @@ export async function waitCycle(backend: WaitBackend, explicitCursor: number | n
   // DESIGN, and an agent that reads silence as loss may destroy its own work. Say so on stderr
   // now, and carry the fact in the wait output below (the durable record is the gate path's job).
   if (applied.proposed) {
+    // One coherent line per outcome — the with-event and without-event messages must not
+    // contradict each other about whether agent_revision_proposed was logged.
     process.stderr.write(
-      "inplan: review mode — your edit was parked as a proposal (agent_revision_proposed); the canonical body is unchanged until the human accepts. This is normal, not a sync failure.\n",
+      applied.eventLogged === false
+        ? "inplan: review mode — your edit was parked as a proposal, but its notification event could NOT be logged: the proposal is safe in the cloud, and the human's editor may not show it until they reload. Not a sync failure.\n"
+        : "inplan: review mode — your edit was parked as a proposal (agent_revision_proposed); the canonical body is unchanged until the human accepts. This is normal, not a sync failure.\n",
     );
   }
   if (applied.parkFailed) {
     process.stderr.write("inplan: pushing your edit as a review proposal FAILED — the edit is kept in the working copy and will be re-pushed on the next run.\n");
-  }
-  if (applied.eventLogged === false) {
-    process.stderr.write("inplan: the proposal was parked, but its notification event could not be logged — the human's editor may not show it until they reload. The proposal itself is safe.\n");
   }
   // Rides every terminal output below, so the agent sees the park no matter how the wait ends —
   // including wait_failed and superseded, where mistaking a parked edit for a failed sync is
@@ -486,7 +487,17 @@ export async function waitCycle(backend: WaitBackend, explicitCursor: number | n
   // Last writer wins — any older waiter sees the token change and steps down. Log the exit reason —
   // including OS signals — so a reaped waiter is diagnosable instead of "vanishing" silently.
   const lockToken = `${process.pid}-${Date.now()}`;
-  await channel.claimLock(lockToken);
+  try {
+    await channel.claimLock(lockToken);
+  } catch (e) {
+    // A write-dead control backend must not crash the wait into a no-status exit — the landing
+    // signal above (proposalOut) is promised on every terminal output, this one included.
+    backend.logExit("claim_lock_failed");
+    process.stderr.write(`inplan: could not claim the wait lock (${String(e)}).\n  If your session expired, run \`inplan login\` and re-attach.\n`);
+    output({ status: "wait_failed", message: `could not claim the wait lock: ${String(e)}`, ...proposalOut });
+    exitAfterFlush(EXIT_WAIT_FAILED);
+    return "exiting";
+  }
   for (const sig of ["SIGTERM", "SIGHUP", "SIGINT"] as const) {
     process.on(sig, () => {
       backend.logExit(`signal:${sig}`);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1188,27 +1188,38 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
     // has emptied: the decision events name the outcome; when none is readable yet, the record
     // waits one more run (a slot-clear can race ahead of its decision event) before degrading to
     // 'decided'. A transient slot read failure skips both — retry next run.
+    // Whether THIS attach transitioned a record pending → terminal. The corpse restore below is
+    // gated on it: only a just-decided proposal's leftover text is a corpse — on any later attach
+    // an identical working copy is a deliberate re-edit (an agent may legitimately re-propose
+    // byte-identical content after a rejection), and overwriting it would destroy real work.
+    let justFinalized = false;
     const slot = await live.store.getProposed().catch(() => undefined);
     if (typeof slot === "string" && needsReparkFromSlot(rds.latestProposal(), slot)) {
       try {
         // A pending record the slot no longer matches was DISPLACED while we were away — but not
         // necessarily superseded: the human may have decided it before another machine parked the
         // slot's new content. Resolve it from the decision events FIRST, so a real acceptance is
-        // never mislabeled; only when no decision is readable does 'superseded' apply (the slot's
-        // replacement content is itself the proof of displacement, so no grace is owed here).
+        // never mislabeled. When no decision is readable, the record gets the same one-run grace
+        // as the empty-slot path (the decision event can lag the slot change) — the repark is
+        // deferred with it, and a still-unreadable outcome next run finalizes as 'superseded'.
         const displaced = rds.pendingProposal();
+        let outcome: ProposalOutcome | null = "superseded";
         if (displaced) {
-          let outcome: ProposalOutcome = "superseded";
           try {
             const { entries } = await live.channel.readSince(0);
             const resolved = resolutionFromEvents(entries, displaced);
             if (resolved !== "decided") outcome = resolved;
+            else if (!displaced.awaitingOutcomeSince) outcome = null; // first sighting — grace
           } catch {
-            /* events unreadable — displacement is still certain, so 'superseded' stands */
+            if (!displaced.awaitingOutcomeSince) outcome = null; // unreadable — same grace
           }
-          rds.resolveProposal(outcome);
         }
-        rds.parkProposal(slot);
+        if (displaced && outcome === null) {
+          rds.noteOutcomeMissing(); // defer both the finalization and the repark one run
+        } else {
+          if (displaced && outcome) justFinalized = rds.resolveProposal(outcome) !== null;
+          rds.parkProposal(slot);
+        }
       } catch (e) {
         // Local persistence trouble must not stop the attach: the cloud proposal stays live and
         // reconciliation retries on the next run.
@@ -1220,20 +1231,21 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
       try {
         const { entries } = await live.channel.readSince(0);
         const outcome = resolutionFromEvents(entries, parkedEarlier);
-        if (outcome !== "decided") rds.resolveProposal(outcome);
-        else if (parkedEarlier.awaitingOutcomeSince) rds.resolveProposal("decided");
+        if (outcome !== "decided") justFinalized = rds.resolveProposal(outcome) !== null;
+        else if (parkedEarlier.awaitingOutcomeSince) justFinalized = rds.resolveProposal("decided") !== null;
         else rds.noteOutcomeMissing();
       } catch {
         /* transient history read failure: leave the record pending and retry next run */
       }
     }
 
-    // A working copy equal to a DECIDED proposal's text is not "unsynced agent edits" — the
+    // A working copy equal to a JUST-decided proposal's text is not "unsynced agent edits" — the
     // post-turn re-sync died before running, and the human has since decided. Restore canonical
     // (the decision stands, whichever way it went); keeping the copy would quarantine it again
-    // next turn and re-park a proposal the human may have just rejected. Skip when a replay is
-    // pending — that marker means the copy holds an unpushed direct edit, not a proposal corpse.
-    if (!rds.replayPending() && isDecidedProposalCorpse(rds.latestProposal(), rds.readWorkFile())) {
+    // next turn and re-park a proposal the human may have just rejected. Gated on justFinalized:
+    // on any LATER attach an identical copy is a deliberate re-edit to preserve, not a corpse.
+    // Skip when a replay is pending — that copy holds an unpushed direct edit.
+    if (justFinalized && !rds.replayPending() && isDecidedProposalCorpse(rds.latestProposal(), rds.readWorkFile())) {
       rds.writeWorkFile(canonical);
       rds.recordSynced(canonical);
     }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -39,7 +39,7 @@ import { addComment, AddCommentError } from "./commentAdd";
 import { docPaths, sidecarRoot, type DocPaths } from "./paths";
 import { loadPluginGate, loadPluginGateOutcome, resolveHubUrl, type PluginAbsenceReason, type PluginGate } from "./pluginGate";
 import { demoteSource, shouldHydrateWorkFile, pendingRequiresReplay, postTurnAction, trackGateDegradations, type WaitOutcome } from "./liveSync";
-import { RemoteDocState, needsReparkFromSlot, resolutionFromEvents, utf8Bytes, type ProposalOutcome } from "./remoteDocState";
+import { RemoteDocState, isDecidedProposalCorpse, needsReparkFromSlot, resolutionFromEvents, utf8Bytes, type ProposalOutcome } from "./remoteDocState";
 import { announcePresence, presenceTokenResolver } from "./presence";
 import { awaitReopen, wakePredicate, waitForActions } from "./wait";
 import { versionFromModule } from "./version";
@@ -341,7 +341,7 @@ export interface WaitBackend {
    *  and that event wakes the wait, this runs instead of the normal status output
    *  and is responsible for emitting its own result — including the turn's landing
    *  signal, passed through `info`, so the handoff can't hide a parked proposal. */
-  onSaveLocally?: (info: { proposal?: { state: "pending_review"; bytes: number; hash: string } }) => Promise<void>;
+  onSaveLocally?: (info: { proposal?: { state: "pending_review" | "park_failed"; bytes: number; hash: string } }) => Promise<void>;
 }
 
 /** Local sidecar-file backend for a document on disk. */
@@ -446,14 +446,26 @@ export async function waitCycle(backend: WaitBackend, explicitCursor: number | n
   }
   // Rides every terminal output below, so the agent sees the park no matter how the wait ends —
   // including wait_failed and superseded, where mistaking a parked edit for a failed sync is
-  // exactly the misread this field exists to prevent.
-  const proposalOut: { proposal?: { state: "pending_review"; bytes: number; hash: string } } = applied.proposed
+  // exactly the misread this field exists to prevent. A FAILED park is machine-readable too
+  // (state "park_failed"): an agent parsing only the JSON must never read a failed push as a
+  // no-change turn — stderr alone is not a signal contract.
+  const proposalOut: { proposal?: { state: "pending_review" | "park_failed"; bytes: number; hash: string } } = applied.proposed
     ? { proposal: { state: "pending_review", bytes: utf8Bytes(current), hash: hashBody(current) } }
-    : {};
+    : applied.parkFailed
+      ? { proposal: { state: "park_failed", bytes: utf8Bytes(current), hash: hashBody(current) } }
+      : {};
 
   // Signal the agent has (re)engaged this round so the editor can clear its
-  // "Agent is thinking…" indicator even when the agent made no body change.
-  await channel.append({ actor: "agent", type: LogEventType.AgentRevised });
+  // "Agent is thinking…" indicator even when the agent made no body change. Guarded: with the
+  // control log write-degraded (the same outage that just swallowed a park event), an unguarded
+  // append here crashed the whole wait with NO status — the one exit that must never happen once
+  // proposalOut is carrying the landing signal. The wait itself may still work (reads can be
+  // healthy while writes fail), and if it doesn't, wait_failed reports with proposalOut attached.
+  try {
+    await channel.append({ actor: "agent", type: LogEventType.AgentRevised });
+  } catch {
+    process.stderr.write("inplan: could not log the turn marker (control log write failed) — the editor may keep showing 'Agent is thinking' until it reloads.\n");
+  }
 
   // ── Everything below only READS, WAITS, and REPORTS. ──────────────────────────────────────────
   //
@@ -1205,6 +1217,16 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
       }
     }
 
+    // A working copy equal to a DECIDED proposal's text is not "unsynced agent edits" — the
+    // post-turn re-sync died before running, and the human has since decided. Restore canonical
+    // (the decision stands, whichever way it went); keeping the copy would quarantine it again
+    // next turn and re-park a proposal the human may have just rejected. Skip when a replay is
+    // pending — that marker means the copy holds an unpushed direct edit, not a proposal corpse.
+    if (!rds.replayPending() && isDecidedProposalCorpse(rds.latestProposal(), rds.readWorkFile())) {
+      rds.writeWorkFile(canonical);
+      rds.recordSynced(canonical);
+    }
+
     // Decide whether to (re)hydrate the working copy from the freshly probed canonical. Seed if
     // absent; keep it if a local fallback edit is pending (must push first); otherwise refresh it
     // ONLY when the agent hasn't touched it since our last sync (hash match) — so we pull the
@@ -1255,7 +1277,7 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
     // live.store isn't updated by gate.applyRevision, so reading it would write a stale doc. If
     // the hub read fails we throw BEFORE writing status, so the doc isn't switched to local.
     const onSaveLocallyGate = localFile
-      ? async (info: { proposal?: { state: "pending_review"; bytes: number; hash: string } }) => {
+      ? async (info: { proposal?: { state: "pending_review" | "park_failed"; bytes: number; hash: string } }) => {
           const body = await gate.readCanonical();
           writeFileSync(localFile, body);
           writeStatus(docPaths(localFile).statusPath, { location: "local", originalPath: localFile, lastSyncedHash: hashBody(body) });

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -39,6 +39,7 @@ import { addComment, AddCommentError } from "./commentAdd";
 import { docPaths, sidecarRoot, type DocPaths } from "./paths";
 import { loadPluginGate, loadPluginGateOutcome, resolveHubUrl, type PluginAbsenceReason, type PluginGate } from "./pluginGate";
 import { demoteSource, shouldHydrateWorkFile, pendingRequiresReplay, postTurnAction, trackGateDegradations, type WaitOutcome } from "./liveSync";
+import { RemoteDocState, resolutionFromEvents } from "./remoteDocState";
 import { announcePresence, presenceTokenResolver } from "./presence";
 import { awaitReopen, wakePredicate, waitForActions } from "./wait";
 import { versionFromModule } from "./version";
@@ -427,7 +428,17 @@ export async function waitCycle(backend: WaitBackend, explicitCursor: number | n
   const acceptance = acceptanceFrom(history);
   const quarantine = acceptance === "review" && parse(canonicalText).body !== parse(current).body;
   // `usePlugin ? gate : null` — only route through the plugin when its read succeeded.
-  await applyGatedEdit(store, channel, ev, { current, canonicalText, quarantine, gate: usePlugin ? gate : null });
+  const applied = await applyGatedEdit(store, channel, ev, { current, canonicalText, quarantine, gate: usePlugin ? gate : null });
+  // A parked proposal must be unmistakable in the moment (#88): the canonical is unchanged BY
+  // DESIGN, and an agent that reads silence as loss may destroy its own work. Say so on stderr
+  // now, and carry the fact in the wait output below (the durable record is the gate path's job).
+  if (applied.proposed) {
+    process.stderr.write(
+      "inplan: review mode — your edit was parked as a proposal (agent_revision_proposed); the canonical body is unchanged until the human accepts. This is normal, not a sync failure.\n",
+    );
+  }
+  // Rides every turn-end output below, so the agent sees the park no matter how the wait ends.
+  const proposalOut = applied.proposed ? { proposal: { state: "pending_review" as const, bytes: current.length, hash: hashBody(current) } } : {};
 
   // Signal the agent has (re)engaged this round so the editor can clear its
   // "Agent is thinking…" indicator even when the agent made no body change.
@@ -513,7 +524,7 @@ export async function waitCycle(backend: WaitBackend, explicitCursor: number | n
     if (navEntry) {
       const path = (navEntry.payload as { path?: string } | undefined)?.path;
       backend.logExit("navigated");
-      output({ status: "navigated", ...(path ? { path } : {}), cursor: result.cursor, closed: false });
+      output({ status: "navigated", ...(path ? { path } : {}), ...proposalOut, cursor: result.cursor, closed: false });
       return "ok";
     }
 
@@ -556,7 +567,7 @@ export async function waitCycle(backend: WaitBackend, explicitCursor: number | n
         // unrecorded and the next wait would re-read and re-report the completed session.
         await channel.setCursor(reopen.cursor);
         backend.logExit(reopen.reason);
-        output({ status: "closed", reason: reopen.reason, cursor: reopen.cursor, closed: true, entries: [...result.entries, ...reopen.entries] });
+        output({ status: "closed", reason: reopen.reason, ...proposalOut, cursor: reopen.cursor, closed: true, entries: [...result.entries, ...reopen.entries] });
         return "ok";
       }
       // A grace reopen deliberately resumes from the PRE-grace cursor: the user entries that proved
@@ -601,6 +612,10 @@ export async function waitCycle(backend: WaitBackend, explicitCursor: number | n
       // when --model was passed), so presence + authorship stay consistent.
       agentAuthor: agentAuthorFor(model),
       ...(reason ? { reason } : {}),
+      // The landing signal for a parked Review-mode edit (#88): pending_review means the push
+      // REACHED the store and awaits the human — the canonical is unchanged by design. Absent
+      // when the turn applied directly (or made no body change).
+      ...proposalOut,
       cursor: result.cursor,
       closed: status === "closed",
       entries: result.entries,
@@ -1103,11 +1118,10 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
   );
   try {
     const workFile = join(sidecarRoot(), "remote", `${docId}.plan.md`);
-    const pendingPath = `${workFile}.pending`; // marker: a local fallback edit awaits a hub push
-    const hashPath = `${workFile}.synced`; // hash of the working copy at our last write/sync
-    mkdirSync(dirname(workFile), { recursive: true });
-    const readIf = (p: string): string | null => (existsSync(p) ? readFileSync(p, "utf8") : null);
-    const recordSynced = (content: string) => writeFileSync(hashPath, hashBody(content));
+    // All per-doc sidecar state (working copy hash, replay marker, proposal record) lives behind
+    // one tested owner (#88) — same files on disk as before, plus the durable proposal record.
+    const rds = new RemoteDocState(workFile, docId);
+    rds.ensureDir();
 
     // Probe the hub on EVERY run. A failure here means we cannot materialize the working copy, so
     // there is nothing for an out-of-process agent to read or edit — the same dead end the
@@ -1122,28 +1136,37 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
       exitAfterFlush(EXIT_PLUGIN_UNAVAILABLE);
       return; // the `finally` below tears presence down on the way out
     }
+    // A proposal parked on an EARLIER run resolves here (#88): if the cloud's proposed slot has
+    // emptied, the human decided — finalize the record with the outcome the decision events name
+    // (accepted / partially_accepted / rejected), so "did my edit land?" stays answerable from
+    // disk even though agent_revision_proposed left the wait output long ago. A transient slot
+    // read failure just retries next run; the record stays pending.
+    const parkedEarlier = rds.pendingProposal();
+    if (parkedEarlier) {
+      const slot = await live.store.getProposed().catch(() => undefined);
+      if (slot === null) {
+        const { entries } = await live.channel.readSince(0);
+        rds.resolveProposal(resolutionFromEvents(entries, parkedEarlier.at));
+      }
+    }
+
     // Decide whether to (re)hydrate the working copy from the freshly probed canonical. Seed if
     // absent; keep it if a local fallback edit is pending (must push first); otherwise refresh it
     // ONLY when the agent hasn't touched it since our last sync (hash match) — so we pull the
     // human's edits without clobbering unsynced agent edits. This is also what lets a FAILED
     // end-of-turn re-sync self-heal on the next run.
-    const exists = existsSync(workFile);
-    if (
-      shouldHydrateWorkFile({
-        exists,
-        pending: existsSync(pendingPath),
-        currentHash: exists ? hashBody(readFileSync(workFile, "utf8")) : null,
-        syncedHash: readIf(hashPath),
-      })
-    ) {
-      writeFileSync(workFile, canonical);
-      recordSynced(canonical);
+    if (shouldHydrateWorkFile(rds.hydrateInput())) {
+      rds.writeWorkFile(canonical);
+      rds.recordSynced(canonical);
     }
 
     // Working doc stays on the local file, but Review-mode PROPOSALS persist to the CLOUD doc's
     // proposal store (via live.store) — otherwise a parked proposal would sit in this machine's
-    // sidecar, invisible to the human in the web editor who's meant to accept/reject it.
+    // sidecar, invisible to the human in the web editor who's meant to accept/reject it. The
+    // wrapper also captures the parked text so the healthy-turn path below can write the durable
+    // proposal record BEFORE the re-sync overwrites the working copy (#88).
     const localStore = fsBackend(workFile).store;
+    let parkedThisTurn: string | null = null;
     const gateStore: DocumentStore = {
       loadDoc: () => localStore.loadDoc(),
       saveDoc: (c) => localStore.saveDoc(c),
@@ -1151,8 +1174,14 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
       setCanonical: (c) => localStore.setCanonical(c),
       backup: (c, m) => localStore.backup(c, m),
       getProposed: () => live.store.getProposed(),
-      setProposed: (c) => live.store.setProposed(c),
-      clearProposed: () => live.store.clearProposed(),
+      setProposed: async (c) => {
+        await live.store.setProposed(c);
+        parkedThisTurn = c;
+      },
+      clearProposed: async () => {
+        await live.store.clearProposed();
+        parkedThisTurn = null;
+      },
     };
     // Save-local handoff on the gate path reads the HUB canonical (the source of truth here);
     // live.store isn't updated by gate.applyRevision, so reading it would write a stale doc. If
@@ -1201,20 +1230,26 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
       // copy either unchanged (clean) or hash-diverged (agent edited); both are handled by the
       // start-of-turn hydration check, and a spurious `.pending` would wrongly skip it next run.
       if (pendingRequiresReplay({ readFailed: tracked.readFailed(), writeFailed: tracked.writeFailed() })) {
-        writeFileSync(pendingPath, "1");
+        rds.markReplayPending();
       }
       process.stderr.write("inplan: hub was unavailable this turn — keeping local edits (will sync next turn)\n");
     } else {
-      // Turn applied to the hub. The working copy is now consistent with the hub for the agent's
-      // part, so record its hash (this makes a FAILED re-sync below self-heal: next run sees a
-      // matching hash and safely hydrates). Then re-sync the copy to the latest canonical (folding
-      // in the human's just-taken turn) so the agent's NEXT turn builds on it, and clear pending.
-      if (existsSync(pendingPath)) rmSync(pendingPath);
-      recordSynced(readFileSync(workFile, "utf8"));
+      // Turn applied to the hub. FIRST persist any proposal parked this turn (#88): the re-sync
+      // below overwrites the working copy with the pre-edit canonical while the proposal is still
+      // pending, so without this record the agent's text would exist only in the cloud slot with
+      // no local trace — the exact shape of the 2026-08-11 work-deletion. The record makes the
+      // park auditable turns later and the text recoverable from `.proposed.md`.
+      if (parkedThisTurn !== null) rds.parkProposal(parkedThisTurn);
+      // The working copy is now consistent with the hub for the agent's part, so record its hash
+      // (this makes a FAILED re-sync below self-heal: next run sees a matching hash and safely
+      // hydrates). Then re-sync the copy to the latest canonical (folding in the human's
+      // just-taken turn) so the agent's NEXT turn builds on it, and clear pending.
+      rds.clearReplayPending();
+      rds.recordSynced(rds.readWorkFile() ?? "");
       try {
         const fresh = await gate.readCanonical();
-        writeFileSync(workFile, fresh);
-        recordSynced(fresh);
+        rds.writeWorkFile(fresh);
+        rds.recordSynced(fresh);
       } catch {
         /* transient: leave the copy (its hash still matches) so the next run hydrates it */
       }

--- a/packages/cli/src/remoteDocState.ts
+++ b/packages/cli/src/remoteDocState.ts
@@ -336,6 +336,11 @@ export class RemoteDocState {
       // absent — reconciliation from the cloud slot rebuilds the truth. Finalized records
       // tolerate the mismatch: their text is historical convenience, not a recovery input.
       if (p.state === "pending_review" && (hashBody(p.text) !== p.hash || utf8Bytes(p.text) !== p.bytes)) return null;
+      // The optional grace marker must be a real timestamp or absent: a malformed truthy value
+      // would read as "already waited one run" and finalize 'decided' on the first slot clear,
+      // skipping the grace entirely. Strip it rather than reject the record — the pending
+      // proposal itself is intact; only the marker is damaged.
+      if (p.awaitingOutcomeSince !== undefined && !Number.isFinite(Date.parse(p.awaitingOutcomeSince))) delete p.awaitingOutcomeSince;
       return p as StoredProposal;
     } catch {
       return null;

--- a/packages/cli/src/remoteDocState.ts
+++ b/packages/cli/src/remoteDocState.ts
@@ -26,7 +26,7 @@
 //    slot at the next attach (see `needsReparkFromSlot`) — the slot is the authoritative side
 //    of the push, so it, not local heuristics, is the recovery source.
 
-import { appendFileSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { appendFileSync, closeSync, existsSync, fstatSync, mkdirSync, openSync, readFileSync, readSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { hashBody, LogEventType, type LogEntry } from "@inplan/core/node";
 import type { HydrateInput } from "./liveSync";
@@ -79,17 +79,18 @@ export function resolutionFromEvents(entries: LogEntry[], park: { at: string; ha
   for (let i = entries.length - 1; i >= 0; i--) {
     const e = entries[i]!;
     if (e.type !== LogEventType.AgentRevisionProposed) continue;
+    // Any candidate — hash-matched or weak — must plausibly BE this park: an event stamped after
+    // our recorded park time (5s slack for CLI-vs-server clock disagreement) is someone else's
+    // LATER park, even when its content hash matches ours (identical text is not identity — a
+    // newer proposal repeating our text must not donate its decision window to this record).
+    const ts = Date.parse(e.ts);
+    if (Number.isFinite(parkedAt) && Number.isFinite(ts) && ts > parkedAt + 5_000) continue;
     if ((e.payload as { hash?: unknown } | undefined)?.hash === park.hash) {
       start = i;
       matched = true;
       break;
     }
-    // Weak-anchor candidate: the newest park event that could plausibly BE this park — i.e. not
-    // stamped after our recorded park time (5s slack for CLI-vs-server clock disagreement).
-    if (start < 0) {
-      const ts = Date.parse(e.ts);
-      if (!Number.isFinite(parkedAt) || !Number.isFinite(ts) || ts <= parkedAt + 5_000) start = i;
-    }
+    if (start < 0) start = i; // newest eligible park: the weak-anchor candidate
   }
   // The window closes at the NEXT park event after the anchor: decisions beyond it belong to a
   // newer proposal. This applies even with NO anchor (every park event postdates us): the first
@@ -204,6 +205,14 @@ export class RemoteDocState {
     const prior = this.pendingProposal();
     const hash = hashBody(text);
     if (prior && prior.hash === hash) {
+      // Same proposal, re-pushed. A stale awaiting-outcome marker must not survive the re-push:
+      // the slot is live again, so a later slot-clear deserves the full grace before degrading
+      // to 'decided', not an immediate finalization off the old sighting.
+      if (prior.awaitingOutcomeSince) {
+        const { awaitingOutcomeSince: _stale, ...rest } = prior;
+        this.publish({ ...rest, text });
+        return rest;
+      }
       this.writeDerivedText(text);
       return prior;
     }
@@ -301,18 +310,35 @@ export class RemoteDocState {
     try {
       const p = JSON.parse(readFileSync(this.recordPath, "utf8")) as Partial<StoredProposal>;
       const validState = p.state === "pending_review" || p.state === "accepted" || p.state === "partially_accepted" || p.state === "rejected" || p.state === "decided" || p.state === "superseded";
-      if (typeof p.id !== "string" || p.docId !== this.docId || typeof p.hash !== "string" || typeof p.bytes !== "number" || !Number.isFinite(Date.parse(p.at ?? "")) || !validState || typeof p.text !== "string") return null;
+      if (typeof p.id !== "string" || p.docId !== this.docId || typeof p.hash !== "string" || !Number.isInteger(p.bytes) || (p.bytes as number) < 0 || !Number.isFinite(Date.parse(p.at ?? "")) || !validState || typeof p.text !== "string") return null;
+      // A PENDING record's text is load-bearing (recovery, re-push, slot comparison), so a
+      // valid-JSON-but-corrupted record whose hash/bytes disagree with its own text reads as
+      // absent — reconciliation from the cloud slot rebuilds the truth. Finalized records
+      // tolerate the mismatch: their text is historical convenience, not a recovery input.
+      if (p.state === "pending_review" && (hashBody(p.text) !== p.hash || utf8Bytes(p.text) !== p.bytes)) return null;
       return p as StoredProposal;
     } catch {
       return null;
     }
   }
 
-  /** The history log's last finalized record, or null (absent/unreadable/invalid). */
+  /** The history log's last finalized record, or null (absent/unreadable/invalid). Reads only the
+   *  file's tail — the log is never pruned, so a whole-file read would grow without bound. */
   private historyTail(): ProposalRecord | null {
     if (!existsSync(this.historyPath)) return null;
     try {
-      const lines = readFileSync(this.historyPath, "utf8").trim().split("\n");
+      const fd = openSync(this.historyPath, "r");
+      let chunk: string;
+      try {
+        const size = fstatSync(fd).size;
+        const span = Math.min(size, 16_384); // far above any single metadata line
+        const buf = Buffer.alloc(span);
+        readSync(fd, buf, 0, span, size - span);
+        chunk = buf.toString("utf8");
+      } finally {
+        closeSync(fd);
+      }
+      const lines = chunk.trim().split("\n");
       const last = JSON.parse(lines[lines.length - 1]!) as Partial<ProposalRecord>;
       if (typeof last.id !== "string" || last.docId !== this.docId || typeof last.hash !== "string" || typeof last.state !== "string") return null;
       return last as ProposalRecord;

--- a/packages/cli/src/remoteDocState.ts
+++ b/packages/cli/src/remoteDocState.ts
@@ -85,7 +85,12 @@ export function resolutionFromEvents(entries: LogEntry[], park: { at: string; ha
     // newer proposal repeating our text must not donate its decision window to this record).
     const ts = Date.parse(e.ts);
     if (Number.isFinite(parkedAt) && Number.isFinite(ts) && ts > parkedAt + 5_000) continue;
-    if ((e.payload as { hash?: unknown } | undefined)?.hash === park.hash) {
+    // A hash match must also not PREDATE us by more than clock skew plausibly allows (10 min —
+    // generous for unsynced clocks): an OLDER proposal that happened to carry identical content
+    // is not our park either, and binding to its event would hand us its decision. Outside the
+    // near window, an identical-hash event only qualifies as a weak anchor like any other park.
+    const nearOurPark = !Number.isFinite(parkedAt) || !Number.isFinite(ts) || ts >= parkedAt - 600_000;
+    if (nearOurPark && (e.payload as { hash?: unknown } | undefined)?.hash === park.hash) {
       start = i;
       matched = true;
       break;
@@ -292,8 +297,11 @@ export class RemoteDocState {
   private finalize(record: ProposalRecord, outcome: ProposalOutcome): ProposalRecord {
     const { awaitingOutcomeSince: _grace, ...rest } = record;
     const finalized: ProposalRecord = { ...rest, state: outcome };
+    // Idempotency is by identity AND outcome: a crash-retried finalization with the same result
+    // appends nothing, but a retry that resolved to a DIFFERENT outcome appends the correction —
+    // the history must never disagree with the record it claims to log.
     const tail = this.historyTail();
-    if (!tail || tail.id !== finalized.id) appendFileSync(this.historyPath, `${JSON.stringify(finalized)}\n`);
+    if (!tail || tail.id !== finalized.id || tail.state !== finalized.state) appendFileSync(this.historyPath, `${JSON.stringify(finalized)}\n`);
     const stored = this.readStored();
     this.publish({ ...finalized, text: stored?.id === finalized.id ? stored.text : "" });
     return finalized;

--- a/packages/cli/src/remoteDocState.ts
+++ b/packages/cli/src/remoteDocState.ts
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Per-doc sidecar state for the live-collab (remote) working copy — the single owner of the
+// file layout under `~/.inplan/sidecars/remote/`. `runRemote` used to open-code every one of
+// these files inline; concentrating them here gives the "did my edit land?" state one tested
+// seam (#88). On disk everything is a flat sibling of the working copy, and `.synced` keeps
+// its exact legacy format (a bare hash string), so older CLIs interoperate unchanged:
+//
+//   <docId>.plan.md                 the working copy the agent reads/edits
+//   <docId>.plan.md.pending        marker: a local fallback edit awaits a hub push
+//   <docId>.plan.md.synced         hash of the working copy at our last write/sync
+//   <docId>.plan.md.proposed.json  the latest proposal record (see ProposalRecord)
+//   <docId>.plan.md.proposed.md    the latest proposal's exact pushed text
+//   <docId>.plan.md.proposals.jsonl  append-only history of finalized records (never pruned)
+//
+// The proposal record is the durable half of the landing signal: `agent_revision_proposed`
+// appears in exactly one wait output (the cursor advances past it), so an agent auditing a
+// turn later needs state on disk. The record is written BEFORE the end-of-turn re-sync
+// overwrites the working copy with canonical, so a parked edit is always recoverable from
+// `.proposed.md` — the clobber that made the 2026-08-11 work-deletion inevitable no longer
+// destroys the only local copy.
+
+import { appendFileSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { hashBody, LogEventType, type LogEntry } from "@inplan/core/node";
+import type { HydrateInput } from "./liveSync";
+
+/** How a pending proposal ended. `decided` = the proposed slot emptied but no decision event was
+ *  readable (the human acted; which way is unknown). `superseded` = a newer park replaced it. */
+export type ProposalOutcome = "accepted" | "partially_accepted" | "rejected" | "decided" | "superseded";
+
+export interface ProposalRecord {
+  docId: string;
+  /** hashBody of the full proposed text (comments included — same hash family as `.synced`). */
+  hash: string;
+  /** UTF-16 length of the proposed text, matching the `agent_revision_proposed` payload. */
+  bytes: number;
+  /** ISO-8601 park time. */
+  at: string;
+  state: "pending_review" | ProposalOutcome;
+}
+
+/**
+ * Map the decision events since a park to the proposal's outcome. Scans newest-first so the
+ * human's most recent decision wins; stops at events older than the park (when timestamps are
+ * parseable) so a previous proposal's decision is never misattributed to this one.
+ */
+export function resolutionFromEvents(entries: LogEntry[], parkedAtIso: string): ProposalOutcome {
+  const parkedAt = Date.parse(parkedAtIso);
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const e = entries[i]!;
+    const ts = Date.parse(e.ts);
+    if (Number.isFinite(parkedAt) && Number.isFinite(ts) && ts < parkedAt) break;
+    if (e.type === LogEventType.RevisionAcceptedAll) return "accepted";
+    if (e.type === LogEventType.RevisionRejectedAll) return "rejected";
+    if (e.type === LogEventType.RevisionHunkAccepted || e.type === LogEventType.RevisionHunkRejected) return "partially_accepted";
+  }
+  return "decided";
+}
+
+export class RemoteDocState {
+  /** Marker: a local fallback edit awaits a hub push (public — liveSync's replay decision reads it). */
+  readonly pendingPath: string;
+  private readonly hashPath: string;
+  private readonly recordPath: string;
+  private readonly textPath: string;
+  private readonly historyPath: string;
+
+  constructor(
+    readonly workFile: string,
+    private readonly docId: string,
+  ) {
+    this.pendingPath = `${workFile}.pending`;
+    this.hashPath = `${workFile}.synced`;
+    this.recordPath = `${workFile}.proposed.json`;
+    this.textPath = `${workFile}.proposed.md`;
+    this.historyPath = `${workFile}.proposals.jsonl`;
+  }
+
+  ensureDir(): void {
+    mkdirSync(dirname(this.workFile), { recursive: true });
+  }
+
+  // ── Working copy + canonical-sync hash (legacy formats, unchanged) ────────────────────────────
+
+  readWorkFile(): string | null {
+    return existsSync(this.workFile) ? readFileSync(this.workFile, "utf8") : null;
+  }
+
+  writeWorkFile(content: string): void {
+    writeFileSync(this.workFile, content);
+  }
+
+  /** Record that the working copy now equals `content` (our last write/sync). */
+  recordSynced(content: string): void {
+    writeFileSync(this.hashPath, hashBody(content));
+  }
+
+  /** Assemble the start-of-turn hydration decision's input (see liveSync.shouldHydrateWorkFile). */
+  hydrateInput(): HydrateInput {
+    const current = this.readWorkFile();
+    return {
+      exists: current !== null,
+      pending: this.replayPending(),
+      currentHash: current !== null ? hashBody(current) : null,
+      syncedHash: existsSync(this.hashPath) ? readFileSync(this.hashPath, "utf8") : null,
+    };
+  }
+
+  // ── Hub-push replay marker (legacy `.pending`, unchanged) ─────────────────────────────────────
+
+  replayPending(): boolean {
+    return existsSync(this.pendingPath);
+  }
+
+  markReplayPending(): void {
+    writeFileSync(this.pendingPath, "1");
+  }
+
+  clearReplayPending(): void {
+    if (existsSync(this.pendingPath)) rmSync(this.pendingPath);
+  }
+
+  // ── Proposal record: the durable "did my edit land?" signal (#88) ─────────────────────────────
+
+  /**
+   * Park a proposal: write the record (`pending_review`) and the exact pushed text. Call BEFORE
+   * anything overwrites the working copy. A still-pending previous record with a different hash is
+   * finalized into the history as `superseded` first, so no record is ever silently lost.
+   */
+  parkProposal(text: string, at: Date = new Date()): ProposalRecord {
+    const prior = this.pendingProposal();
+    if (prior && prior.hash !== hashBody(text)) this.finalize(prior, "superseded");
+    const record: ProposalRecord = {
+      docId: this.docId,
+      hash: hashBody(text),
+      bytes: text.length,
+      at: at.toISOString(),
+      state: "pending_review",
+    };
+    writeFileSync(this.recordPath, JSON.stringify(record, null, 2));
+    writeFileSync(this.textPath, text);
+    return record;
+  }
+
+  /** The latest record regardless of state, or null (missing/unreadable). */
+  latestProposal(): ProposalRecord | null {
+    if (!existsSync(this.recordPath)) return null;
+    try {
+      const parsed = JSON.parse(readFileSync(this.recordPath, "utf8")) as ProposalRecord;
+      return typeof parsed?.hash === "string" && typeof parsed?.state === "string" ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+
+  /** The latest record only while it awaits the human's decision. */
+  pendingProposal(): ProposalRecord | null {
+    const record = this.latestProposal();
+    return record?.state === "pending_review" ? record : null;
+  }
+
+  /** The latest proposal's exact pushed text (recovery path after the working-copy re-sync). */
+  proposedText(): string | null {
+    return existsSync(this.textPath) ? readFileSync(this.textPath, "utf8") : null;
+  }
+
+  /**
+   * Finalize the pending record with the human's decision: rewrite its state in place (the latest
+   * outcome stays one `cat` away) and append it to the never-pruned history log.
+   */
+  resolveProposal(outcome: ProposalOutcome): ProposalRecord | null {
+    const pending = this.pendingProposal();
+    if (!pending) return null;
+    return this.finalize(pending, outcome);
+  }
+
+  private finalize(record: ProposalRecord, outcome: ProposalOutcome): ProposalRecord {
+    const finalized: ProposalRecord = { ...record, state: outcome };
+    writeFileSync(this.recordPath, JSON.stringify(finalized, null, 2));
+    appendFileSync(this.historyPath, `${JSON.stringify(finalized)}\n`);
+    return finalized;
+  }
+}

--- a/packages/cli/src/remoteDocState.ts
+++ b/packages/cli/src/remoteDocState.ts
@@ -211,20 +211,45 @@ export class RemoteDocState {
    * later run would ever recreate one (the working copy stops diverging). The text alone is
    * enough to reconstruct a truthful record: the text is only ever written after a confirmed
    * push, so `pending_review` is correct, and the park time falls back to the file's mtime.
+   *
+   * One disambiguation: `finalize` leaves the text in place, so a damaged record may belong to
+   * an already-FINALIZED proposal — resurrecting that as pending would re-resolve it and append
+   * a duplicate history line under a fresh mtime-based `at`. When the history's tail finalized
+   * this exact text AND the text hasn't been rewritten since (a later park reuses the file and
+   * bumps its mtime), recover the finalized record verbatim. On ambiguity, prefer pending: a
+   * duplicate history line is cosmetic; hiding a genuinely pending proposal is not.
    */
   private recoverOrphanText(): ProposalRecord | null {
     if (!existsSync(this.textPath)) return null;
+    let text: string;
+    let mtimeMs: number;
     try {
-      const text = readFileSync(this.textPath, "utf8");
-      const record: ProposalRecord = {
-        docId: this.docId,
-        hash: hashBody(text),
-        bytes: utf8Bytes(text),
-        at: statSync(this.textPath).mtime.toISOString(),
-        state: "pending_review",
-      };
+      text = readFileSync(this.textPath, "utf8");
+      mtimeMs = statSync(this.textPath).mtime.getTime();
+    } catch {
+      return null;
+    }
+    const tail = this.historyTail();
+    const record: ProposalRecord =
+      tail && tail.hash === hashBody(text) && mtimeMs <= Date.parse(tail.at) + 5_000
+        ? tail
+        : { docId: this.docId, hash: hashBody(text), bytes: utf8Bytes(text), at: new Date(mtimeMs).toISOString(), state: "pending_review" };
+    try {
       writeFileSync(this.recordPath, JSON.stringify(record, null, 2));
-      return record;
+    } catch {
+      /* best-effort republish — the reconstruction is still the truth, so return it regardless */
+    }
+    return record;
+  }
+
+  /** The history log's last finalized record, or null (absent/unreadable/invalid). */
+  private historyTail(): ProposalRecord | null {
+    if (!existsSync(this.historyPath)) return null;
+    try {
+      const lines = readFileSync(this.historyPath, "utf8").trim().split("\n");
+      const last = JSON.parse(lines[lines.length - 1]!) as Partial<ProposalRecord>;
+      if (last.docId !== this.docId || typeof last.hash !== "string" || typeof last.bytes !== "number" || !Number.isFinite(Date.parse(last.at ?? "")) || typeof last.state !== "string") return null;
+      return last as ProposalRecord;
     } catch {
       return null;
     }
@@ -264,13 +289,7 @@ export class RemoteDocState {
 
   /** Whether the history's last line already records this park (crash-retry idempotency). */
   private historyEndsWith(record: ProposalRecord): boolean {
-    if (!existsSync(this.historyPath)) return false;
-    try {
-      const lines = readFileSync(this.historyPath, "utf8").trim().split("\n");
-      const last = JSON.parse(lines[lines.length - 1]!) as Partial<ProposalRecord>;
-      return last.hash === record.hash && last.at === record.at;
-    } catch {
-      return false;
-    }
+    const tail = this.historyTail();
+    return tail !== null && tail.hash === record.hash && tail.at === record.at;
   }
 }

--- a/packages/cli/src/remoteDocState.ts
+++ b/packages/cli/src/remoteDocState.ts
@@ -20,7 +20,7 @@
 // `.proposed.md` — the clobber that made the 2026-08-11 work-deletion inevitable no longer
 // destroys the only local copy.
 
-import { appendFileSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { hashBody, LogEventType, type LogEntry } from "@inplan/core/node";
 import type { HydrateInput } from "./liveSync";
@@ -56,9 +56,10 @@ export interface ProposalRecord {
  */
 export function resolutionFromEvents(entries: LogEntry[], park: { at: string; hash: string }): ProposalOutcome {
   // This park's event: the last agent_revision_proposed whose payload hash matches the record —
-  // or, when no event carries this hash, the last park event of any kind (single-machine case /
-  // older CLI without the hash payload).
+  // or, when no event carries this hash (this park's append failed, or an older CLI wrote no
+  // hash), the last park event of any kind as a WEAK anchor.
   let start = -1;
+  let matched = false;
   let lastPark = -1;
   for (let i = entries.length - 1; i >= 0; i--) {
     const e = entries[i]!;
@@ -66,6 +67,7 @@ export function resolutionFromEvents(entries: LogEntry[], park: { at: string; ha
     if (lastPark < 0) lastPark = i;
     if ((e.payload as { hash?: unknown } | undefined)?.hash === park.hash) {
       start = i;
+      matched = true;
       break;
     }
   }
@@ -81,10 +83,14 @@ export function resolutionFromEvents(entries: LogEntry[], park: { at: string; ha
       }
     }
   }
+  // Only a hash-MATCHED anchor earns pure log-order trust. A weak anchor may be an OLDER park
+  // (ours never appended), so its window can contain a PREVIOUS proposal's decision — the
+  // timestamp filter still applies there, preferring a degraded "decided" over finalizing this
+  // record with another proposal's outcome.
   const parkedAt = Date.parse(park.at);
   for (let i = end - 1; i > start; i--) {
     const e = entries[i]!;
-    if (start < 0) {
+    if (!matched) {
       const ts = Date.parse(e.ts);
       if (Number.isFinite(parkedAt) && Number.isFinite(ts) && ts < parkedAt) break;
     }
@@ -187,12 +193,38 @@ export class RemoteDocState {
    *  shape check (wrong doc, non-numeric bytes, unparseable park time, unknown state). A partial
    *  record must read as absent, or it could be finalized with missing metadata. */
   latestProposal(): ProposalRecord | null {
-    if (!existsSync(this.recordPath)) return null;
+    if (!existsSync(this.recordPath)) return this.recoverOrphanText();
     try {
       const p = JSON.parse(readFileSync(this.recordPath, "utf8")) as Partial<ProposalRecord>;
       const validState = p.state === "pending_review" || p.state === "accepted" || p.state === "partially_accepted" || p.state === "rejected" || p.state === "decided" || p.state === "superseded";
-      if (p.docId !== this.docId || typeof p.hash !== "string" || typeof p.bytes !== "number" || !Number.isFinite(Date.parse(p.at ?? "")) || !validState) return null;
+      if (p.docId !== this.docId || typeof p.hash !== "string" || typeof p.bytes !== "number" || !Number.isFinite(Date.parse(p.at ?? "")) || !validState) return this.recoverOrphanText();
       return p as ProposalRecord;
+    } catch {
+      return this.recoverOrphanText();
+    }
+  }
+
+  /**
+   * Crash recovery for the park's write pair: `parkProposal` writes the text, then the record. A
+   * process killed between the two (or mid-record) leaves a confirmed-pushed proposal with its
+   * text on disk but no readable record — and if the human accepts it while the CLI is down, no
+   * later run would ever recreate one (the working copy stops diverging). The text alone is
+   * enough to reconstruct a truthful record: the text is only ever written after a confirmed
+   * push, so `pending_review` is correct, and the park time falls back to the file's mtime.
+   */
+  private recoverOrphanText(): ProposalRecord | null {
+    if (!existsSync(this.textPath)) return null;
+    try {
+      const text = readFileSync(this.textPath, "utf8");
+      const record: ProposalRecord = {
+        docId: this.docId,
+        hash: hashBody(text),
+        bytes: utf8Bytes(text),
+        at: statSync(this.textPath).mtime.toISOString(),
+        state: "pending_review",
+      };
+      writeFileSync(this.recordPath, JSON.stringify(record, null, 2));
+      return record;
     } catch {
       return null;
     }

--- a/packages/cli/src/remoteDocState.ts
+++ b/packages/cli/src/remoteDocState.ts
@@ -129,6 +129,18 @@ export function needsReparkFromSlot(latest: ProposalRecord | null, slotText: str
   return latest === null || latest.state !== "pending_review" || latest.hash !== hashBody(slotText);
 }
 
+/**
+ * Whether the working copy is the CORPSE of a decided proposal: its content equals a terminal
+ * record's text (the post-turn re-sync never ran before the process died). Hydration normally
+ * protects a diverged working copy as "unsynced agent edits" — but this copy is not an edit to
+ * preserve, it is content the human already decided; keeping it would make the next turn re-park
+ * a rejected proposal. The caller restores canonical instead (the decision stands).
+ */
+export function isDecidedProposalCorpse(latest: ProposalRecord | null, currentContent: string | null): boolean {
+  if (!latest || latest.state === "pending_review" || currentContent === null) return false;
+  return hashBody(currentContent) === latest.hash;
+}
+
 export class RemoteDocState {
   /** Marker: a local fallback edit awaits a hub push (public — liveSync's replay decision reads it). */
   readonly pendingPath: string;

--- a/packages/cli/src/remoteDocState.ts
+++ b/packages/cli/src/remoteDocState.ts
@@ -9,18 +9,24 @@
 //   <docId>.plan.md                 the working copy the agent reads/edits
 //   <docId>.plan.md.pending        marker: a local fallback edit awaits a hub push
 //   <docId>.plan.md.synced         hash of the working copy at our last write/sync
-//   <docId>.plan.md.proposed.json  the latest proposal record (see ProposalRecord)
-//   <docId>.plan.md.proposed.md    the latest proposal's exact pushed text
-//   <docId>.plan.md.proposals.jsonl  append-only history of finalized records (never pruned)
+//   <docId>.plan.md.proposed.json  the AUTHORITATIVE proposal record + its exact text,
+//                                  published atomically (tmp + rename)
+//   <docId>.plan.md.proposed.md    a derived, read-convenience copy of the proposed text
+//   <docId>.plan.md.proposals.jsonl  append-only history of finalized records (never pruned;
+//                                  metadata only — accepted text lives in canonical history)
 //
 // The proposal record is the durable half of the landing signal: `agent_revision_proposed`
 // appears in exactly one wait output (the cursor advances past it), so an agent auditing a
-// turn later needs state on disk. The record is written BEFORE the end-of-turn re-sync
-// overwrites the working copy with canonical, so a parked edit is always recoverable from
-// `.proposed.md` — the clobber that made the 2026-08-11 work-deletion inevitable no longer
-// destroys the only local copy.
+// turn later needs state on disk. Persistence is deliberately crash-shaped:
+//  - the record and its text publish as ONE atomic rename, so no torn write-pair can ever
+//    advertise a proposal without its text (or vice versa);
+//  - each park carries a unique `id`, so history idempotency and supersede detection never
+//    confuse two proposals that happen to share content;
+//  - anything this machine still misses after a crash is reconciled from the CLOUD's proposed
+//    slot at the next attach (see `needsReparkFromSlot`) — the slot is the authoritative side
+//    of the push, so it, not local heuristics, is the recovery source.
 
-import { appendFileSync, existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { hashBody, LogEventType, type LogEntry } from "@inplan/core/node";
 import type { HydrateInput } from "./liveSync";
@@ -34,6 +40,8 @@ export type ProposalOutcome = "accepted" | "partially_accepted" | "rejected" | "
 export const utf8Bytes = (text: string): number => Buffer.byteLength(text, "utf8");
 
 export interface ProposalRecord {
+  /** Unique per park (content may repeat; identity must not). */
+  id: string;
   docId: string;
   /** hashBody of the full proposed text (comments included — same hash family as `.synced`). */
   hash: string;
@@ -42,6 +50,15 @@ export interface ProposalRecord {
   /** ISO-8601 park time. */
   at: string;
   state: "pending_review" | ProposalOutcome;
+  /** Set when the cloud slot was seen empty but no decision event was readable yet — the record
+   *  stays pending for one more look before degrading to `decided`, so a slot-clear racing ahead
+   *  of its decision event can't permanently erase the real outcome. */
+  awaitingOutcomeSince?: string;
+}
+
+/** The persisted shape of `.proposed.json`: the record plus its exact text, one atomic unit. */
+interface StoredProposal extends ProposalRecord {
+  text: string;
 }
 
 /**
@@ -49,45 +66,42 @@ export interface ProposalRecord {
  * wins. Binding is by the log's own order, not the clock: the park appended
  * `agent_revision_proposed` carrying the proposal's hash, so the decision window is (this park's
  * event, the next park event] — decisions for a LATER proposal (parked and decided by another
- * machine while this one was offline) can never be misattributed to this record. Fallbacks, in
- * order: an un-hashed park event (older CLI) matches as the last park event; no park event at all
- * (the append failed) falls back to timestamp comparison against the recorded park time, where
- * CLI-clock vs server-timestamp skew can at worst degrade a fast decision to "decided".
+ * machine while this one was offline) can never be misattributed to this record. When no event
+ * carries this hash (the append failed, or an older CLI wrote no hash), the anchor degrades to
+ * the newest park event that does not POSTDATE this record's park time — a later machine's park
+ * must not become our window — and the timestamp filter stays on inside a weak window, preferring
+ * a degraded "decided" over finalizing this record with another proposal's outcome.
  */
 export function resolutionFromEvents(entries: LogEntry[], park: { at: string; hash: string }): ProposalOutcome {
-  // This park's event: the last agent_revision_proposed whose payload hash matches the record —
-  // or, when no event carries this hash (this park's append failed, or an older CLI wrote no
-  // hash), the last park event of any kind as a WEAK anchor.
+  const parkedAt = Date.parse(park.at);
   let start = -1;
   let matched = false;
-  let lastPark = -1;
   for (let i = entries.length - 1; i >= 0; i--) {
     const e = entries[i]!;
     if (e.type !== LogEventType.AgentRevisionProposed) continue;
-    if (lastPark < 0) lastPark = i;
     if ((e.payload as { hash?: unknown } | undefined)?.hash === park.hash) {
       start = i;
       matched = true;
       break;
     }
-  }
-  if (start < 0) start = lastPark;
-  // The window closes at the NEXT park event after ours: decisions beyond it belong to a newer
-  // proposal.
-  let end = entries.length;
-  if (start >= 0) {
-    for (let i = start + 1; i < entries.length; i++) {
-      if (entries[i]!.type === LogEventType.AgentRevisionProposed) {
-        end = i;
-        break;
-      }
+    // Weak-anchor candidate: the newest park event that could plausibly BE this park — i.e. not
+    // stamped after our recorded park time (5s slack for CLI-vs-server clock disagreement).
+    if (start < 0) {
+      const ts = Date.parse(e.ts);
+      if (!Number.isFinite(parkedAt) || !Number.isFinite(ts) || ts <= parkedAt + 5_000) start = i;
     }
   }
-  // Only a hash-MATCHED anchor earns pure log-order trust. A weak anchor may be an OLDER park
-  // (ours never appended), so its window can contain a PREVIOUS proposal's decision — the
-  // timestamp filter still applies there, preferring a degraded "decided" over finalizing this
-  // record with another proposal's outcome.
-  const parkedAt = Date.parse(park.at);
+  // The window closes at the NEXT park event after the anchor: decisions beyond it belong to a
+  // newer proposal. This applies even with NO anchor (every park event postdates us): the first
+  // park event still starts someone else's window, and a later proposal's decision carries a
+  // later timestamp too — the timestamp filter alone could not exclude it.
+  let end = entries.length;
+  for (let i = start + 1; i < entries.length; i++) {
+    if (entries[i]!.type === LogEventType.AgentRevisionProposed) {
+      end = i;
+      break;
+    }
+  }
   for (let i = end - 1; i > start; i--) {
     const e = entries[i]!;
     if (!matched) {
@@ -99,6 +113,19 @@ export function resolutionFromEvents(entries: LogEntry[], park: { at: string; ha
     if (e.type === LogEventType.RevisionHunkAccepted || e.type === LogEventType.RevisionHunkRejected) return "partially_accepted";
   }
   return "decided";
+}
+
+/**
+ * Whether the CLOUD's proposed slot holds a proposal this machine has no live record of — the
+ * reconciliation check run at attach. True when a slot exists but the latest local record is
+ * absent, terminal, or about different content: whatever local write was lost (a crash between
+ * the confirmed push and the record publish, a re-park of identical text after a finalization),
+ * re-parking the slot's own text recreates the truthful pending record from the authoritative
+ * side. Cheap and idempotent — a healthy pending record simply returns false.
+ */
+export function needsReparkFromSlot(latest: ProposalRecord | null, slotText: string | null | undefined): boolean {
+  if (typeof slotText !== "string") return false;
+  return latest === null || latest.state !== "pending_review" || latest.hash !== hashBody(slotText);
 }
 
 export class RemoteDocState {
@@ -167,25 +194,29 @@ export class RemoteDocState {
   // ── Proposal record: the durable "did my edit land?" signal (#88) ─────────────────────────────
 
   /**
-   * Park a proposal: write the record (`pending_review`) and the exact pushed text. Call BEFORE
-   * anything overwrites the working copy. A still-pending previous record with a different hash is
-   * finalized into the history as `superseded` first, so no record is ever silently lost.
+   * Park a proposal: publish the record + its exact text as ONE atomic rename, then refresh the
+   * derived `.proposed.md` copy (best-effort — the JSON is authoritative). A still-pending
+   * previous record about different content is finalized into the history as `superseded` first,
+   * so no record is ever silently lost; re-parking identical content keeps the existing pending
+   * identity (same proposal, re-pushed) instead of minting a new one.
    */
   parkProposal(text: string, at: Date = new Date()): ProposalRecord {
     const prior = this.pendingProposal();
-    if (prior && prior.hash !== hashBody(text)) this.finalize(prior, "superseded");
+    const hash = hashBody(text);
+    if (prior && prior.hash === hash) {
+      this.writeDerivedText(text);
+      return prior;
+    }
+    if (prior) this.finalize(prior, "superseded");
     const record: ProposalRecord = {
+      id: `${at.getTime().toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
       docId: this.docId,
-      hash: hashBody(text),
+      hash,
       bytes: utf8Bytes(text),
       at: at.toISOString(),
       state: "pending_review",
     };
-    // Text first, record last: the record is the publish point, so a process killed between the
-    // two writes leaves an unadvertised text file — never a pending_review record whose text is
-    // missing (which would defeat the recovery path the record exists to provide).
-    writeFileSync(this.textPath, text);
-    writeFileSync(this.recordPath, JSON.stringify(record, null, 2));
+    this.publish({ ...record, text });
     return record;
   }
 
@@ -193,66 +224,10 @@ export class RemoteDocState {
    *  shape check (wrong doc, non-numeric bytes, unparseable park time, unknown state). A partial
    *  record must read as absent, or it could be finalized with missing metadata. */
   latestProposal(): ProposalRecord | null {
-    if (!existsSync(this.recordPath)) return this.recoverOrphanText();
-    try {
-      const p = JSON.parse(readFileSync(this.recordPath, "utf8")) as Partial<ProposalRecord>;
-      const validState = p.state === "pending_review" || p.state === "accepted" || p.state === "partially_accepted" || p.state === "rejected" || p.state === "decided" || p.state === "superseded";
-      if (p.docId !== this.docId || typeof p.hash !== "string" || typeof p.bytes !== "number" || !Number.isFinite(Date.parse(p.at ?? "")) || !validState) return this.recoverOrphanText();
-      return p as ProposalRecord;
-    } catch {
-      return this.recoverOrphanText();
-    }
-  }
-
-  /**
-   * Crash recovery for the park's write pair: `parkProposal` writes the text, then the record. A
-   * process killed between the two (or mid-record) leaves a confirmed-pushed proposal with its
-   * text on disk but no readable record — and if the human accepts it while the CLI is down, no
-   * later run would ever recreate one (the working copy stops diverging). The text alone is
-   * enough to reconstruct a truthful record: the text is only ever written after a confirmed
-   * push, so `pending_review` is correct, and the park time falls back to the file's mtime.
-   *
-   * One disambiguation: `finalize` leaves the text in place, so a damaged record may belong to
-   * an already-FINALIZED proposal — resurrecting that as pending would re-resolve it and append
-   * a duplicate history line under a fresh mtime-based `at`. When the history's tail finalized
-   * this exact text AND the text hasn't been rewritten since (a later park reuses the file and
-   * bumps its mtime), recover the finalized record verbatim. On ambiguity, prefer pending: a
-   * duplicate history line is cosmetic; hiding a genuinely pending proposal is not.
-   */
-  private recoverOrphanText(): ProposalRecord | null {
-    if (!existsSync(this.textPath)) return null;
-    let text: string;
-    let mtimeMs: number;
-    try {
-      text = readFileSync(this.textPath, "utf8");
-      mtimeMs = statSync(this.textPath).mtime.getTime();
-    } catch {
-      return null;
-    }
-    const tail = this.historyTail();
-    const record: ProposalRecord =
-      tail && tail.hash === hashBody(text) && mtimeMs <= Date.parse(tail.at) + 5_000
-        ? tail
-        : { docId: this.docId, hash: hashBody(text), bytes: utf8Bytes(text), at: new Date(mtimeMs).toISOString(), state: "pending_review" };
-    try {
-      writeFileSync(this.recordPath, JSON.stringify(record, null, 2));
-    } catch {
-      /* best-effort republish — the reconstruction is still the truth, so return it regardless */
-    }
+    const stored = this.readStored();
+    if (!stored) return null;
+    const { text: _text, ...record } = stored;
     return record;
-  }
-
-  /** The history log's last finalized record, or null (absent/unreadable/invalid). */
-  private historyTail(): ProposalRecord | null {
-    if (!existsSync(this.historyPath)) return null;
-    try {
-      const lines = readFileSync(this.historyPath, "utf8").trim().split("\n");
-      const last = JSON.parse(lines[lines.length - 1]!) as Partial<ProposalRecord>;
-      if (last.docId !== this.docId || typeof last.hash !== "string" || typeof last.bytes !== "number" || !Number.isFinite(Date.parse(last.at ?? "")) || typeof last.state !== "string") return null;
-      return last as ProposalRecord;
-    } catch {
-      return null;
-    }
   }
 
   /** The latest record only while it awaits the human's decision. */
@@ -263,12 +238,29 @@ export class RemoteDocState {
 
   /** The latest proposal's exact pushed text (recovery path after the working-copy re-sync). */
   proposedText(): string | null {
-    return existsSync(this.textPath) ? readFileSync(this.textPath, "utf8") : null;
+    return this.readStored()?.text ?? null;
   }
 
   /**
-   * Finalize the pending record with the human's decision: rewrite its state in place (the latest
-   * outcome stays one `cat` away) and append it to the never-pruned history log.
+   * First sighting of "slot empty but no decision event readable yet": mark the record instead of
+   * finalizing, so a slot-clear that races ahead of its decision event gets one more run to
+   * surface the real outcome. Returns the updated record (or null when nothing is pending).
+   */
+  noteOutcomeMissing(at: Date = new Date()): ProposalRecord | null {
+    const stored = this.readStored();
+    if (!stored || stored.state !== "pending_review" || stored.awaitingOutcomeSince) return null;
+    const updated: StoredProposal = { ...stored, awaitingOutcomeSince: at.toISOString() };
+    this.publish(updated);
+    const { text: _text, ...record } = updated;
+    return record;
+  }
+
+  /**
+   * Finalize the pending record with the human's decision: append it to the never-pruned history
+   * log FIRST (metadata only — an accepted text's fate is canonical history's job), then
+   * republish the record. A crash between the writes leaves the record pending, so the next
+   * resolution retries — and the retry is idempotent because the history tail already carries
+   * this park's unique id.
    */
   resolveProposal(outcome: ProposalOutcome): ProposalRecord | null {
     const pending = this.pendingProposal();
@@ -277,19 +269,55 @@ export class RemoteDocState {
   }
 
   private finalize(record: ProposalRecord, outcome: ProposalOutcome): ProposalRecord {
-    const finalized: ProposalRecord = { ...record, state: outcome };
-    // History first, record last: a crash between the writes leaves the record pending, so the
-    // next resolution retries — and the retry is idempotent because a history tail line matching
-    // this park (hash + at) is not appended twice. The reverse order would leave a terminal
-    // record with its history line missing forever (nothing would ever retry the append).
-    if (!this.historyEndsWith(record)) appendFileSync(this.historyPath, `${JSON.stringify(finalized)}\n`);
-    writeFileSync(this.recordPath, JSON.stringify(finalized, null, 2));
+    const { awaitingOutcomeSince: _grace, ...rest } = record;
+    const finalized: ProposalRecord = { ...rest, state: outcome };
+    const tail = this.historyTail();
+    if (!tail || tail.id !== finalized.id) appendFileSync(this.historyPath, `${JSON.stringify(finalized)}\n`);
+    const stored = this.readStored();
+    this.publish({ ...finalized, text: stored?.id === finalized.id ? stored.text : "" });
     return finalized;
   }
 
-  /** Whether the history's last line already records this park (crash-retry idempotency). */
-  private historyEndsWith(record: ProposalRecord): boolean {
-    const tail = this.historyTail();
-    return tail !== null && tail.hash === record.hash && tail.at === record.at;
+  // ── Persistence primitives ────────────────────────────────────────────────────────────────────
+
+  /** Atomic publish: the record + text land as one rename, then the derived .md refreshes. */
+  private publish(stored: StoredProposal): void {
+    const tmp = `${this.recordPath}.tmp`;
+    writeFileSync(tmp, JSON.stringify(stored, null, 2));
+    renameSync(tmp, this.recordPath);
+    this.writeDerivedText(stored.text);
+  }
+
+  private writeDerivedText(text: string): void {
+    try {
+      writeFileSync(this.textPath, text);
+    } catch {
+      /* derived copy only — the authoritative text is inside .proposed.json */
+    }
+  }
+
+  private readStored(): StoredProposal | null {
+    if (!existsSync(this.recordPath)) return null;
+    try {
+      const p = JSON.parse(readFileSync(this.recordPath, "utf8")) as Partial<StoredProposal>;
+      const validState = p.state === "pending_review" || p.state === "accepted" || p.state === "partially_accepted" || p.state === "rejected" || p.state === "decided" || p.state === "superseded";
+      if (typeof p.id !== "string" || p.docId !== this.docId || typeof p.hash !== "string" || typeof p.bytes !== "number" || !Number.isFinite(Date.parse(p.at ?? "")) || !validState || typeof p.text !== "string") return null;
+      return p as StoredProposal;
+    } catch {
+      return null;
+    }
+  }
+
+  /** The history log's last finalized record, or null (absent/unreadable/invalid). */
+  private historyTail(): ProposalRecord | null {
+    if (!existsSync(this.historyPath)) return null;
+    try {
+      const lines = readFileSync(this.historyPath, "utf8").trim().split("\n");
+      const last = JSON.parse(lines[lines.length - 1]!) as Partial<ProposalRecord>;
+      if (typeof last.id !== "string" || last.docId !== this.docId || typeof last.hash !== "string" || typeof last.state !== "string") return null;
+      return last as ProposalRecord;
+    } catch {
+      return null;
+    }
   }
 }

--- a/packages/cli/src/remoteDocState.ts
+++ b/packages/cli/src/remoteDocState.ts
@@ -45,16 +45,28 @@ export interface ProposalRecord {
 }
 
 /**
- * Map the decision events since a park to the proposal's outcome. Scans newest-first so the
- * human's most recent decision wins; stops at events older than the park (when timestamps are
- * parseable) so a previous proposal's decision is never misattributed to this one.
+ * Map the decision events since a park to the proposal's outcome, newest-first so the human's most
+ * recent decision wins. The park boundary is the log's own order, not the clock: the park appended
+ * `agent_revision_proposed`, and only one proposal pends at a time, so everything after the LAST
+ * such event belongs to this park. Timestamp comparison against the recorded park time is only the
+ * fallback for a park whose event append failed — there, CLI-clock vs server-timestamp skew can at
+ * worst degrade a fast decision to "decided", never misattribute an old one.
  */
 export function resolutionFromEvents(entries: LogEntry[], parkedAtIso: string): ProposalOutcome {
-  const parkedAt = Date.parse(parkedAtIso);
+  let boundary = -1;
   for (let i = entries.length - 1; i >= 0; i--) {
+    if (entries[i]!.type === LogEventType.AgentRevisionProposed) {
+      boundary = i;
+      break;
+    }
+  }
+  const parkedAt = Date.parse(parkedAtIso);
+  for (let i = entries.length - 1; i > boundary; i--) {
     const e = entries[i]!;
-    const ts = Date.parse(e.ts);
-    if (Number.isFinite(parkedAt) && Number.isFinite(ts) && ts < parkedAt) break;
+    if (boundary < 0) {
+      const ts = Date.parse(e.ts);
+      if (Number.isFinite(parkedAt) && Number.isFinite(ts) && ts < parkedAt) break;
+    }
     if (e.type === LogEventType.RevisionAcceptedAll) return "accepted";
     if (e.type === LogEventType.RevisionRejectedAll) return "rejected";
     if (e.type === LogEventType.RevisionHunkAccepted || e.type === LogEventType.RevisionHunkRejected) return "partially_accepted";
@@ -142,17 +154,24 @@ export class RemoteDocState {
       at: at.toISOString(),
       state: "pending_review",
     };
-    writeFileSync(this.recordPath, JSON.stringify(record, null, 2));
+    // Text first, record last: the record is the publish point, so a process killed between the
+    // two writes leaves an unadvertised text file — never a pending_review record whose text is
+    // missing (which would defeat the recovery path the record exists to provide).
     writeFileSync(this.textPath, text);
+    writeFileSync(this.recordPath, JSON.stringify(record, null, 2));
     return record;
   }
 
-  /** The latest record regardless of state, or null (missing/unreadable). */
+  /** The latest record regardless of state, or null — missing, unreadable, or failing the full
+   *  shape check (wrong doc, non-numeric bytes, unparseable park time, unknown state). A partial
+   *  record must read as absent, or it could be finalized with missing metadata. */
   latestProposal(): ProposalRecord | null {
     if (!existsSync(this.recordPath)) return null;
     try {
-      const parsed = JSON.parse(readFileSync(this.recordPath, "utf8")) as ProposalRecord;
-      return typeof parsed?.hash === "string" && typeof parsed?.state === "string" ? parsed : null;
+      const p = JSON.parse(readFileSync(this.recordPath, "utf8")) as Partial<ProposalRecord>;
+      const validState = p.state === "pending_review" || p.state === "accepted" || p.state === "partially_accepted" || p.state === "rejected" || p.state === "decided" || p.state === "superseded";
+      if (p.docId !== this.docId || typeof p.hash !== "string" || typeof p.bytes !== "number" || !Number.isFinite(Date.parse(p.at ?? "")) || !validState) return null;
+      return p as ProposalRecord;
     } catch {
       return null;
     }

--- a/packages/cli/src/remoteDocState.ts
+++ b/packages/cli/src/remoteDocState.ts
@@ -29,11 +29,15 @@ import type { HydrateInput } from "./liveSync";
  *  readable (the human acted; which way is unknown). `superseded` = a newer park replaced it. */
 export type ProposalOutcome = "accepted" | "partially_accepted" | "rejected" | "decided" | "superseded";
 
+/** UTF-8 byte length — the one sizing used by the proposal record, the wait output's `proposal`
+ *  field, and the `agent_revision_proposed` payload, so the three never disagree. */
+export const utf8Bytes = (text: string): number => Buffer.byteLength(text, "utf8");
+
 export interface ProposalRecord {
   docId: string;
   /** hashBody of the full proposed text (comments included — same hash family as `.synced`). */
   hash: string;
-  /** UTF-16 length of the proposed text, matching the `agent_revision_proposed` payload. */
+  /** UTF-8 byte length of the proposed text, matching the `agent_revision_proposed` payload. */
   bytes: number;
   /** ISO-8601 park time. */
   at: string;
@@ -134,7 +138,7 @@ export class RemoteDocState {
     const record: ProposalRecord = {
       docId: this.docId,
       hash: hashBody(text),
-      bytes: text.length,
+      bytes: utf8Bytes(text),
       at: at.toISOString(),
       state: "pending_review",
     };

--- a/packages/cli/src/remoteDocState.ts
+++ b/packages/cli/src/remoteDocState.ts
@@ -45,25 +45,46 @@ export interface ProposalRecord {
 }
 
 /**
- * Map the decision events since a park to the proposal's outcome, newest-first so the human's most
- * recent decision wins. The park boundary is the log's own order, not the clock: the park appended
- * `agent_revision_proposed`, and only one proposal pends at a time, so everything after the LAST
- * such event belongs to this park. Timestamp comparison against the recorded park time is only the
- * fallback for a park whose event append failed — there, CLI-clock vs server-timestamp skew can at
- * worst degrade a fast decision to "decided", never misattribute an old one.
+ * Map decision events to THIS proposal's outcome, newest-first so the human's most recent decision
+ * wins. Binding is by the log's own order, not the clock: the park appended
+ * `agent_revision_proposed` carrying the proposal's hash, so the decision window is (this park's
+ * event, the next park event] — decisions for a LATER proposal (parked and decided by another
+ * machine while this one was offline) can never be misattributed to this record. Fallbacks, in
+ * order: an un-hashed park event (older CLI) matches as the last park event; no park event at all
+ * (the append failed) falls back to timestamp comparison against the recorded park time, where
+ * CLI-clock vs server-timestamp skew can at worst degrade a fast decision to "decided".
  */
-export function resolutionFromEvents(entries: LogEntry[], parkedAtIso: string): ProposalOutcome {
-  let boundary = -1;
+export function resolutionFromEvents(entries: LogEntry[], park: { at: string; hash: string }): ProposalOutcome {
+  // This park's event: the last agent_revision_proposed whose payload hash matches the record —
+  // or, when no event carries this hash, the last park event of any kind (single-machine case /
+  // older CLI without the hash payload).
+  let start = -1;
+  let lastPark = -1;
   for (let i = entries.length - 1; i >= 0; i--) {
-    if (entries[i]!.type === LogEventType.AgentRevisionProposed) {
-      boundary = i;
+    const e = entries[i]!;
+    if (e.type !== LogEventType.AgentRevisionProposed) continue;
+    if (lastPark < 0) lastPark = i;
+    if ((e.payload as { hash?: unknown } | undefined)?.hash === park.hash) {
+      start = i;
       break;
     }
   }
-  const parkedAt = Date.parse(parkedAtIso);
-  for (let i = entries.length - 1; i > boundary; i--) {
+  if (start < 0) start = lastPark;
+  // The window closes at the NEXT park event after ours: decisions beyond it belong to a newer
+  // proposal.
+  let end = entries.length;
+  if (start >= 0) {
+    for (let i = start + 1; i < entries.length; i++) {
+      if (entries[i]!.type === LogEventType.AgentRevisionProposed) {
+        end = i;
+        break;
+      }
+    }
+  }
+  const parkedAt = Date.parse(park.at);
+  for (let i = end - 1; i > start; i--) {
     const e = entries[i]!;
-    if (boundary < 0) {
+    if (start < 0) {
       const ts = Date.parse(e.ts);
       if (Number.isFinite(parkedAt) && Number.isFinite(ts) && ts < parkedAt) break;
     }
@@ -200,8 +221,24 @@ export class RemoteDocState {
 
   private finalize(record: ProposalRecord, outcome: ProposalOutcome): ProposalRecord {
     const finalized: ProposalRecord = { ...record, state: outcome };
+    // History first, record last: a crash between the writes leaves the record pending, so the
+    // next resolution retries — and the retry is idempotent because a history tail line matching
+    // this park (hash + at) is not appended twice. The reverse order would leave a terminal
+    // record with its history line missing forever (nothing would ever retry the append).
+    if (!this.historyEndsWith(record)) appendFileSync(this.historyPath, `${JSON.stringify(finalized)}\n`);
     writeFileSync(this.recordPath, JSON.stringify(finalized, null, 2));
-    appendFileSync(this.historyPath, `${JSON.stringify(finalized)}\n`);
     return finalized;
+  }
+
+  /** Whether the history's last line already records this park (crash-retry idempotency). */
+  private historyEndsWith(record: ProposalRecord): boolean {
+    if (!existsSync(this.historyPath)) return false;
+    try {
+      const lines = readFileSync(this.historyPath, "utf8").trim().split("\n");
+      const last = JSON.parse(lines[lines.length - 1]!) as Partial<ProposalRecord>;
+      return last.hash === record.hash && last.at === record.at;
+    } catch {
+      return false;
+    }
   }
 }

--- a/packages/cli/test/applyGatedEdit.test.ts
+++ b/packages/cli/test/applyGatedEdit.test.ts
@@ -90,7 +90,7 @@ describe("applyGatedEdit — file path (no plugin)", () => {
       throw new Error("log unavailable");
     };
     const applied = await applyGatedEdit(store, channel, ev({ changed: true }), { current: "agent body", canonicalText: "canon", quarantine: true, gate: null });
-    expect(applied).toEqual({ proposed: true }); // no crash, no false failure
+    expect(applied).toEqual({ proposed: true, eventLogged: false }); // no crash, no false failure — and the missing event is reported
     expect(await store.getProposed()).toBe("agent body");
     expect(await store.loadDoc()).toBe("canon"); // the revert did run
   });

--- a/packages/cli/test/applyGatedEdit.test.ts
+++ b/packages/cli/test/applyGatedEdit.test.ts
@@ -28,7 +28,8 @@ describe("applyGatedEdit — file path (no plugin)", () => {
   it("auto-accepts a body change: advances canonical, clears proposed, logs DocumentEdited", async () => {
     const store = new MemoryDocumentStore("new body");
     const channel = new MemoryControlChannel();
-    await applyGatedEdit(store, channel, ev({ changed: true }), { current: "new body", canonicalText: "old", quarantine: false, gate: null });
+    const applied = await applyGatedEdit(store, channel, ev({ changed: true }), { current: "new body", canonicalText: "old", quarantine: false, gate: null });
+    expect(applied.proposed).toBe(false);
     expect(await store.getCanonical()).toBe("new body");
     expect(await types(channel)).toEqual([LogEventType.DocumentEdited]);
   });
@@ -36,7 +37,8 @@ describe("applyGatedEdit — file path (no plugin)", () => {
   it("quarantines a Review-mode body change: parks proposed, reverts the file to canonical, logs AgentRevisionProposed", async () => {
     const store = new MemoryDocumentStore("agent body");
     const channel = new MemoryControlChannel();
-    await applyGatedEdit(store, channel, ev({ changed: true }), { current: "agent body", canonicalText: "canon", quarantine: true, gate: null });
+    const applied = await applyGatedEdit(store, channel, ev({ changed: true }), { current: "agent body", canonicalText: "canon", quarantine: true, gate: null });
+    expect(applied.proposed).toBe(true); // the caller surfaces the park (#88)
     expect(await store.getProposed()).toBe("agent body");
     expect(await store.loadDoc()).toBe("canon"); // working file reverted to canonical
     expect(await types(channel)).toEqual([LogEventType.AgentRevisionProposed]);
@@ -54,7 +56,8 @@ describe("applyGatedEdit — file path (no plugin)", () => {
   it("no change: writes nothing, logs nothing", async () => {
     const store = new MemoryDocumentStore("same");
     const channel = new MemoryControlChannel();
-    await applyGatedEdit(store, channel, ev({ changed: false }), { current: "same", canonicalText: "same", quarantine: false, gate: null });
+    const applied = await applyGatedEdit(store, channel, ev({ changed: false }), { current: "same", canonicalText: "same", quarantine: false, gate: null });
+    expect(applied.proposed).toBe(false);
     expect(await store.getCanonical()).toBeNull();
     expect(await types(channel)).toEqual([]);
   });
@@ -85,7 +88,8 @@ describe("applyGatedEdit — plugin path (a plugin gate is connected)", () => {
     const store = new MemoryDocumentStore("agent body");
     const channel = new MemoryControlChannel();
     const gate = fakeGate();
-    await applyGatedEdit(store, channel, ev({ changed: true }), { current: "agent body", canonicalText: "canon", quarantine: true, gate });
+    const applied = await applyGatedEdit(store, channel, ev({ changed: true }), { current: "agent body", canonicalText: "canon", quarantine: true, gate });
+    expect(applied.proposed).toBe(true);
     expect(await store.getProposed()).toBe("agent body");
     expect(await store.loadDoc()).toBe("agent body"); // NOT reverted to canon
     expect(gate.applyRevision).not.toHaveBeenCalled();

--- a/packages/cli/test/applyGatedEdit.test.ts
+++ b/packages/cli/test/applyGatedEdit.test.ts
@@ -67,18 +67,32 @@ describe("applyGatedEdit — file path (no plugin)", () => {
     expect(await types(channel)).toEqual([]); // nothing was proposed, so no event claims it was
   });
 
-  it("a failed canonical restore AFTER a successful push also degrades: no event, parkFailed reported", async () => {
-    // The push landed but the file revert rejected: the park sequence is incomplete, and the log
-    // must not claim it finished. The working copy still holds the edit; the next run retries.
+  it("a failed canonical restore AFTER a successful push is a COMPLETED park, not a failed one", async () => {
+    // The store holds the proposal (the human can see it in their editor), so the log and return
+    // must say so — claiming FAILED here is the same false signal #88 exists to kill. The failed
+    // revert just leaves the edit in the working copy, where the hydration guard protects it.
     const store = new MemoryDocumentStore("agent body");
     store.saveDoc = async () => {
       throw new Error("disk full");
     };
     const channel = new MemoryControlChannel();
     const applied = await applyGatedEdit(store, channel, ev({ changed: true }), { current: "agent body", canonicalText: "canon", quarantine: true, gate: null });
-    expect(applied).toEqual({ proposed: false, parkFailed: true });
-    expect(await store.getProposed()).toBe("agent body"); // the push itself did land
-    expect(await types(channel)).toEqual([]);
+    expect(applied).toEqual({ proposed: true });
+    expect(await store.getProposed()).toBe("agent body");
+    expect(await store.loadDoc()).toBe("agent body"); // revert failed — edit stays put
+    expect(await types(channel)).toEqual([LogEventType.AgentRevisionProposed]); // the park is logged
+  });
+
+  it("a failed event append after a successful park still reports proposed — the park is real", async () => {
+    const store = new MemoryDocumentStore("agent body");
+    const channel = new MemoryControlChannel();
+    channel.append = async () => {
+      throw new Error("log unavailable");
+    };
+    const applied = await applyGatedEdit(store, channel, ev({ changed: true }), { current: "agent body", canonicalText: "canon", quarantine: true, gate: null });
+    expect(applied).toEqual({ proposed: true }); // no crash, no false failure
+    expect(await store.getProposed()).toBe("agent body");
+    expect(await store.loadDoc()).toBe("canon"); // the revert did run
   });
 
   it("no change: writes nothing, logs nothing", async () => {

--- a/packages/cli/test/applyGatedEdit.test.ts
+++ b/packages/cli/test/applyGatedEdit.test.ts
@@ -53,6 +53,20 @@ describe("applyGatedEdit — file path (no plugin)", () => {
     expect(await types(channel)).toEqual([LogEventType.DocumentEdited]);
   });
 
+  it("park failure degrades: the file is NOT reverted, no event is appended, parkFailed is reported", async () => {
+    // A crashed park used to reject all the way out of waitCycle — no status, no marker — and a
+    // continued turn would have re-synced the working copy over the ONLY copy of the edit.
+    const store = new MemoryDocumentStore("agent body");
+    store.setProposed = async () => {
+      throw new Error("hub down");
+    };
+    const channel = new MemoryControlChannel();
+    const applied = await applyGatedEdit(store, channel, ev({ changed: true }), { current: "agent body", canonicalText: "canon", quarantine: true, gate: null });
+    expect(applied).toEqual({ proposed: false, parkFailed: true });
+    expect(await store.loadDoc()).toBe("agent body"); // NOT reverted — this is the only copy
+    expect(await types(channel)).toEqual([]); // nothing was proposed, so no event claims it was
+  });
+
   it("no change: writes nothing, logs nothing", async () => {
     const store = new MemoryDocumentStore("same");
     const channel = new MemoryControlChannel();

--- a/packages/cli/test/applyGatedEdit.test.ts
+++ b/packages/cli/test/applyGatedEdit.test.ts
@@ -67,6 +67,20 @@ describe("applyGatedEdit — file path (no plugin)", () => {
     expect(await types(channel)).toEqual([]); // nothing was proposed, so no event claims it was
   });
 
+  it("a failed canonical restore AFTER a successful push also degrades: no event, parkFailed reported", async () => {
+    // The push landed but the file revert rejected: the park sequence is incomplete, and the log
+    // must not claim it finished. The working copy still holds the edit; the next run retries.
+    const store = new MemoryDocumentStore("agent body");
+    store.saveDoc = async () => {
+      throw new Error("disk full");
+    };
+    const channel = new MemoryControlChannel();
+    const applied = await applyGatedEdit(store, channel, ev({ changed: true }), { current: "agent body", canonicalText: "canon", quarantine: true, gate: null });
+    expect(applied).toEqual({ proposed: false, parkFailed: true });
+    expect(await store.getProposed()).toBe("agent body"); // the push itself did land
+    expect(await types(channel)).toEqual([]);
+  });
+
   it("no change: writes nothing, logs nothing", async () => {
     const store = new MemoryDocumentStore("same");
     const channel = new MemoryControlChannel();

--- a/packages/cli/test/remoteDocState.test.ts
+++ b/packages/cli/test/remoteDocState.test.ts
@@ -10,7 +10,7 @@ import { mkdtempSync, mkdirSync, readFileSync, rmSync, existsSync, utimesSync, w
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { LogEventType, hashBody, type LogEntry } from "@inplan/core/node";
-import { RemoteDocState, resolutionFromEvents, utf8Bytes } from "../src/remoteDocState";
+import { RemoteDocState, needsReparkFromSlot, resolutionFromEvents, utf8Bytes } from "../src/remoteDocState";
 import { shouldHydrateWorkFile } from "../src/liveSync";
 
 let dir: string;
@@ -95,9 +95,9 @@ describe("resolutionFromEvents", () => {
     expect(resolutionFromEvents(entries, PARK)).toBe("decided");
   });
 
-  it("an un-hashed park event (older CLI) still anchors as the last park", () => {
+  it("an un-hashed park event (older CLI) still anchors when it plausibly IS this park (within clock slack)", () => {
     const entries = [
-      parkEvent("2026-08-15T12:01:00.000Z"), // no hash payload
+      parkEvent("2026-08-15T12:00:03.000Z"), // no hash payload; stamped ~our park time
       entry(LogEventType.RevisionAcceptedAll, "2026-08-15T12:05:00.000Z"),
     ];
     expect(resolutionFromEvents(entries, PARK)).toBe("accepted");
@@ -110,6 +110,18 @@ describe("resolutionFromEvents", () => {
     const entries = [
       parkEvent("2026-08-15T11:00:00.000Z", "hash-OLD"),
       entry(LogEventType.RevisionAcceptedAll, "2026-08-15T11:30:00.000Z"), // the OLD proposal's decision
+    ];
+    expect(resolutionFromEvents(entries, PARK)).toBe("decided");
+  });
+
+  it("a LATER machine's park never becomes our weak anchor — its decision postdates us but is still not ours", () => {
+    // Our park's append failed AND another machine parked after us. The later park event must not
+    // anchor our window (its ts postdates our recorded park time), and the window must close at
+    // that park even without an anchor — the timestamp filter alone cannot exclude the later
+    // decision, because it genuinely postdates our park.
+    const entries = [
+      parkEvent("2026-08-15T12:10:00.000Z", "hash-P2"), // the other machine's park, after ours (12:00)
+      entry(LogEventType.RevisionAcceptedAll, "2026-08-15T12:15:00.000Z"), // P2's decision
     ];
     expect(resolutionFromEvents(entries, PARK)).toBe("decided");
   });
@@ -186,70 +198,58 @@ describe("park / audit / resolve", () => {
     expect(s.latestProposal()).toBeNull();
   });
 
-  it("a corrupt or missing record RECOVERS from the orphan text (the park's crash window)", () => {
-    // parkProposal writes text first, record last: a kill between the writes leaves a
-    // confirmed-pushed proposal with no record. The text alone reconstructs a truthful one.
+  it("the publish is atomic: a corrupt record reads as absent (no torn write-pair), no .tmp remains", () => {
     s.parkProposal("v1");
+    expect(existsSync(join(dir, "remote", "doc-1.plan.md.proposed.json.tmp"))).toBe(false);
     const recordPath = join(dir, "remote", "doc-1.plan.md.proposed.json");
-    writeFileSync(recordPath, "{ this is not json"); // crash mid-record-write
-    expect(s.latestProposal()).toMatchObject({ state: "pending_review", hash: hashBody("v1") });
-    rmSync(recordPath); // crash before the record write entirely
-    expect(s.pendingProposal()).toMatchObject({ state: "pending_review", hash: hashBody("v1") });
-    expect(s.latestProposal()?.docId).toBe("doc-1");
-  });
-
-  it("no record AND no text reads as no proposal, never a crash", () => {
-    expect(s.latestProposal()).toBeNull();
+    writeFileSync(recordPath, "{ this is not json"); // external damage
+    expect(s.latestProposal()).toBeNull(); // no heuristics — reconciliation from the cloud slot heals this
     expect(s.pendingProposal()).toBeNull();
   });
 
-  it("a FINALIZED proposal whose record is damaged recovers as finalized, never as pending", () => {
-    // finalize leaves the text in place; resurrecting a decided proposal as pending would
-    // re-resolve it and append a duplicate history line under a fresh mtime-based `at`.
-    const parked = s.parkProposal("v1");
+  it("no record reads as no proposal, never a crash", () => {
+    expect(s.latestProposal()).toBeNull();
+    expect(s.pendingProposal()).toBeNull();
+    expect(s.proposedText()).toBeNull();
+  });
+
+  it("two proposals with IDENTICAL content and park time keep distinct identities in the history", () => {
+    // History idempotency is by unique id, not content: a genuine second proposal that happens to
+    // repeat earlier content (even at the same recorded time) must not be swallowed as a
+    // crash-retry of the first.
+    const at = new Date("2026-08-15T00:00:00.000Z");
+    const first = s.parkProposal("same text", at);
     s.resolveProposal("accepted");
-    const recordPath = join(dir, "remote", "doc-1.plan.md.proposed.json");
-    const textPath = join(dir, "remote", "doc-1.plan.md.proposed.md");
-    utimesSync(textPath, new Date(parked.at), new Date(parked.at)); // pin mtime = park time (deterministic)
-    rmSync(recordPath);
-    const recovered = s.latestProposal();
-    expect(recovered).toMatchObject({ state: "accepted", at: parked.at });
-    expect(s.pendingProposal()).toBeNull(); // never re-resolved
-    s.resolveProposal("rejected"); // a stray re-resolution attempt is a no-op
+    const second = s.parkProposal("same text", at); // terminal record → a NEW proposal is minted
+    expect(second.id).not.toBe(first.id);
+    s.resolveProposal("rejected");
     const history = readFileSync(join(dir, "remote", "doc-1.plan.md.proposals.jsonl"), "utf8").trim().split("\n");
-    expect(history).toHaveLength(1);
+    expect(history).toHaveLength(2);
+    expect(JSON.parse(history[0]!)).toMatchObject({ id: first.id, state: "accepted" });
+    expect(JSON.parse(history[1]!)).toMatchObject({ id: second.id, state: "rejected" });
   });
 
-  it("a LATER park reusing identical text is pending, even though the history tail matches its hash", () => {
-    const first = s.parkProposal("same text");
-    s.resolveProposal("accepted");
-    s.parkProposal("same text"); // a new proposal with identical content
-    const recordPath = join(dir, "remote", "doc-1.plan.md.proposed.json");
-    const textPath = join(dir, "remote", "doc-1.plan.md.proposed.md");
-    // The re-park rewrote the text well after the finalized park's `at`:
-    const later = new Date(Date.parse(first.at) + 60_000);
-    utimesSync(textPath, later, later);
-    writeFileSync(recordPath, "{ truncated"); // crash mid-record-write on the SECOND park
-    expect(s.latestProposal()).toMatchObject({ state: "pending_review", hash: hashBody("same text") });
-    expect(s.pendingProposal()).not.toBeNull();
-  });
-
-  it("recovery returns the reconstruction even when republishing the record file fails", () => {
+  it("noteOutcomeMissing marks once, keeps the record pending, and finalize clears the marker", () => {
     s.parkProposal("v1");
-    const recordPath = join(dir, "remote", "doc-1.plan.md.proposed.json");
-    rmSync(recordPath);
-    mkdirSync(recordPath); // a directory at the record path makes the republish write throw
-    expect(s.latestProposal()).toMatchObject({ state: "pending_review", hash: hashBody("v1") });
+    const marked = s.noteOutcomeMissing(new Date("2026-08-15T01:00:00.000Z"));
+    expect(marked?.awaitingOutcomeSince).toBe("2026-08-15T01:00:00.000Z");
+    expect(s.pendingProposal()?.awaitingOutcomeSince).toBe("2026-08-15T01:00:00.000Z"); // still pending
+    expect(s.noteOutcomeMissing()).toBeNull(); // already marked — second sighting is the caller's cue to finalize
+    const finalized = s.resolveProposal("decided");
+    expect(finalized?.awaitingOutcomeSince).toBeUndefined(); // the grace marker never outlives the decision
+    expect(s.latestProposal()?.state).toBe("decided");
   });
 
   it("a record failing the full shape check reads as absent — never finalized with bad metadata", () => {
     const recordPath = join(dir, "remote", "doc-1.plan.md.proposed.json");
-    const good = { docId: "doc-1", hash: "h", bytes: 3, at: "2026-08-15T00:00:00.000Z", state: "pending_review" };
+    const good = { id: "p-1", docId: "doc-1", hash: "h", bytes: 3, at: "2026-08-15T00:00:00.000Z", state: "pending_review", text: "abc" };
     for (const bad of [
       { ...good, docId: "some-other-doc" }, // a record copied from another doc
       { ...good, bytes: "3" }, // non-numeric bytes
       { ...good, at: "not-a-date" }, // unparseable park time
       { ...good, state: "unknown_state" }, // outside the allowed states
+      { ...good, id: undefined }, // no identity
+      { ...good, text: undefined }, // no embedded text — a torn legacy shape
       { docId: "doc-1", state: "pending_review" }, // partial record
     ]) {
       writeFileSync(recordPath, JSON.stringify(bad));
@@ -257,7 +257,46 @@ describe("park / audit / resolve", () => {
       expect(s.pendingProposal()).toBeNull();
     }
     writeFileSync(recordPath, JSON.stringify(good));
-    expect(s.latestProposal()).toEqual(good);
+    const { text: _text, ...record } = good;
+    expect(s.latestProposal()).toEqual(record);
+    expect(s.proposedText()).toBe("abc");
+  });
+});
+
+describe("needsReparkFromSlot — reconciliation from the cloud's authoritative side", () => {
+  const pendingV1 = () => s.parkProposal("v1");
+
+  it("no slot → nothing to reconcile, regardless of local state", () => {
+    expect(needsReparkFromSlot(null, null)).toBe(false);
+    expect(needsReparkFromSlot(null, undefined)).toBe(false); // transient read failure — retry later
+    expect(needsReparkFromSlot(pendingV1(), null)).toBe(false);
+  });
+
+  it("a slot with NO local record re-parks (the push landed; the record publish crashed)", () => {
+    expect(needsReparkFromSlot(null, "v1")).toBe(true);
+  });
+
+  it("a slot with a TERMINAL local record re-parks — even for identical content (a re-park after a finalization)", () => {
+    pendingV1();
+    const finalized = s.resolveProposal("accepted")!;
+    expect(needsReparkFromSlot(finalized, "v1")).toBe(true);
+    expect(needsReparkFromSlot(finalized, "v2")).toBe(true);
+  });
+
+  it("a slot about DIFFERENT content than the pending record re-parks (the newer park's publish was lost)", () => {
+    expect(needsReparkFromSlot(pendingV1(), "v2")).toBe(true);
+  });
+
+  it("a healthy pending record matching the slot does nothing", () => {
+    expect(needsReparkFromSlot(pendingV1(), "v1")).toBe(false);
+  });
+
+  it("re-parking from the slot recreates a truthful pending record", () => {
+    pendingV1();
+    s.resolveProposal("accepted");
+    const rec = s.parkProposal("v1"); // what runRemote does when needsReparkFromSlot says true
+    expect(rec.state).toBe("pending_review");
+    expect(s.pendingProposal()?.hash).toBe(hashBody("v1"));
   });
 });
 

--- a/packages/cli/test/remoteDocState.test.ts
+++ b/packages/cli/test/remoteDocState.test.ts
@@ -279,6 +279,19 @@ describe("park / audit / resolve", () => {
     expect(s.latestProposal()?.state).toBe("decided");
   });
 
+  it("a malformed awaiting-outcome marker is stripped, never treated as an elapsed grace", () => {
+    // A truthy-but-garbage marker would read as "already waited one run" and finalize 'decided'
+    // on the first slot clear. The pending proposal itself is intact — only the marker drops.
+    s.parkProposal("v1");
+    const recordPath = join(dir, "remote", "doc-1.plan.md.proposed.json");
+    const stored = JSON.parse(readFileSync(recordPath, "utf8"));
+    writeFileSync(recordPath, JSON.stringify({ ...stored, awaitingOutcomeSince: "not-a-timestamp" }, null, 2));
+    const pending = s.pendingProposal();
+    expect(pending).not.toBeNull();
+    expect(pending?.awaitingOutcomeSince).toBeUndefined(); // stripped → the caller grants the full grace
+    expect(s.noteOutcomeMissing(new Date("2026-08-15T01:00:00.000Z"))?.awaitingOutcomeSince).toBe("2026-08-15T01:00:00.000Z");
+  });
+
   it("re-pushing identical text RESETS a stale awaiting-outcome marker — the slot is live again", () => {
     // Without the reset, a later slot-clear would finalize 'decided' immediately off the old
     // sighting instead of granting the full grace for the decision event to surface.

--- a/packages/cli/test/remoteDocState.test.ts
+++ b/packages/cli/test/remoteDocState.test.ts
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// RemoteDocState — the durable "did my edit land?" state (#88). The properties pinned here are
+// the ones whose absence caused the 2026-08-11 work-deletion: a parked proposal must survive the
+// end-of-turn working-copy overwrite, must be auditable turns later, and must resolve to the
+// human's actual decision (including partial hunk acceptance), never silently vanish.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LogEventType, hashBody, type LogEntry } from "@inplan/core/node";
+import { RemoteDocState, resolutionFromEvents } from "../src/remoteDocState";
+import { shouldHydrateWorkFile } from "../src/liveSync";
+
+let dir: string;
+let s: RemoteDocState;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "inplan-rds-"));
+  s = new RemoteDocState(join(dir, "remote", "doc-1.plan.md"), "doc-1");
+  s.ensureDir();
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+const entry = (type: string, ts: string): LogEntry => ({ seq: 1, ts, actor: "user", type });
+
+describe("resolutionFromEvents", () => {
+  const PARK = "2026-08-15T12:00:00.000Z";
+  it.each([
+    ["accepted", LogEventType.RevisionAcceptedAll, "accepted"],
+    ["rejected", LogEventType.RevisionRejectedAll, "rejected"],
+    ["hunk-accepted → partial", LogEventType.RevisionHunkAccepted, "partially_accepted"],
+    ["hunk-rejected → partial", LogEventType.RevisionHunkRejected, "partially_accepted"],
+  ])("%s", (_label, type, want) => {
+    expect(resolutionFromEvents([entry(type, "2026-08-15T12:05:00.000Z")], PARK)).toBe(want);
+  });
+
+  it("no decision event readable → 'decided' (the slot emptied; which way is unknown)", () => {
+    expect(resolutionFromEvents([entry(LogEventType.AgentRevised, "2026-08-15T12:05:00.000Z")], PARK)).toBe("decided");
+  });
+
+  it("a decision OLDER than the park belongs to a previous proposal and is ignored", () => {
+    expect(resolutionFromEvents([entry(LogEventType.RevisionAcceptedAll, "2026-08-15T11:00:00.000Z")], PARK)).toBe("decided");
+  });
+
+  it("the newest decision wins when several exist since the park", () => {
+    const entries = [
+      entry(LogEventType.RevisionRejectedAll, "2026-08-15T12:01:00.000Z"),
+      entry(LogEventType.RevisionAcceptedAll, "2026-08-15T12:09:00.000Z"),
+    ];
+    expect(resolutionFromEvents(entries, PARK)).toBe("accepted");
+  });
+});
+
+describe("park / audit / resolve", () => {
+  it("a parked proposal survives the end-of-turn working-copy overwrite (the #88 clobber)", () => {
+    s.writeWorkFile("agent's 48KB of work");
+    s.parkProposal("agent's 48KB of work");
+    // The end-of-turn re-sync then overwrites the working copy with the pre-edit canonical:
+    s.writeWorkFile("pre-edit canonical");
+    s.recordSynced("pre-edit canonical");
+
+    const pending = s.pendingProposal();
+    expect(pending?.state).toBe("pending_review");
+    expect(pending?.hash).toBe(hashBody("agent's 48KB of work"));
+    expect(s.proposedText()).toBe("agent's 48KB of work"); // the recovery path
+  });
+
+  it("resolve rewrites the record in place AND appends to the never-pruned history", () => {
+    s.parkProposal("v1");
+    s.resolveProposal("accepted");
+    expect(s.latestProposal()?.state).toBe("accepted");
+    expect(s.pendingProposal()).toBeNull();
+
+    s.parkProposal("v2");
+    s.resolveProposal("rejected");
+    const history = readFileSync(join(dir, "remote", "doc-1.plan.md.proposals.jsonl"), "utf8").trim().split("\n");
+    expect(history).toHaveLength(2); // kept forever — nothing pruned
+    expect(JSON.parse(history[0]!).state).toBe("accepted");
+    expect(JSON.parse(history[1]!).state).toBe("rejected");
+  });
+
+  it("re-parking different text finalizes the still-pending record as 'superseded' — never lost", () => {
+    s.parkProposal("first attempt");
+    s.parkProposal("second attempt");
+    const history = readFileSync(join(dir, "remote", "doc-1.plan.md.proposals.jsonl"), "utf8").trim().split("\n");
+    expect(history).toHaveLength(1);
+    expect(JSON.parse(history[0]!)).toMatchObject({ state: "superseded", hash: hashBody("first attempt") });
+    expect(s.pendingProposal()?.hash).toBe(hashBody("second attempt"));
+  });
+
+  it("re-parking IDENTICAL text does not spam the history (same proposal, re-pushed)", () => {
+    s.parkProposal("same");
+    s.parkProposal("same");
+    expect(existsSync(join(dir, "remote", "doc-1.plan.md.proposals.jsonl"))).toBe(false);
+    expect(s.pendingProposal()?.hash).toBe(hashBody("same"));
+  });
+
+  it("resolveProposal without a pending record is a no-op", () => {
+    expect(s.resolveProposal("accepted")).toBeNull();
+    expect(s.latestProposal()).toBeNull();
+  });
+
+  it("a corrupt record file reads as no record, never a crash", () => {
+    s.parkProposal("v1");
+    const recordPath = join(dir, "remote", "doc-1.plan.md.proposed.json");
+    rmSync(recordPath);
+    expect(s.latestProposal()).toBeNull();
+  });
+});
+
+describe("legacy formats + hydration input (back-compat)", () => {
+  it(".synced stays a bare hash string, byte-identical to the legacy writer", () => {
+    s.writeWorkFile("content");
+    s.recordSynced("content");
+    expect(readFileSync(join(dir, "remote", "doc-1.plan.md.synced"), "utf8")).toBe(hashBody("content"));
+  });
+
+  it("hydrateInput feeds shouldHydrateWorkFile exactly as the inline code did", () => {
+    // No file yet → hydrate.
+    expect(shouldHydrateWorkFile(s.hydrateInput())).toBe(true);
+    // Fresh sync → hashes match → hydrate (pull the human's edits).
+    s.writeWorkFile("synced content");
+    s.recordSynced("synced content");
+    expect(shouldHydrateWorkFile(s.hydrateInput())).toBe(true);
+    // Agent edited since → keep the copy.
+    s.writeWorkFile("agent edited this");
+    expect(shouldHydrateWorkFile(s.hydrateInput())).toBe(false);
+    // Replay pending → never overwrite.
+    s.recordSynced("agent edited this");
+    s.markReplayPending();
+    expect(shouldHydrateWorkFile(s.hydrateInput())).toBe(false);
+    s.clearReplayPending();
+    expect(shouldHydrateWorkFile(s.hydrateInput())).toBe(true);
+  });
+
+  it("proposal files never affect the hydration decision", () => {
+    s.writeWorkFile("synced");
+    s.recordSynced("synced");
+    s.parkProposal("a pending proposal");
+    expect(shouldHydrateWorkFile(s.hydrateInput())).toBe(true);
+  });
+});

--- a/packages/cli/test/remoteDocState.test.ts
+++ b/packages/cli/test/remoteDocState.test.ts
@@ -10,7 +10,7 @@ import { mkdtempSync, readFileSync, rmSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { LogEventType, hashBody, type LogEntry } from "@inplan/core/node";
-import { RemoteDocState, resolutionFromEvents } from "../src/remoteDocState";
+import { RemoteDocState, resolutionFromEvents, utf8Bytes } from "../src/remoteDocState";
 import { shouldHydrateWorkFile } from "../src/liveSync";
 
 let dir: string;
@@ -94,6 +94,14 @@ describe("park / audit / resolve", () => {
     s.parkProposal("same");
     expect(existsSync(join(dir, "remote", "doc-1.plan.md.proposals.jsonl"))).toBe(false);
     expect(s.pendingProposal()?.hash).toBe(hashBody("same"));
+  });
+
+  it("bytes is the UTF-8 byte length, not the UTF-16 code-unit count", () => {
+    const text = "café ☕"; // 6 code units; é is 2 UTF-8 bytes, ☕ is 3
+    const record = s.parkProposal(text);
+    expect(record.bytes).toBe(utf8Bytes(text));
+    expect(record.bytes).toBe(9);
+    expect(record.bytes).not.toBe(text.length);
   });
 
   it("resolveProposal without a pending record is a no-op", () => {

--- a/packages/cli/test/remoteDocState.test.ts
+++ b/packages/cli/test/remoteDocState.test.ts
@@ -68,7 +68,7 @@ describe("resolutionFromEvents", () => {
   it("a previous proposal's decision BEFORE the park event is never misattributed", () => {
     const entries = [
       entry(LogEventType.RevisionAcceptedAll, "2026-08-15T12:30:00.000Z"), // late server ts, but before the park in log order
-      parkEvent("2026-08-15T12:31:00.000Z", "hash-P1"),
+      parkEvent("2026-08-15T12:00:02.000Z", "hash-P1"), // ours (within clock slack)
     ];
     expect(resolutionFromEvents(entries, PARK)).toBe("decided");
   });
@@ -77,7 +77,7 @@ describe("resolutionFromEvents", () => {
     // Machine A parks P1 and goes offline; the human rejects P1; machine B parks P2 which is
     // accepted. When A finally resolves P1 it must read P1's rejection, not P2's acceptance.
     const entries = [
-      parkEvent("2026-08-15T12:01:00.000Z", "hash-P1"),
+      parkEvent("2026-08-15T12:00:02.000Z", "hash-P1"), // ours (within clock slack)
       entry(LogEventType.RevisionRejectedAll, "2026-08-15T12:05:00.000Z"), // P1's decision
       parkEvent("2026-08-15T12:10:00.000Z", "hash-P2"),
       entry(LogEventType.RevisionAcceptedAll, "2026-08-15T12:15:00.000Z"), // P2's decision
@@ -88,7 +88,7 @@ describe("resolutionFromEvents", () => {
 
   it("a later proposal with no decision for ours → 'decided', never the newer proposal's outcome", () => {
     const entries = [
-      parkEvent("2026-08-15T12:01:00.000Z", "hash-P1"),
+      parkEvent("2026-08-15T12:00:02.000Z", "hash-P1"), // ours (within clock slack)
       parkEvent("2026-08-15T12:10:00.000Z", "hash-P2"),
       entry(LogEventType.RevisionAcceptedAll, "2026-08-15T12:15:00.000Z"), // P2's decision only
     ];
@@ -112,6 +112,18 @@ describe("resolutionFromEvents", () => {
       entry(LogEventType.RevisionAcceptedAll, "2026-08-15T11:30:00.000Z"), // the OLD proposal's decision
     ];
     expect(resolutionFromEvents(entries, PARK)).toBe("decided");
+  });
+
+  it("a hash match POSTDATING our park is someone else's identical-text proposal — never our anchor", () => {
+    // Identical text is not identity: a newer proposal repeating our content must not donate its
+    // decision window to this record. Our own (eligible) park event still anchors correctly.
+    const entries = [
+      parkEvent("2026-08-15T11:58:00.000Z", "hash-P1"), // ours (within clock slack of PARK.at)
+      entry(LogEventType.RevisionRejectedAll, "2026-08-15T11:59:00.000Z"), // OUR decision
+      parkEvent("2026-08-15T12:10:00.000Z", "hash-P1"), // another machine's park, SAME text
+      entry(LogEventType.RevisionAcceptedAll, "2026-08-15T12:15:00.000Z"), // THEIR decision
+    ];
+    expect(resolutionFromEvents(entries, PARK)).toBe("rejected");
   });
 
   it("a LATER machine's park never becomes our weak anchor — its decision postdates us but is still not ours", () => {
@@ -240,9 +252,34 @@ describe("park / audit / resolve", () => {
     expect(s.latestProposal()?.state).toBe("decided");
   });
 
+  it("re-pushing identical text RESETS a stale awaiting-outcome marker — the slot is live again", () => {
+    // Without the reset, a later slot-clear would finalize 'decided' immediately off the old
+    // sighting instead of granting the full grace for the decision event to surface.
+    const first = s.parkProposal("v1");
+    s.noteOutcomeMissing();
+    const repushed = s.parkProposal("v1");
+    expect(repushed.id).toBe(first.id); // same proposal, re-pushed
+    expect(repushed.awaitingOutcomeSince).toBeUndefined();
+    expect(s.pendingProposal()?.awaitingOutcomeSince).toBeUndefined();
+  });
+
+  it("a pending record whose hash/bytes disagree with its own text reads as absent", () => {
+    // Valid JSON is not integrity: a corrupted pending record must not feed re-push or slot
+    // comparison with text it doesn't actually describe. Finalized records tolerate the mismatch
+    // (their text is historical convenience, not a recovery input).
+    const recordPath = join(dir, "remote", "doc-1.plan.md.proposed.json");
+    const base = { id: "p-1", docId: "doc-1", bytes: utf8Bytes("abc"), at: "2026-08-15T00:00:00.000Z", text: "abc" };
+    writeFileSync(recordPath, JSON.stringify({ ...base, state: "pending_review", hash: "not-the-text-hash" }));
+    expect(s.latestProposal()).toBeNull();
+    writeFileSync(recordPath, JSON.stringify({ ...base, state: "pending_review", hash: hashBody("abc"), bytes: 999 }));
+    expect(s.latestProposal()).toBeNull();
+    writeFileSync(recordPath, JSON.stringify({ ...base, state: "accepted", hash: "not-the-text-hash" }));
+    expect(s.latestProposal()?.state).toBe("accepted");
+  });
+
   it("a record failing the full shape check reads as absent — never finalized with bad metadata", () => {
     const recordPath = join(dir, "remote", "doc-1.plan.md.proposed.json");
-    const good = { id: "p-1", docId: "doc-1", hash: "h", bytes: 3, at: "2026-08-15T00:00:00.000Z", state: "pending_review", text: "abc" };
+    const good = { id: "p-1", docId: "doc-1", hash: hashBody("abc"), bytes: utf8Bytes("abc"), at: "2026-08-15T00:00:00.000Z", state: "pending_review", text: "abc" };
     for (const bad of [
       { ...good, docId: "some-other-doc" }, // a record copied from another doc
       { ...good, bytes: "3" }, // non-numeric bytes

--- a/packages/cli/test/remoteDocState.test.ts
+++ b/packages/cli/test/remoteDocState.test.ts
@@ -114,6 +114,33 @@ describe("resolutionFromEvents", () => {
     expect(resolutionFromEvents(entries, PARK)).toBe("decided");
   });
 
+  it("a hash match far PREDATING our park is an OLDER identical-text proposal — never our anchor", () => {
+    // The backward twin of the postdating case: our event never appended, and an old proposal
+    // with identical content was decided hours ago. Its event must not bind our window — outside
+    // the near window it only weak-anchors, and the timestamp filter then excludes its decision.
+    const entries = [
+      parkEvent("2026-08-15T08:00:00.000Z", "hash-P1"), // an OLD proposal, same content
+      entry(LogEventType.RevisionAcceptedAll, "2026-08-15T08:30:00.000Z"), // ITS decision
+    ];
+    expect(resolutionFromEvents(entries, PARK)).toBe("decided"); // ours at 12:00 — never 'accepted'
+  });
+
+  it("a retried finalization with a DIFFERENT outcome appends the correction to the history", () => {
+    s.parkProposal("v1");
+    s.resolveProposal("accepted");
+    const historyPath = join(dir, "remote", "doc-1.plan.md.proposals.jsonl");
+    const recordPath = join(dir, "remote", "doc-1.plan.md.proposed.json");
+    // Crash window: history has 'accepted', the record republish never ran — and the retry
+    // resolves differently this time. The history must follow the record, not silently disagree.
+    const stored = JSON.parse(readFileSync(recordPath, "utf8"));
+    writeFileSync(recordPath, JSON.stringify({ ...stored, state: "pending_review" }, null, 2));
+    s.resolveProposal("rejected");
+    const lines = readFileSync(historyPath, "utf8").trim().split("\n");
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[1]!)).toMatchObject({ id: stored.id, state: "rejected" });
+    expect(s.latestProposal()?.state).toBe("rejected"); // record and history tail agree
+  });
+
   it("a hash match POSTDATING our park is someone else's identical-text proposal — never our anchor", () => {
     // Identical text is not identity: a newer proposal repeating our content must not donate its
     // decision window to this record. Our own (eligible) park event still anchors correctly.

--- a/packages/cli/test/remoteDocState.test.ts
+++ b/packages/cli/test/remoteDocState.test.ts
@@ -10,7 +10,7 @@ import { mkdtempSync, mkdirSync, readFileSync, rmSync, existsSync, utimesSync, w
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { LogEventType, hashBody, type LogEntry } from "@inplan/core/node";
-import { RemoteDocState, needsReparkFromSlot, resolutionFromEvents, utf8Bytes } from "../src/remoteDocState";
+import { RemoteDocState, isDecidedProposalCorpse, needsReparkFromSlot, resolutionFromEvents, utf8Bytes } from "../src/remoteDocState";
 import { shouldHydrateWorkFile } from "../src/liveSync";
 
 let dir: string;
@@ -297,6 +297,27 @@ describe("park / audit / resolve", () => {
     const { text: _text, ...record } = good;
     expect(s.latestProposal()).toEqual(record);
     expect(s.proposedText()).toBe("abc");
+  });
+});
+
+describe("isDecidedProposalCorpse — the working copy after a park-then-crash-then-decision", () => {
+  it("a working copy equal to a DECIDED record's text is the corpse — restore canonical, don't re-park", () => {
+    s.parkProposal("rejected content");
+    const rejected = s.resolveProposal("rejected")!;
+    expect(isDecidedProposalCorpse(rejected, "rejected content")).toBe(true);
+  });
+
+  it("a PENDING record's matching copy is not a corpse — the proposal is live", () => {
+    const pending = s.parkProposal("live content");
+    expect(isDecidedProposalCorpse(pending, "live content")).toBe(false);
+  });
+
+  it("diverged content is real agent work, never a corpse", () => {
+    s.parkProposal("decided content");
+    const decided = s.resolveProposal("accepted")!;
+    expect(isDecidedProposalCorpse(decided, "something the agent typed since")).toBe(false);
+    expect(isDecidedProposalCorpse(decided, null)).toBe(false);
+    expect(isDecidedProposalCorpse(null, "anything")).toBe(false);
   });
 });
 

--- a/packages/cli/test/remoteDocState.test.ts
+++ b/packages/cli/test/remoteDocState.test.ts
@@ -6,7 +6,7 @@
 // human's actual decision (including partial hunk acceptance), never silently vanish.
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, existsSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { LogEventType, hashBody, type LogEntry } from "@inplan/core/node";
@@ -49,6 +49,26 @@ describe("resolutionFromEvents", () => {
       entry(LogEventType.RevisionAcceptedAll, "2026-08-15T12:09:00.000Z"),
     ];
     expect(resolutionFromEvents(entries, PARK)).toBe("accepted");
+  });
+
+  it("log order beats the clock: a decision after the park EVENT counts even when server timestamps lag the CLI clock", () => {
+    // The CLI records the park time from its own clock; Supabase stamps events server-side. With
+    // the CLI clock ahead, a fast acceptance can carry a ts EARLIER than the recorded park — the
+    // agent_revision_proposed event's position in the log is the boundary that cannot skew.
+    const entries = [
+      entry(LogEventType.RevisionRejectedAll, "2026-08-15T11:50:00.000Z"), // a PREVIOUS proposal's decision
+      entry(LogEventType.AgentRevisionProposed, "2026-08-15T11:58:00.000Z"), // this park (server ts behind PARK)
+      entry(LogEventType.RevisionAcceptedAll, "2026-08-15T11:59:00.000Z"), // fast acceptance, ts still < PARK
+    ];
+    expect(resolutionFromEvents(entries, PARK)).toBe("accepted");
+  });
+
+  it("a previous proposal's decision BEFORE the park event is never misattributed", () => {
+    const entries = [
+      entry(LogEventType.RevisionAcceptedAll, "2026-08-15T12:30:00.000Z"), // late server ts, but before the park in log order
+      entry(LogEventType.AgentRevisionProposed, "2026-08-15T12:31:00.000Z"),
+    ];
+    expect(resolutionFromEvents(entries, PARK)).toBe("decided");
   });
 });
 
@@ -112,8 +132,28 @@ describe("park / audit / resolve", () => {
   it("a corrupt record file reads as no record, never a crash", () => {
     s.parkProposal("v1");
     const recordPath = join(dir, "remote", "doc-1.plan.md.proposed.json");
-    rmSync(recordPath);
+    writeFileSync(recordPath, "{ this is not json"); // exercises the parse-failure branch
     expect(s.latestProposal()).toBeNull();
+    rmSync(recordPath); // and plain absence
+    expect(s.latestProposal()).toBeNull();
+  });
+
+  it("a record failing the full shape check reads as absent — never finalized with bad metadata", () => {
+    const recordPath = join(dir, "remote", "doc-1.plan.md.proposed.json");
+    const good = { docId: "doc-1", hash: "h", bytes: 3, at: "2026-08-15T00:00:00.000Z", state: "pending_review" };
+    for (const bad of [
+      { ...good, docId: "some-other-doc" }, // a record copied from another doc
+      { ...good, bytes: "3" }, // non-numeric bytes
+      { ...good, at: "not-a-date" }, // unparseable park time
+      { ...good, state: "unknown_state" }, // outside the allowed states
+      { docId: "doc-1", state: "pending_review" }, // partial record
+    ]) {
+      writeFileSync(recordPath, JSON.stringify(bad));
+      expect(s.latestProposal()).toBeNull();
+      expect(s.pendingProposal()).toBeNull();
+    }
+    writeFileSync(recordPath, JSON.stringify(good));
+    expect(s.latestProposal()).toEqual(good);
   });
 });
 

--- a/packages/cli/test/remoteDocState.test.ts
+++ b/packages/cli/test/remoteDocState.test.ts
@@ -25,7 +25,9 @@ afterEach(() => rmSync(dir, { recursive: true, force: true }));
 const entry = (type: string, ts: string): LogEntry => ({ seq: 1, ts, actor: "user", type });
 
 describe("resolutionFromEvents", () => {
-  const PARK = "2026-08-15T12:00:00.000Z";
+  const PARK = { at: "2026-08-15T12:00:00.000Z", hash: "hash-P1" };
+  const parkEvent = (ts: string, hash?: string): LogEntry => ({ seq: 1, ts, actor: "agent", type: LogEventType.AgentRevisionProposed, ...(hash ? { payload: { bytes: 1, hash } } : {}) });
+
   it.each([
     ["accepted", LogEventType.RevisionAcceptedAll, "accepted"],
     ["rejected", LogEventType.RevisionRejectedAll, "rejected"],
@@ -57,7 +59,7 @@ describe("resolutionFromEvents", () => {
     // agent_revision_proposed event's position in the log is the boundary that cannot skew.
     const entries = [
       entry(LogEventType.RevisionRejectedAll, "2026-08-15T11:50:00.000Z"), // a PREVIOUS proposal's decision
-      entry(LogEventType.AgentRevisionProposed, "2026-08-15T11:58:00.000Z"), // this park (server ts behind PARK)
+      parkEvent("2026-08-15T11:58:00.000Z", "hash-P1"), // this park (server ts behind PARK)
       entry(LogEventType.RevisionAcceptedAll, "2026-08-15T11:59:00.000Z"), // fast acceptance, ts still < PARK
     ];
     expect(resolutionFromEvents(entries, PARK)).toBe("accepted");
@@ -66,9 +68,39 @@ describe("resolutionFromEvents", () => {
   it("a previous proposal's decision BEFORE the park event is never misattributed", () => {
     const entries = [
       entry(LogEventType.RevisionAcceptedAll, "2026-08-15T12:30:00.000Z"), // late server ts, but before the park in log order
-      entry(LogEventType.AgentRevisionProposed, "2026-08-15T12:31:00.000Z"),
+      parkEvent("2026-08-15T12:31:00.000Z", "hash-P1"),
     ];
     expect(resolutionFromEvents(entries, PARK)).toBe("decided");
+  });
+
+  it("decisions bind to THIS proposal's park event by hash — a later proposal's decision is never claimed", () => {
+    // Machine A parks P1 and goes offline; the human rejects P1; machine B parks P2 which is
+    // accepted. When A finally resolves P1 it must read P1's rejection, not P2's acceptance.
+    const entries = [
+      parkEvent("2026-08-15T12:01:00.000Z", "hash-P1"),
+      entry(LogEventType.RevisionRejectedAll, "2026-08-15T12:05:00.000Z"), // P1's decision
+      parkEvent("2026-08-15T12:10:00.000Z", "hash-P2"),
+      entry(LogEventType.RevisionAcceptedAll, "2026-08-15T12:15:00.000Z"), // P2's decision
+    ];
+    expect(resolutionFromEvents(entries, PARK)).toBe("rejected");
+    expect(resolutionFromEvents(entries, { at: "2026-08-15T12:10:00.000Z", hash: "hash-P2" })).toBe("accepted");
+  });
+
+  it("a later proposal with no decision for ours → 'decided', never the newer proposal's outcome", () => {
+    const entries = [
+      parkEvent("2026-08-15T12:01:00.000Z", "hash-P1"),
+      parkEvent("2026-08-15T12:10:00.000Z", "hash-P2"),
+      entry(LogEventType.RevisionAcceptedAll, "2026-08-15T12:15:00.000Z"), // P2's decision only
+    ];
+    expect(resolutionFromEvents(entries, PARK)).toBe("decided");
+  });
+
+  it("an un-hashed park event (older CLI) still anchors as the last park", () => {
+    const entries = [
+      parkEvent("2026-08-15T12:01:00.000Z"), // no hash payload
+      entry(LogEventType.RevisionAcceptedAll, "2026-08-15T12:05:00.000Z"),
+    ];
+    expect(resolutionFromEvents(entries, PARK)).toBe("accepted");
   });
 });
 
@@ -122,6 +154,20 @@ describe("park / audit / resolve", () => {
     expect(record.bytes).toBe(utf8Bytes(text));
     expect(record.bytes).toBe(9);
     expect(record.bytes).not.toBe(text.length);
+  });
+
+  it("a crashed finalization retries without duplicating history (history first, record last, idempotent)", () => {
+    s.parkProposal("v1");
+    s.resolveProposal("accepted");
+    const historyPath = join(dir, "remote", "doc-1.plan.md.proposals.jsonl");
+    const recordPath = join(dir, "remote", "doc-1.plan.md.proposed.json");
+    // Simulate the crash window: history was appended but the record rewrite never happened —
+    // roll the record back to pending_review as if the process died between the two writes.
+    const record = JSON.parse(readFileSync(recordPath, "utf8"));
+    writeFileSync(recordPath, JSON.stringify({ ...record, state: "pending_review" }, null, 2));
+    s.resolveProposal("accepted"); // the retry
+    expect(readFileSync(historyPath, "utf8").trim().split("\n")).toHaveLength(1); // no duplicate line
+    expect(s.latestProposal()?.state).toBe("accepted"); // and the record is finalized now
   });
 
   it("resolveProposal without a pending record is a no-op", () => {

--- a/packages/cli/test/remoteDocState.test.ts
+++ b/packages/cli/test/remoteDocState.test.ts
@@ -102,6 +102,17 @@ describe("resolutionFromEvents", () => {
     ];
     expect(resolutionFromEvents(entries, PARK)).toBe("accepted");
   });
+
+  it("a WEAK anchor (our park's event never appended) keeps the timestamp filter — an older proposal's decision is never claimed", () => {
+    // Our park's append failed; the last park event in the log is a PREVIOUS proposal's, and its
+    // decision sits inside that window. Only a hash-matched anchor earns pure log-order trust;
+    // here the decision predates our recorded park time, so it must not finalize our record.
+    const entries = [
+      parkEvent("2026-08-15T11:00:00.000Z", "hash-OLD"),
+      entry(LogEventType.RevisionAcceptedAll, "2026-08-15T11:30:00.000Z"), // the OLD proposal's decision
+    ];
+    expect(resolutionFromEvents(entries, PARK)).toBe("decided");
+  });
 });
 
 describe("park / audit / resolve", () => {
@@ -175,13 +186,21 @@ describe("park / audit / resolve", () => {
     expect(s.latestProposal()).toBeNull();
   });
 
-  it("a corrupt record file reads as no record, never a crash", () => {
+  it("a corrupt or missing record RECOVERS from the orphan text (the park's crash window)", () => {
+    // parkProposal writes text first, record last: a kill between the writes leaves a
+    // confirmed-pushed proposal with no record. The text alone reconstructs a truthful one.
     s.parkProposal("v1");
     const recordPath = join(dir, "remote", "doc-1.plan.md.proposed.json");
-    writeFileSync(recordPath, "{ this is not json"); // exercises the parse-failure branch
+    writeFileSync(recordPath, "{ this is not json"); // crash mid-record-write
+    expect(s.latestProposal()).toMatchObject({ state: "pending_review", hash: hashBody("v1") });
+    rmSync(recordPath); // crash before the record write entirely
+    expect(s.pendingProposal()).toMatchObject({ state: "pending_review", hash: hashBody("v1") });
+    expect(s.latestProposal()?.docId).toBe("doc-1");
+  });
+
+  it("no record AND no text reads as no proposal, never a crash", () => {
     expect(s.latestProposal()).toBeNull();
-    rmSync(recordPath); // and plain absence
-    expect(s.latestProposal()).toBeNull();
+    expect(s.pendingProposal()).toBeNull();
   });
 
   it("a record failing the full shape check reads as absent — never finalized with bad metadata", () => {

--- a/packages/cli/test/remoteDocState.test.ts
+++ b/packages/cli/test/remoteDocState.test.ts
@@ -6,7 +6,7 @@
 // human's actual decision (including partial hunk acceptance), never silently vanish.
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, readFileSync, rmSync, existsSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, existsSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { LogEventType, hashBody, type LogEntry } from "@inplan/core/node";
@@ -201,6 +201,45 @@ describe("park / audit / resolve", () => {
   it("no record AND no text reads as no proposal, never a crash", () => {
     expect(s.latestProposal()).toBeNull();
     expect(s.pendingProposal()).toBeNull();
+  });
+
+  it("a FINALIZED proposal whose record is damaged recovers as finalized, never as pending", () => {
+    // finalize leaves the text in place; resurrecting a decided proposal as pending would
+    // re-resolve it and append a duplicate history line under a fresh mtime-based `at`.
+    const parked = s.parkProposal("v1");
+    s.resolveProposal("accepted");
+    const recordPath = join(dir, "remote", "doc-1.plan.md.proposed.json");
+    const textPath = join(dir, "remote", "doc-1.plan.md.proposed.md");
+    utimesSync(textPath, new Date(parked.at), new Date(parked.at)); // pin mtime = park time (deterministic)
+    rmSync(recordPath);
+    const recovered = s.latestProposal();
+    expect(recovered).toMatchObject({ state: "accepted", at: parked.at });
+    expect(s.pendingProposal()).toBeNull(); // never re-resolved
+    s.resolveProposal("rejected"); // a stray re-resolution attempt is a no-op
+    const history = readFileSync(join(dir, "remote", "doc-1.plan.md.proposals.jsonl"), "utf8").trim().split("\n");
+    expect(history).toHaveLength(1);
+  });
+
+  it("a LATER park reusing identical text is pending, even though the history tail matches its hash", () => {
+    const first = s.parkProposal("same text");
+    s.resolveProposal("accepted");
+    s.parkProposal("same text"); // a new proposal with identical content
+    const recordPath = join(dir, "remote", "doc-1.plan.md.proposed.json");
+    const textPath = join(dir, "remote", "doc-1.plan.md.proposed.md");
+    // The re-park rewrote the text well after the finalized park's `at`:
+    const later = new Date(Date.parse(first.at) + 60_000);
+    utimesSync(textPath, later, later);
+    writeFileSync(recordPath, "{ truncated"); // crash mid-record-write on the SECOND park
+    expect(s.latestProposal()).toMatchObject({ state: "pending_review", hash: hashBody("same text") });
+    expect(s.pendingProposal()).not.toBeNull();
+  });
+
+  it("recovery returns the reconstruction even when republishing the record file fails", () => {
+    s.parkProposal("v1");
+    const recordPath = join(dir, "remote", "doc-1.plan.md.proposed.json");
+    rmSync(recordPath);
+    mkdirSync(recordPath); // a directory at the record path makes the republish write throw
+    expect(s.latestProposal()).toMatchObject({ state: "pending_review", hash: hashBody("v1") });
   });
 
   it("a record failing the full shape check reads as absent — never finalized with bad metadata", () => {

--- a/packages/cli/test/waitCycleResume.test.ts
+++ b/packages/cli/test/waitCycleResume.test.ts
@@ -245,6 +245,25 @@ describe("waitCycle resume is a loop, not a re-entry", () => {
     }
   });
 
+  it("a failed lock claim exits as wait_failed WITH the landing signal, never a bare crash", async () => {
+    // The lock claim is the last unguarded write before the wait: with the control backend
+    // write-dead it used to reject the whole run — no JSON at all — right after a park.
+    const h = harness(DOC_B);
+    h.channel.claimLock = async () => {
+      throw new Error("backend unavailable");
+    };
+    const gate = { readCanonical: async () => DOC_A, applyRevision: async () => {} };
+    try {
+      const run = waitCycle(h.backend, null, new Set(), undefined, gate);
+      await expect(run).resolves.toBe("exiting");
+      const last = h.lastJson() as ReturnType<typeof h.lastJson> & { proposal?: { state: string } };
+      expect(last.status).toBe("wait_failed");
+      expect(last.proposal).toMatchObject({ state: "pending_review", hash: hashBody(DOC_B) }); // the park still reported
+    } finally {
+      h.restore();
+    }
+  });
+
   it("no `proposal` key when the turn made no body change", async () => {
     const h = harness(DOC_A);
     try {

--- a/packages/cli/test/waitCycleResume.test.ts
+++ b/packages/cli/test/waitCycleResume.test.ts
@@ -14,7 +14,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { LogEventType, MemoryControlChannel, MemoryDocumentStore, type LogEntry } from "@inplan/core/node";
+import { LogEventType, MemoryControlChannel, MemoryDocumentStore, hashBody, type LogEntry } from "@inplan/core/node";
 import { waitCycle, type WaitBackend } from "../src/cli";
 
 const DOC_A = "# Plan\n\nOriginal body.\n\n<!--inplan\n[]\n-->\n";
@@ -144,6 +144,38 @@ describe("waitCycle resume is a loop, not a re-entry", () => {
 
       expect(await countEvents(h.channel, LogEventType.AgentRevisionProposed)).toBe(1);
       expect(h.lastJson().status).toBe("your_turn");
+    } finally {
+      h.restore();
+    }
+  });
+
+  it("a parked Review proposal is reported in the wait output (#88 landing signal)", async () => {
+    // The push reached the store and awaits the human — the wait output must say so, or an agent
+    // auditing "did my edit land?" reads the unchanged canonical as loss (the 2026-08-11 incident).
+    const h = harness(DOC_B); // the agent's working copy, differing from the hub canonical
+    const gate = { readCanonical: async () => DOC_A, applyRevision: async () => {} };
+    try {
+      const run = waitCycle(h.backend, null, new Set(), undefined, gate);
+      await reloadThenAct(h.channel);
+      await expect(run).resolves.toBe("ok");
+
+      const last = h.lastJson() as ReturnType<typeof h.lastJson> & { proposal?: { state: string; bytes: number; hash: string } };
+      expect(last.proposal).toEqual({ state: "pending_review", bytes: DOC_B.length, hash: hashBody(DOC_B) });
+      expect(h.stderr()).toContain("parked as a proposal");
+      expect(await h.store.getProposed()).toBe(DOC_B);
+    } finally {
+      h.restore();
+    }
+  });
+
+  it("no `proposal` key when the turn made no body change", async () => {
+    const h = harness(DOC_A);
+    try {
+      const run = waitCycle(h.backend, null, new Set());
+      await reloadThenAct(h.channel);
+      await expect(run).resolves.toBe("ok");
+      expect("proposal" in h.lastJson()).toBe(false);
+      expect(h.stderr()).not.toContain("parked as a proposal");
     } finally {
       h.restore();
     }

--- a/packages/cli/test/waitCycleResume.test.ts
+++ b/packages/cli/test/waitCycleResume.test.ts
@@ -16,6 +16,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { LogEventType, MemoryControlChannel, MemoryDocumentStore, hashBody, type LogEntry } from "@inplan/core/node";
 import { waitCycle, type WaitBackend } from "../src/cli";
+import { utf8Bytes } from "../src/remoteDocState";
 
 const DOC_A = "# Plan\n\nOriginal body.\n\n<!--inplan\n[]\n-->\n";
 const DOC_B = "# Plan\n\nAgent-edited body.\n\n<!--inplan\n[]\n-->\n";
@@ -160,10 +161,56 @@ describe("waitCycle resume is a loop, not a re-entry", () => {
       await expect(run).resolves.toBe("ok");
 
       const last = h.lastJson() as ReturnType<typeof h.lastJson> & { proposal?: { state: string; bytes: number; hash: string } };
-      expect(last.proposal).toEqual({ state: "pending_review", bytes: DOC_B.length, hash: hashBody(DOC_B) });
+      expect(last.proposal).toEqual({ state: "pending_review", bytes: utf8Bytes(DOC_B), hash: hashBody(DOC_B) });
       expect(h.stderr()).toContain("parked as a proposal");
       expect(await h.store.getProposed()).toBe(DOC_B);
     } finally {
+      h.restore();
+    }
+  });
+
+  it("a superseded wait still reports the proposal it parked (#88)", async () => {
+    // The park happened in THIS run's turn; a newer waiter taking over must not make it look
+    // like the push failed — superseded is a step-down, not a rollback.
+    const h = harness(DOC_B);
+    const gate = { readCanonical: async () => DOC_A, applyRevision: async () => {} };
+    try {
+      const run = waitCycle(h.backend, null, new Set(), undefined, gate);
+      await waitUntil(async () => (await countEvents(h.channel, LogEventType.AgentRevisionProposed)) >= 1);
+      await h.channel.claimLock("a-newer-waiter"); // an out-of-band newer waiter takes the doc
+      await expect(run).resolves.toBe("ok");
+
+      const last = h.lastJson() as ReturnType<typeof h.lastJson> & { proposal?: { state: string } };
+      expect(last.status).toBe("superseded");
+      expect(last.proposal).toMatchObject({ state: "pending_review", hash: hashBody(DOC_B) });
+    } finally {
+      h.restore();
+    }
+  });
+
+  it("a failed wait still reports the proposal it parked (#88)", async () => {
+    // The proposal reached the store BEFORE the wait began; losing contact afterwards must not
+    // read as "the edit went nowhere".
+    process.env.INPLAN_ERROR_GRACE_MS = "20";
+    const h = harness(DOC_B);
+    const gate = { readCanonical: async () => DOC_A, applyRevision: async () => {} };
+    const origReadSince = h.channel.readSince.bind(h.channel);
+    let failing = false;
+    h.channel.readSince = async (cursor: number) => {
+      if (failing) throw new Error("session expired");
+      return origReadSince(cursor);
+    };
+    try {
+      const run = waitCycle(h.backend, null, new Set(), undefined, gate);
+      await waitUntil(async () => (await countEvents(h.channel, LogEventType.AgentRevisionProposed)) >= 1);
+      failing = true; // every poll now fails; the grace (20ms) trips and the wait gives up
+      await expect(run).resolves.toBe("exiting");
+
+      const last = h.lastJson() as ReturnType<typeof h.lastJson> & { proposal?: { state: string } };
+      expect(last.status).toBe("wait_failed");
+      expect(last.proposal).toMatchObject({ state: "pending_review", hash: hashBody(DOC_B) });
+    } finally {
+      delete process.env.INPLAN_ERROR_GRACE_MS;
       h.restore();
     }
   });

--- a/packages/cli/test/waitCycleResume.test.ts
+++ b/packages/cli/test/waitCycleResume.test.ts
@@ -215,6 +215,36 @@ describe("waitCycle resume is a loop, not a re-entry", () => {
     }
   });
 
+  it("a FAILED park is machine-readable (proposal.state park_failed) and survives a write-dead control log", async () => {
+    // Two failures at once — the push rejects AND every agent-side log append fails (the same
+    // outage). Previously the unguarded turn-marker append crashed the wait with NO status; now
+    // the wait completes and the JSON says exactly what happened, so an agent parsing only the
+    // output (stderr discarded) can never read a failed push as a no-change turn.
+    const h = harness(DOC_B);
+    h.store.setProposed = async () => {
+      throw new Error("hub down");
+    };
+    const origAppend = h.channel.append.bind(h.channel);
+    h.channel.append = async (e: Parameters<typeof origAppend>[0]) => {
+      if (e.actor === "agent") throw new Error("log write denied");
+      return origAppend(e);
+    };
+    const gate = { readCanonical: async () => DOC_A, applyRevision: async () => {} };
+    try {
+      const run = waitCycle(h.backend, null, new Set(), undefined, gate);
+      await waitUntil(async () => h.stderr().includes("FAILED")); // the park failure was reported → turn processing done
+      await h.channel.append({ actor: "user", type: LogEventType.TurnEnded });
+      await expect(run).resolves.toBe("ok");
+
+      const last = h.lastJson() as ReturnType<typeof h.lastJson> & { proposal?: { state: string; hash: string } };
+      expect(last.status).toBe("your_turn");
+      expect(last.proposal).toMatchObject({ state: "park_failed", hash: hashBody(DOC_B) });
+      expect(await h.store.getProposed()).toBeNull(); // nothing landed anywhere
+    } finally {
+      h.restore();
+    }
+  });
+
   it("no `proposal` key when the turn made no body change", async () => {
     const h = harness(DOC_A);
     try {

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -98,9 +98,17 @@ How to audit "did my edit land?", in order:
    `revision_hunk_accepted`, or `revision_rejected_all`.
 
 If the park itself fails, the wait JSON carries `proposal: { state: "park_failed", bytes,
-hash }` (and stderr says the push FAILED) — there is no `agent_revision_proposed` event and
-no `pending_review` record; your edit stays in the working copy, and the next `wait` run
-re-detects the divergence and retries the park. Do not re-create the edit; just re-run.
+hash }` (and stderr says the push FAILED) — `park_failed` means exactly that the **cloud push
+was not confirmed**: no `agent_revision_proposed` event, no `pending_review` record; your edit
+stays in the working copy, and the next `wait` run re-detects the divergence and retries the
+park. Do not re-create the edit; just re-run.
+
+The converse also holds: a CONFIRMED push stays parked even when a piece of local bookkeeping
+failed around it. The event append or the local record write can fail after the push landed —
+stderr says so when it happens — and the next `wait --remote` run reconciles the missing
+artifacts from the cloud's own proposed slot. A temporarily missing event or record therefore
+never means the park failed; only `park_failed` (or the absence of any park signal plus a
+still-diverged working copy) means that.
 
 Two things are **normal and must never be read as data loss**: after a healthy turn the
 working copy is re-synced to the current canonical (so your parked edit is no longer in it —

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -81,9 +81,11 @@ output carries `proposal: { state: "pending_review", bytes, hash }`, an
 
 How to audit "did my edit land?", in order:
 1. **This turn:** the `proposal` field in the wait JSON (`pending_review` = safely parked), or
-   a `document_edited` entry (= applied directly to canonical). The `proposal` field also rides
-   a `wait_failed`, `superseded`, or `moved_local` ending — losing the wait afterwards does not
-   un-park your edit, so check the field (and the record below) before classifying it.
+   a `document_edited` entry (= applied directly to canonical). The `proposal` field rides
+   **every** turn-ending output when a park happened this turn — `your_turn`/`activity`,
+   `closed`, `navigated`, `wait_failed`, `superseded`, and `moved_local` — losing or handing
+   off the wait afterwards does not un-park your edit, so check the field (and the record
+   below) before classifying it.
 2. **Any later turn:** read `<workingCopy>.proposed.json` — the durable record. Its `state`
    becomes `accepted`, `partially_accepted`, or `rejected` once the human decides (or
    `decided` when history is readable but no usable outcome event can be recovered — a

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -81,14 +81,22 @@ output carries `proposal: { state: "pending_review", bytes, hash }`, an
 
 How to audit "did my edit land?", in order:
 1. **This turn:** the `proposal` field in the wait JSON (`pending_review` = safely parked), or
-   a `document_edited` entry (= applied directly to canonical).
+   a `document_edited` entry (= applied directly to canonical). The `proposal` field also rides
+   a `wait_failed`, `superseded`, or `moved_local` ending — losing the wait afterwards does not
+   un-park your edit, so check the field (and the record below) before classifying it.
 2. **Any later turn:** read `<workingCopy>.proposed.json` — the durable record. Its `state`
    becomes `accepted`, `partially_accepted`, or `rejected` once the human decides (or
-   `decided` when the outcome event wasn't readable). The exact text you pushed is kept next
-   to it in `<workingCopy>.proposed.md`, and every finalized record is appended to
+   `decided` when the outcome event wasn't readable, and `superseded` when a newer proposal of
+   yours replaced it — the newest record is the authoritative one). The exact text you pushed
+   is kept next to it in `<workingCopy>.proposed.md`, and every finalized record is appended to
    `<workingCopy>.proposals.jsonl`.
 3. A later wait's `entries` may also carry the decision itself: `revision_accepted_all`,
    `revision_hunk_accepted`, or `revision_rejected_all`.
+
+If the park itself fails (stderr says the proposal push FAILED), there is no
+`agent_revision_proposed` event and no `pending_review` record — your edit stays in the
+working copy, and the next `wait` run re-detects the divergence and retries the park. Do not
+re-create the edit; just re-run.
 
 Two things are **normal and must never be read as data loss**: after a healthy turn the
 working copy is re-synced to the current canonical (so your parked edit is no longer in it —

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -86,8 +86,10 @@ How to audit "did my edit land?", in order:
    un-park your edit, so check the field (and the record below) before classifying it.
 2. **Any later turn:** read `<workingCopy>.proposed.json` — the durable record. Its `state`
    becomes `accepted`, `partially_accepted`, or `rejected` once the human decides (or
-   `decided` when the outcome event wasn't readable, and `superseded` when a newer proposal of
-   yours replaced it — the newest record is the authoritative one). The exact text you pushed
+   `decided` when history is readable but no usable outcome event can be recovered — a
+   transient history-read failure instead leaves the record pending and retries next run), and
+   `superseded` when a newer proposal of yours replaced it — the newest record is the
+   authoritative one. The exact text you pushed
    is kept next to it in `<workingCopy>.proposed.md`, and every finalized record is appended to
    `<workingCopy>.proposals.jsonl`.
 3. A later wait's `entries` may also carry the decision itself: `revision_accepted_all`,

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -67,8 +67,11 @@ re-run the same command and it resumes the same sign-in. If the link itself expi
 
 For a cloud document, `inplan wait --remote <docId>` materializes a **working copy** at
 `~/.inplan/sidecars/remote/<docId>.plan.md` and tells you so on stderr. That working copy is
-**your editing surface** — the one exception to the "never touch the sidecars" rule below.
-Edit it, then re-run the same `wait` command: the run pushes your edit and waits for the human.
+**your editing surface** — the one file under the sidecars you may edit (the CLI puts it there
+*for* you). Edit it, then re-run the same `wait` command: the run pushes your edit and waits
+for the human. The `.proposed.*` records described below are **read-only audit state** — read
+them to answer "did my edit land?", but never rewrite or delete them (they are the durable
+history the CLI maintains).
 
 **Review mode parks your edit — that is success, not failure.** Most cloud docs are in review
 mode: your body edit is NOT applied to the canonical; it is pushed to the cloud as a
@@ -96,9 +99,9 @@ copy or `.synced` looks stale** — check the proposal record first.
 ## File convention
 
 Save plans as `<name>.plan.md`. The `inplan` CLI keeps its own working files under
-`~/.inplan/sidecars/<key>/` — it owns these; never read or edit them by hand. (One exception:
-the `wait --remote` working copy and its `.proposed.*` records, described above — the CLI
-puts them there *for* you.)
+`~/.inplan/sidecars/<key>/` — it owns these; never read or edit them by hand. (Exceptions,
+described above: the `wait --remote` working copy is yours to **edit**, and its `.proposed.*`
+records are yours to **read** for audit — never to modify.)
 
 ## Auto-approval (review happens in the app)
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -100,9 +100,12 @@ How to audit "did my edit land?", in order:
 
 If the park itself fails, the wait JSON carries `proposal: { state: "park_failed", bytes,
 hash }` (and stderr says the push FAILED) — `park_failed` means exactly that the **cloud push
-was not confirmed**: no `agent_revision_proposed` event, no `pending_review` record; your edit
-stays in the working copy, and the next `wait` run re-detects the divergence and retries the
-park. Do not re-create the edit; just re-run.
+was not confirmed**. It does NOT prove the push didn't land: a lost response can leave the
+proposal live in the cloud while the local event and record are missing. Either way the retry
+is safe and automatic — the next `wait` run first reconciles the cloud's proposal slot (a
+landed push is adopted as the pending record, not re-sent), and re-pushing identical content
+is idempotent (same proposal identity, no duplicate). Your edit stays in the working copy;
+do not re-create it — just re-run.
 
 The converse also holds: a CONFIRMED push stays parked even when a piece of local bookkeeping
 failed around it. The event append or the local record write can fail after the push landed —

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -91,9 +91,10 @@ How to audit "did my edit land?", in order:
    `decided` when history is readable but no usable outcome event can be recovered — a
    transient history-read failure instead leaves the record pending and retries next run), and
    `superseded` when a newer proposal of yours replaced it — the newest record is the
-   authoritative one. The exact text you pushed
-   is kept next to it in `<workingCopy>.proposed.md`, and every finalized record is appended to
-   `<workingCopy>.proposals.jsonl`.
+   authoritative one. The exact text you pushed is embedded in the record itself (its `text`
+   field — audit from there); `<workingCopy>.proposed.md` is only a derived, read-convenience
+   copy that can be missing or stale until the next run reconciles it. Every finalized record
+   is appended to `<workingCopy>.proposals.jsonl`.
 3. A later wait's `entries` may also carry the decision itself: `revision_accepted_all`,
    `revision_hunk_accepted`, or `revision_rejected_all`.
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -63,10 +63,42 @@ exits with a timeout message while the session is still valid — that is not a 
 re-run the same command and it resumes the same sign-in. If the link itself expires
 (`expiresInSec`, ~10 minutes), the re-run prints a fresh URL — repeat from 1.
 
+## Cloud documents (wait --remote)
+
+For a cloud document, `inplan wait --remote <docId>` materializes a **working copy** at
+`~/.inplan/sidecars/remote/<docId>.plan.md` and tells you so on stderr. That working copy is
+**your editing surface** — the one exception to the "never touch the sidecars" rule below.
+Edit it, then re-run the same `wait` command: the run pushes your edit and waits for the human.
+
+**Review mode parks your edit — that is success, not failure.** Most cloud docs are in review
+mode: your body edit is NOT applied to the canonical; it is pushed to the cloud as a
+**proposal** for the human to accept or reject in their editor. When that happens the wait
+output carries `proposal: { state: "pending_review", bytes, hash }`, an
+`agent_revision_proposed` entry appears in `entries`, and stderr says the edit was parked.
+
+How to audit "did my edit land?", in order:
+1. **This turn:** the `proposal` field in the wait JSON (`pending_review` = safely parked), or
+   a `document_edited` entry (= applied directly to canonical).
+2. **Any later turn:** read `<workingCopy>.proposed.json` — the durable record. Its `state`
+   becomes `accepted`, `partially_accepted`, or `rejected` once the human decides (or
+   `decided` when the outcome event wasn't readable). The exact text you pushed is kept next
+   to it in `<workingCopy>.proposed.md`, and every finalized record is appended to
+   `<workingCopy>.proposals.jsonl`.
+3. A later wait's `entries` may also carry the decision itself: `revision_accepted_all`,
+   `revision_hunk_accepted`, or `revision_rejected_all`.
+
+Two things are **normal and must never be read as data loss**: after a healthy turn the
+working copy is re-synced to the current canonical (so your parked edit is no longer in it —
+it lives in `.proposed.md` and in the cloud), and `.synced` tracks only canonical syncs (it
+says nothing about proposals). **Never delete or rewrite your local work because the working
+copy or `.synced` looks stale** — check the proposal record first.
+
 ## File convention
 
 Save plans as `<name>.plan.md`. The `inplan` CLI keeps its own working files under
-`~/.inplan/sidecars/<key>/` — it owns these; never read or edit them by hand.
+`~/.inplan/sidecars/<key>/` — it owns these; never read or edit them by hand. (One exception:
+the `wait --remote` working copy and its `.proposed.*` records, described above — the CLI
+puts them there *for* you.)
 
 ## Auto-approval (review happens in the app)
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -97,10 +97,10 @@ How to audit "did my edit land?", in order:
 3. A later wait's `entries` may also carry the decision itself: `revision_accepted_all`,
    `revision_hunk_accepted`, or `revision_rejected_all`.
 
-If the park itself fails (stderr says the proposal push FAILED), there is no
-`agent_revision_proposed` event and no `pending_review` record — your edit stays in the
-working copy, and the next `wait` run re-detects the divergence and retries the park. Do not
-re-create the edit; just re-run.
+If the park itself fails, the wait JSON carries `proposal: { state: "park_failed", bytes,
+hash }` (and stderr says the push FAILED) — there is no `agent_revision_proposed` event and
+no `pending_review` record; your edit stays in the working copy, and the next `wait` run
+re-detects the divergence and retries the park. Do not re-create the edit; just re-run.
 
 Two things are **normal and must never be read as data loss**: after a healthy turn the
 working copy is re-synced to the current canonical (so your parked edit is no longer in it —


### PR DESCRIPTION
Fixes the remaining item of #88 (the "did my edit land?" signal). Design was worked through collaboratively in a planning doc evaluating the option space on code structure, architecture, extensibility, and readability; the decisions: a state-owning module over inline markers, records kept forever, no new CLI query surface yet, and the acceptance-source mismatch split out as #94.

**Problem.** In review mode (the default for every remote doc) an agent's edit parks as a proposal — and the agent had no reliable way to know that's what happened: `agent_revision_proposed` appears in exactly one wait output (the cursor advances past it), `.synced` tracks only canonical syncs, and the end-of-turn re-sync overwrote the working copy with the pre-edit canonical while the proposal was still pending, destroying the only local copy of the pushed text. The 2026-08-11 near-miss (an agent deleting ~48KB of its own parked work) followed exactly that chain.

**Change.**
- **`RemoteDocState`** (new, unit-tested) becomes the single owner of the per-doc remote sidecar files. On disk everything stays a flat sibling of the working copy and `.synced` keeps its byte-identical legacy format, so older CLIs interoperate unchanged. New: a proposal record (`.proposed.json` + the exact pushed text in `.proposed.md`), written **before** the re-sync clobber; on a later run, once the cloud's proposed slot has emptied, the record resolves to `accepted` / `partially_accepted` / `rejected` from the decision events (newest wins; events older than the park are ignored), falling back to `decided`. Finalized records append to a never-pruned `.proposals.jsonl`; re-parking different text finalizes the prior record as `superseded` rather than losing it. `runRemote`'s inline, untested sidecar IO is replaced by module calls.
- **`applyGatedEdit` returns `{ proposed }`**, and `waitCycle` surfaces it: an additive `proposal: { state: "pending_review", bytes, hash }` field on every turn-end output shape, plus a stderr line stating a park is normal, not a sync failure.
- **SKILL.md** gains a `## Cloud documents (wait --remote)` section naming the working copy as the editing surface (resolving its direct contradiction with the "never touch the sidecars" rule), documenting the audit chain (wait field → proposal record → decision events), and the explicit rule: never conclude loss from the working copy or `.synced`.

**Testing.** 21 new `RemoteDocState` tests (the park survives the working-copy overwrite; resolution appends to the history; supersede-on-repark; identical-text re-park doesn't spam history; corrupt record reads as absent; `.synced` byte-identical; hydration decisions unchanged and unaffected by proposal files). `applyGatedEdit`'s return pinned on all four branches, and two `waitCycle` tests for the output field and its absence on a no-change turn. Proven as regression tests by reverting the park signal to pre-fix behavior: 3 fail, restored all pass. Full suite + coverage gate green.

**Follow-up:** #94 (the CLI drops the `acceptance` carried by `mode_changed`, so a machine-global `auto` bypasses a doc set to review) is scheduled immediately after this lands. The cloud repo's integration smoke will be extended to assert the record's presence and hash after a review-mode push once this merges (open-core lands first, then the cloud side).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/96?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added durable proposal handling for remote document workflows.
  * Review-mode edits now show pending-review status, proposal size, and content hash.
  * Added recovery and resynchronization after proposal acceptance, rejection, or supersession.
  * Added protection against replaying failed or interrupted proposal updates.

* **Bug Fixes**
  * Improved remote document consistency across interruptions and resynchronization.
  * Preserved working files when proposal parking fails and clearly reported the failure.

* **Documentation**
  * Updated remote workflow guidance for working-copy editing, proposal review, auditing, and stale-state recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->