### PR TITLE
Core: proposals get first-class identity — the DocumentStore proposal surface

### DIFF
--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -528,8 +528,8 @@ function registerIpc(): void {
     win?.close();
   });
   ipcMain.handle("proposal:get", () => session?.pendingProposal() ?? null);
-  ipcMain.handle("proposal:clear", () => {
-    session?.clearProposal();
+  ipcMain.handle("proposal:clear", (_e, outcome?: "accepted" | "partially_accepted" | "rejected") => {
+    session?.clearProposal(outcome);
   });
   // New-doc actions (Create Doc / Move Text to New Doc): the renderer owns the body edit + the
   // (relative) link; main owns the location picker + the file write, both relative to the current

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -326,7 +326,7 @@ function watchSession(): (() => void) | null {
     onExternalChange: (content) => win?.webContents.send("doc:external-change", { path: s.paths.file, content }),
     onAgentDone: () => win?.webContents.send("agent:done"),
     onAgentActive: () => win?.webContents.send("agent:active"),
-    onProposal: (content) => win?.webContents.send("doc:proposal", { content }),
+    onProposal: (content, id) => win?.webContents.send("doc:proposal", { content, ...(id ? { id } : {}) }),
     onReload: () => win?.webContents.send("agent:reload"),
     onAgentMessage: (text, ts) => win?.webContents.send("agent:message", { text, ts }),
   });
@@ -527,9 +527,9 @@ function registerIpc(): void {
     quitConfirmed = true;
     win?.close();
   });
-  ipcMain.handle("proposal:get", () => session?.pendingProposal() ?? null);
-  ipcMain.handle("proposal:clear", (_e, outcome?: "accepted" | "partially_accepted" | "rejected") => {
-    session?.clearProposal(outcome);
+  ipcMain.handle("proposal:get", async () => (await session?.pendingProposal()) ?? null);
+  ipcMain.handle("proposal:clear", (_e, outcome?: "accepted" | "partially_accepted" | "rejected", id?: string) => {
+    session?.clearProposal(outcome, id);
   });
   // New-doc actions (Create Doc / Move Text to New Doc): the renderer owns the body edit + the
   // (relative) link; main owns the location picker + the file write, both relative to the current

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -528,9 +528,7 @@ function registerIpc(): void {
     win?.close();
   });
   ipcMain.handle("proposal:get", async () => (await session?.pendingProposal()) ?? null);
-  ipcMain.handle("proposal:clear", (_e, outcome?: "accepted" | "partially_accepted" | "rejected", id?: string) => {
-    session?.clearProposal(outcome, id);
-  });
+  ipcMain.handle("proposal:clear", (_e, outcome?: "accepted" | "partially_accepted" | "rejected", id?: string) => session?.clearProposal(outcome, id));
   // New-doc actions (Create Doc / Move Text to New Doc): the renderer owns the body edit + the
   // (relative) link; main owns the location picker + the file write, both relative to the current
   // doc's directory so the embedded link is a normal sibling-relative Markdown link.

--- a/packages/app/src/main/session.ts
+++ b/packages/app/src/main/session.ts
@@ -204,6 +204,9 @@ export class Session {
     if (entries.some((e) => e.type === LogEventType.AgentRevisionProposed)) {
       void this.pendingProposal().then((proposed) => {
         if (proposed != null) handlers.onProposal(proposed.content, proposed.id);
+      }).catch(() => {
+        /* a corrupted, unpreservable rows file fails loudly on the next explicit operation;
+           the passive dispatch must not crash the main process over it */
       });
     }
     // An accepted agent edit: the working file holds the agent's revision (the gate

--- a/packages/app/src/main/session.ts
+++ b/packages/app/src/main/session.ts
@@ -142,6 +142,12 @@ export class Session {
     // (its cleanup can fail independently) must never resurface a decided proposal as an id-less
     // review. The bare-file read only serves genuinely pre-rows sidecars.
     if (store.hasProposalHistory()) return null;
+    if (!existsSync(this.paths.proposedPath)) return null;
+    // A CLI can mint the row between the lookup above and this read — the derived file would then
+    // be a real row's content served WITHOUT its id, and an id-less review resolves whatever is
+    // pending at Apply time. One re-lookup collapses that race to the row (with its identity).
+    const raced = await store.myPendingProposal();
+    if (raced) return { id: raced.id, content: raced.content };
     return existsSync(this.paths.proposedPath) ? { content: readFileSync(this.paths.proposedPath, "utf8") } : null;
   }
 

--- a/packages/app/src/main/session.ts
+++ b/packages/app/src/main/session.ts
@@ -135,23 +135,30 @@ export class Session {
   /** The parked Review-mode proposal, if one is pending. Row-backed (proposals v1) with a
    *  legacy fallback to the derived content file (a pre-rows sidecar). */
   async pendingProposal(): Promise<{ id?: string; content: string } | null> {
-    const mine = await new FsDocumentStore(this.paths).myPendingProposal();
+    const store = new FsDocumentStore(this.paths);
+    const mine = await store.myPendingProposal();
     if (mine) return { id: mine.id, content: mine.content };
+    // Once row-backed state exists, the rows are the ONLY truth: a leftover derived content file
+    // (its cleanup can fail independently) must never resurface a decided proposal as an id-less
+    // review. The bare-file read only serves genuinely pre-rows sidecars.
+    if (store.hasProposalHistory()) return null;
     return existsSync(this.paths.proposedPath) ? { content: readFileSync(this.paths.proposedPath, "utf8") } : null;
   }
 
   /** Settle the parked proposal once the human has decided — the outcome lands on the proposal
    *  row (proposals v1); the derived proposedPath file is cleared by the store. Legacy fallback:
    *  a stray content file with no row is simply removed. */
-  clearProposal(outcome: "accepted" | "partially_accepted" | "rejected" = "accepted", id?: string): void {
+  async clearProposal(outcome: "accepted" | "partially_accepted" | "rejected" = "accepted", id?: string): Promise<void> {
+    // Awaited end-to-end (the IPC handler returns this promise): a failed decision must surface
+    // to the renderer as a failed invoke, not report success and resurface on the next launch —
+    // and an unhandled rejection here would crash the main process.
     const store = new FsDocumentStore(this.paths);
-    void store.myPendingProposal().then(async (mine) => {
-      // Settle the EXACT reviewed proposal when its id is known; deciding a since-superseded row
-      // is a state-guarded no-op — better than landing the outcome on a newer row.
-      const target = id ?? mine?.id;
-      if (target) await store.decideProposal(target, outcome);
-      else if (existsSync(this.paths.proposedPath)) unlinkSync(this.paths.proposedPath);
-    });
+    const mine = await store.myPendingProposal();
+    // Settle the EXACT reviewed proposal when its id is known; deciding a since-superseded row
+    // is a state-guarded no-op — better than landing the outcome on a newer row.
+    const target = id ?? mine?.id;
+    if (target) await store.decideProposal(target, outcome);
+    else if (!store.hasProposalHistory() && existsSync(this.paths.proposedPath)) unlinkSync(this.paths.proposedPath);
   }
 
   /** Record why the session ended (logged at most once) so the agent's `wait` can report it. */

--- a/packages/app/src/main/session.ts
+++ b/packages/app/src/main/session.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { appendLog, CONTROL_LOG_VERSION, FsControlChannel, type LogEntry, LogEventType, readGlobalSettings, readLog, writeGlobalSettings } from "@inplan/core/node";
+import { appendLog, CONTROL_LOG_VERSION, FsControlChannel, FsDocumentStore, type LogEntry, LogEventType, readGlobalSettings, readLog, writeGlobalSettings } from "@inplan/core/node";
 import type { Settings } from "@inplan/renderer";
 import { existsSync, mkdirSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
@@ -137,9 +137,15 @@ export class Session {
     return existsSync(this.paths.proposedPath) ? readFileSync(this.paths.proposedPath, "utf8") : null;
   }
 
-  /** Discard the parked proposal once the human has accepted/rejected it. */
-  clearProposal(): void {
-    if (existsSync(this.paths.proposedPath)) unlinkSync(this.paths.proposedPath);
+  /** Settle the parked proposal once the human has decided — the outcome lands on the proposal
+   *  row (proposals v1); the derived proposedPath file is cleared by the store. Legacy fallback:
+   *  a stray content file with no row is simply removed. */
+  clearProposal(outcome: "accepted" | "partially_accepted" | "rejected" = "accepted"): void {
+    const store = new FsDocumentStore(this.paths);
+    void store.myPendingProposal().then(async (mine) => {
+      if (mine) await store.decideProposal(mine.id, outcome);
+      else if (existsSync(this.paths.proposedPath)) unlinkSync(this.paths.proposedPath);
+    });
   }
 
   /** Record why the session ended (logged at most once) so the agent's `wait` can report it. */

--- a/packages/app/src/main/session.ts
+++ b/packages/app/src/main/session.ts
@@ -149,6 +149,11 @@ export class Session {
    *  row (proposals v1); the derived proposedPath file is cleared by the store. Legacy fallback:
    *  a stray content file with no row is simply removed. */
   async clearProposal(outcome: "accepted" | "partially_accepted" | "rejected" = "accepted", id?: string): Promise<void> {
+    // IPC payloads are runtime data — a malformed outcome would be persisted as an invalid state
+    // and quarantine the rows file on the next read. Validate before touching the store.
+    if (outcome !== "accepted" && outcome !== "partially_accepted" && outcome !== "rejected") {
+      throw new Error(`invalid proposal outcome: ${String(outcome)}`);
+    }
     // Awaited end-to-end (the IPC handler returns this promise): a failed decision must surface
     // to the renderer as a failed invoke, not report success and resurface on the next launch —
     // and an unhandled rejection here would crash the main process.
@@ -211,9 +216,11 @@ export class Session {
     if (entries.some((e) => e.type === LogEventType.AgentRevisionProposed)) {
       void this.pendingProposal().then((proposed) => {
         if (proposed != null) handlers.onProposal(proposed.content, proposed.id);
-      }).catch(() => {
-        /* a corrupted, unpreservable rows file fails loudly on the next explicit operation;
-           the passive dispatch must not crash the main process over it */
+      }).catch((e: unknown) => {
+        // The passive dispatch must not crash the main process, but a swallowed failure here can
+        // also be TRANSIENT (lock contention) and silently drop the review banner — log it so a
+        // missing banner is diagnosable; the failure re-surfaces on the next explicit operation.
+        console.warn("inplan: could not read the pending proposal for review dispatch:", e);
       });
     }
     // An accepted agent edit: the working file holds the agent's revision (the gate

--- a/packages/app/src/main/session.ts
+++ b/packages/app/src/main/session.ts
@@ -132,18 +132,24 @@ export class Session {
     this.pendingContent = content;
   }
 
-  /** The parked Review-mode proposal, if one is pending (the file exists ⇔ undecided). */
-  pendingProposal(): string | null {
-    return existsSync(this.paths.proposedPath) ? readFileSync(this.paths.proposedPath, "utf8") : null;
+  /** The parked Review-mode proposal, if one is pending. Row-backed (proposals v1) with a
+   *  legacy fallback to the derived content file (a pre-rows sidecar). */
+  async pendingProposal(): Promise<{ id?: string; content: string } | null> {
+    const mine = await new FsDocumentStore(this.paths).myPendingProposal();
+    if (mine) return { id: mine.id, content: mine.content };
+    return existsSync(this.paths.proposedPath) ? { content: readFileSync(this.paths.proposedPath, "utf8") } : null;
   }
 
   /** Settle the parked proposal once the human has decided — the outcome lands on the proposal
    *  row (proposals v1); the derived proposedPath file is cleared by the store. Legacy fallback:
    *  a stray content file with no row is simply removed. */
-  clearProposal(outcome: "accepted" | "partially_accepted" | "rejected" = "accepted"): void {
+  clearProposal(outcome: "accepted" | "partially_accepted" | "rejected" = "accepted", id?: string): void {
     const store = new FsDocumentStore(this.paths);
     void store.myPendingProposal().then(async (mine) => {
-      if (mine) await store.decideProposal(mine.id, outcome);
+      // Settle the EXACT reviewed proposal when its id is known; deciding a since-superseded row
+      // is a state-guarded no-op — better than landing the outcome on a newer row.
+      const target = id ?? mine?.id;
+      if (target) await store.decideProposal(target, outcome);
       else if (existsSync(this.paths.proposedPath)) unlinkSync(this.paths.proposedPath);
     });
   }
@@ -196,8 +202,9 @@ export class Session {
       }
     }
     if (entries.some((e) => e.type === LogEventType.AgentRevisionProposed)) {
-      const proposed = this.pendingProposal();
-      if (proposed != null) handlers.onProposal(proposed);
+      void this.pendingProposal().then((proposed) => {
+        if (proposed != null) handlers.onProposal(proposed.content, proposed.id);
+      });
     }
     // An accepted agent edit: the working file holds the agent's revision (the gate
     // set canonical to it). Load it — this replaces the old raw working-file watch.
@@ -220,7 +227,7 @@ export interface WatchHandlers {
   onExternalChange: (content: string) => void;
   onAgentDone: () => void;
   onAgentActive: () => void;
-  onProposal: (content: string) => void;
+  onProposal: (content: string, id?: string) => void;
   onReload: () => void;
   onAgentMessage: (text: string, ts: string) => void;
 }

--- a/packages/app/src/preload/index.ts
+++ b/packages/app/src/preload/index.ts
@@ -128,8 +128,8 @@ const api: Api = {
   },
   closeWindow: () => ipcRenderer.invoke("window:close"),
   getProposal: () => ipcRenderer.invoke("proposal:get"),
-  clearProposal: (outcome?: "accepted" | "partially_accepted" | "rejected") => ipcRenderer.invoke("proposal:clear", outcome),
-  onProposal: (cb: (payload: { content: string }) => void) => {
+  clearProposal: (outcome?: "accepted" | "partially_accepted" | "rejected", id?: string) => ipcRenderer.invoke("proposal:clear", outcome, id),
+  onProposal: (cb: (payload: { content: string; id?: string }) => void) => {
     const h = (_e: unknown, payload: { content: string }): void => cb(payload);
     ipcRenderer.on("doc:proposal", h);
     return () => ipcRenderer.removeListener("doc:proposal", h);

--- a/packages/app/src/preload/index.ts
+++ b/packages/app/src/preload/index.ts
@@ -128,7 +128,7 @@ const api: Api = {
   },
   closeWindow: () => ipcRenderer.invoke("window:close"),
   getProposal: () => ipcRenderer.invoke("proposal:get"),
-  clearProposal: () => ipcRenderer.invoke("proposal:clear"),
+  clearProposal: (outcome?: "accepted" | "partially_accepted" | "rejected") => ipcRenderer.invoke("proposal:clear", outcome),
   onProposal: (cb: (payload: { content: string }) => void) => {
     const h = (_e: unknown, payload: { content: string }): void => cb(payload);
     ipcRenderer.on("doc:proposal", h);

--- a/packages/app/test/session.test.ts
+++ b/packages/app/test/session.test.ts
@@ -53,11 +53,12 @@ describe("Session.dispatchLog", () => {
     expect(h.onAgentMessage).toHaveBeenNthCalledWith(2, "second", "2026-06-01T00:00:00Z");
   });
 
-  it("a parked Review proposal loads proposed.md and is NOT adopted as an external change", () => {
+  it("a parked Review proposal loads proposed.md and is NOT adopted as an external change", async () => {
     writeFileSync(session.paths.proposedPath, "# Plan\n\nPROPOSED rewrite.\n");
     const h = handlers();
     session.dispatchLog([entry("agent", LogEventType.AgentRevisionProposed, { bytes: 22 }), entry("agent", LogEventType.AgentRevised)], h);
-    expect(h.onProposal).toHaveBeenCalledWith("# Plan\n\nPROPOSED rewrite.\n");
+    await new Promise((r) => setTimeout(r, 0)); // pendingProposal is row-backed and async now
+    expect(h.onProposal).toHaveBeenCalledWith("# Plan\n\nPROPOSED rewrite.\n", undefined); // legacy content-file park carries no row id
     expect(h.onExternalChange).not.toHaveBeenCalled(); // baseline never moves → no empty-diff race
     expect(h.onAgentActive).toHaveBeenCalled();
   });

--- a/packages/app/test/session.test.ts
+++ b/packages/app/test/session.test.ts
@@ -58,7 +58,7 @@ describe("Session.dispatchLog", () => {
     const h = handlers();
     session.dispatchLog([entry("agent", LogEventType.AgentRevisionProposed, { bytes: 22 }), entry("agent", LogEventType.AgentRevised)], h);
     await new Promise((r) => setTimeout(r, 0)); // pendingProposal is row-backed and async now
-    expect(h.onProposal).toHaveBeenCalledWith("# Plan\n\nPROPOSED rewrite.\n", undefined); // legacy content-file park carries no row id
+    expect(h.onProposal).toHaveBeenCalledWith("# Plan\n\nPROPOSED rewrite.\n", expect.any(String)); // the legacy park is ADOPTED as a row and gains a real identity
     expect(h.onExternalChange).not.toHaveBeenCalled(); // baseline never moves → no empty-diff race
     expect(h.onAgentActive).toHaveBeenCalled();
   });

--- a/packages/backend-supabase/src/client.ts
+++ b/packages/backend-supabase/src/client.ts
@@ -13,6 +13,9 @@ export interface SupabaseBackend {
 }
 
 export interface SupabaseBackendOptions {
+  /** Who parks proposals through this backend (proposals v1) — REQUIRED, no ambient default:
+   *  "my pending proposal" must mean exactly one proposer. */
+  proposer: import("./supabaseDocumentStore").ProposerIdentity;
   url: string;
   /**
    * Anon key for browser/SPA clients (RLS enforced) or the service-role key for
@@ -35,6 +38,6 @@ export function createSupabaseBackend(opts: SupabaseBackendOptions): SupabaseBac
   return {
     db,
     channel: new SupabaseControlChannel(db, opts.docId, opts.consumerId),
-    store: new SupabaseDocumentStore(db, opts.docId),
+    store: new SupabaseDocumentStore(db, opts.docId, opts.proposer),
   };
 }

--- a/packages/backend-supabase/src/supabaseDocumentStore.ts
+++ b/packages/backend-supabase/src/supabaseDocumentStore.ts
@@ -90,22 +90,32 @@ export class SupabaseDocumentStore implements DocumentStore {
 
   async createProposal(input: ProposalInput): Promise<{ id: string }> {
     const id = input.id ?? mintProposalId();
-    // Supersede the caller's OWN previous pending row when the id differs. Sequential statements
-    // rather than a transaction: the worst interleaving (a decision landing in between) leaves
-    // either a decided row — immutable below — or one extra superseded row, both benign; a
-    // proposer only races itself here (single live waiter per client).
-    await this.db.from("proposals").update({ state: "superseded" }).match({ doc_id: this.docId, state: "pending", ...this.mineFilter() }).neq("id", id);
-    // Converge-if-pending FIRST (a plain upsert would resurrect a decided row back to pending —
-    // terminal states are immutable). Zero rows updated + row exists ⇒ decided while we retried:
-    // the decision wins and the call converges as a no-op on that id.
-    const { data: updated, error: upErr } = await this.db
+    // Look BEFORE any mutation: a stale retry of a DECIDED id must return untouched — running
+    // the supersede first would let it displace the caller's newer live proposal. Terminal
+    // states are immutable; the decision wins every race below.
+    const existing = await this.getProposal(id);
+    if (existing) {
+      if (existing.state !== "pending") return { id };
+      // Converge-if-pending, scoped to the caller's own rows (defense-in-depth beside RLS: the
+      // service-role path bypasses RLS, and an id must never let one proposer rewrite another's
+      // pending content). Zero rows = decided or not ours in the meantime — converge as a no-op.
+      const { error } = await this.db
+        .from("proposals")
+        .update({ content: input.content, base_hash: input.baseHash, base_content: input.baseContent })
+        .match({ doc_id: this.docId, id, state: "pending", ...this.mineFilter() });
+      if (error) throw new Error(`createProposal failed: ${error.message}`);
+      return { id };
+    }
+    // New id: supersede the caller's OWN previous pending row, then insert. Sequential statements
+    // rather than a transaction — a proposer only races itself (single live waiter per client),
+    // and the phase-B partial unique index (one pending per proposer per doc) backstops the rest:
+    // a concurrent insert surfaces as a unique violation, handled as convergence below.
+    const { error: supersedeErr } = await this.db
       .from("proposals")
-      .update({ content: input.content, base_hash: input.baseHash, base_content: input.baseContent })
-      .match({ doc_id: this.docId, id, state: "pending" })
-      .select("id");
-    if (upErr) throw new Error(`createProposal failed: ${upErr.message}`);
-    if ((updated ?? []).length > 0) return { id };
-    if (await this.getProposal(id)) return { id }; // exists but not pending — terminal, immutable
+      .update({ state: "superseded" })
+      .match({ doc_id: this.docId, state: "pending", ...this.mineFilter() })
+      .neq("id", id);
+    if (supersedeErr) throw new Error(`createProposal failed: ${supersedeErr.message}`);
     const { error } = await this.db.from("proposals").insert({
       id,
       doc_id: this.docId,
@@ -117,7 +127,12 @@ export class SupabaseDocumentStore implements DocumentStore {
       base_content: input.baseContent,
       state: "pending",
     });
-    if (error) throw new Error(`createProposal failed: ${error.message}`);
+    if (error) {
+      // Unique violation (the id, or the one-pending-per-proposer index) = another writer of OURS
+      // got there first; the park converges on whatever exists rather than failing.
+      if ((error as { code?: string }).code === "23505" && (await this.getProposal(id))) return { id };
+      throw new Error(`createProposal failed: ${error.message}`);
+    }
     return { id };
   }
 

--- a/packages/backend-supabase/src/supabaseDocumentStore.ts
+++ b/packages/backend-supabase/src/supabaseDocumentStore.ts
@@ -1,10 +1,41 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import type { SupabaseClient } from "@supabase/supabase-js";
-import type { DocumentStore, VersionMeta } from "@inplan/core";
+import type { DocumentStore, ProposalInput, ProposalRow, ProposalState, VersionMeta } from "@inplan/core";
+import { mintProposalId } from "@inplan/core";
 
 /** A `documents` column that holds free text (see db/schema.sql). */
-type DocColumn = "body" | "canonical" | "proposed";
+type DocColumn = "body" | "canonical";
+
+/** Who is parking proposals through this store — identifies "my" rows (proposals v1). */
+export interface ProposerIdentity {
+  kind: "user" | "agent";
+  /** auth.uid() for kind "user" (RLS also enforces it); an agent name for kind "agent". */
+  userId?: string;
+  /** Stable per-machine/client id (persisted by the caller). */
+  clientId: string;
+}
+
+/** The `proposals` table row shape (see the proposals-v1 migration in the cloud repo). */
+interface DbProposalRow {
+  id: string;
+  content: string;
+  base_hash: string;
+  base_content: string;
+  state: ProposalState;
+  created_at: string;
+  decided_at: string | null;
+}
+
+const toRow = (r: DbProposalRow): ProposalRow => ({
+  id: r.id,
+  content: r.content,
+  baseHash: r.base_hash,
+  baseContent: r.base_content,
+  state: r.state,
+  createdAt: r.created_at,
+  ...(r.decided_at ? { decidedAt: r.decided_at } : {}),
+});
 
 /** A `doc_versions` checkpoint's metadata (no body) — for a history list. */
 export interface VersionSummary {
@@ -29,7 +60,17 @@ export class SupabaseDocumentStore implements DocumentStore {
   constructor(
     private readonly db: SupabaseClient,
     private readonly docId: string,
+    /** Defaults suit the web editor (a signed-in user reviewing in the browser). CLI and agent
+     *  callers pass their own identity so "my pending proposal" means theirs. */
+    private readonly proposer: ProposerIdentity = { kind: "user", clientId: "web" },
   ) {}
+
+  /** Filter for the caller's own proposal rows. */
+  private mineFilter() {
+    const f: Record<string, string> = { proposer_kind: this.proposer.kind, client_id: this.proposer.clientId };
+    if (this.proposer.userId !== undefined) f.proposer_user_id = this.proposer.userId;
+    return f;
+  }
 
   async loadDoc(): Promise<string> {
     return (await this.readColumn("body")) ?? "";
@@ -47,16 +88,73 @@ export class SupabaseDocumentStore implements DocumentStore {
     await this.writeColumns({ canonical: content });
   }
 
-  async getProposed(): Promise<string | null> {
-    return this.readColumn("proposed");
+  async createProposal(input: ProposalInput): Promise<{ id: string }> {
+    const id = input.id ?? mintProposalId();
+    // Supersede the caller's OWN previous pending row when the id differs. Sequential statements
+    // rather than a transaction: the worst interleaving (a decision landing in between) leaves
+    // either a decided row — immutable below — or one extra superseded row, both benign; a
+    // proposer only races itself here (single live waiter per client).
+    await this.db.from("proposals").update({ state: "superseded" }).match({ doc_id: this.docId, state: "pending", ...this.mineFilter() }).neq("id", id);
+    // Converge-if-pending FIRST (a plain upsert would resurrect a decided row back to pending —
+    // terminal states are immutable). Zero rows updated + row exists ⇒ decided while we retried:
+    // the decision wins and the call converges as a no-op on that id.
+    const { data: updated, error: upErr } = await this.db
+      .from("proposals")
+      .update({ content: input.content, base_hash: input.baseHash, base_content: input.baseContent })
+      .match({ doc_id: this.docId, id, state: "pending" })
+      .select("id");
+    if (upErr) throw new Error(`createProposal failed: ${upErr.message}`);
+    if ((updated ?? []).length > 0) return { id };
+    if (await this.getProposal(id)) return { id }; // exists but not pending — terminal, immutable
+    const { error } = await this.db.from("proposals").insert({
+      id,
+      doc_id: this.docId,
+      proposer_kind: this.proposer.kind,
+      proposer_user_id: this.proposer.userId ?? null,
+      client_id: this.proposer.clientId,
+      content: input.content,
+      base_hash: input.baseHash,
+      base_content: input.baseContent,
+      state: "pending",
+    });
+    if (error) throw new Error(`createProposal failed: ${error.message}`);
+    return { id };
   }
 
-  async setProposed(content: string): Promise<void> {
-    await this.writeColumns({ proposed: content });
+  async myPendingProposal(): Promise<ProposalRow | null> {
+    const { data, error } = await this.db
+      .from("proposals")
+      .select("id, content, base_hash, base_content, state, created_at, decided_at")
+      .match({ doc_id: this.docId, state: "pending", ...this.mineFilter() })
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if (error) throw new Error(`myPendingProposal failed: ${error.message}`);
+    return data ? toRow(data as DbProposalRow) : null;
   }
 
-  async clearProposed(): Promise<void> {
-    await this.writeColumns({ proposed: null });
+  async getProposal(id: string): Promise<ProposalRow | null> {
+    const { data, error } = await this.db
+      .from("proposals")
+      .select("id, content, base_hash, base_content, state, created_at, decided_at")
+      .match({ doc_id: this.docId, id })
+      .maybeSingle();
+    if (error) throw new Error(`getProposal failed: ${error.message}`);
+    return data ? toRow(data as DbProposalRow) : null;
+  }
+
+  async withdrawProposal(id: string): Promise<void> {
+    // State-guarded: only a pending row moves; a raced decision wins (terminal is immutable).
+    const { error } = await this.db.from("proposals").update({ state: "withdrawn" }).match({ doc_id: this.docId, id, state: "pending", ...this.mineFilter() });
+    if (error) throw new Error(`withdrawProposal failed: ${error.message}`);
+  }
+
+  async decideProposal(id: string, state: "accepted" | "partially_accepted" | "rejected"): Promise<void> {
+    const { error } = await this.db
+      .from("proposals")
+      .update({ state, decided_at: new Date().toISOString() })
+      .match({ doc_id: this.docId, id, state: "pending" });
+    if (error) throw new Error(`decideProposal failed: ${error.message}`);
   }
 
   async backup(content: string, meta?: VersionMeta): Promise<void> {

--- a/packages/backend-supabase/src/supabaseDocumentStore.ts
+++ b/packages/backend-supabase/src/supabaseDocumentStore.ts
@@ -60,9 +60,10 @@ export class SupabaseDocumentStore implements DocumentStore {
   constructor(
     private readonly db: SupabaseClient,
     private readonly docId: string,
-    /** Defaults suit the web editor (a signed-in user reviewing in the browser). CLI and agent
-     *  callers pass their own identity so "my pending proposal" means theirs. */
-    private readonly proposer: ProposerIdentity = { kind: "user", clientId: "web" },
+    /** REQUIRED — no default. "My pending proposal" must mean exactly one proposer: a defaulted
+     *  identity without a userId matched every user-kind row, and on the service-role path (which
+     *  bypasses RLS) that let one caller read, supersede, or withdraw another's pending proposal. */
+    private readonly proposer: ProposerIdentity,
   ) {}
 
   /** Filter for the caller's own proposal rows. */
@@ -89,7 +90,10 @@ export class SupabaseDocumentStore implements DocumentStore {
   }
 
   async createProposal(input: ProposalInput): Promise<{ id: string }> {
-    const id = input.id ?? mintProposalId();
+    // Identical content with no explicit id re-parks the SAME proposal (a retry, not a
+    // successor) — same rule as the memory/fs backends, pinned by the shared contract.
+    const reuse = input.id ? null : await this.myPendingProposal();
+    const id = input.id ?? (reuse && reuse.content === input.content ? reuse.id : mintProposalId());
     // Look BEFORE any mutation: a stale retry of a DECIDED id must return untouched — running
     // the supersede first would let it displace the caller's newer live proposal. Terminal
     // states are immutable; the decision wins every race below.
@@ -128,9 +132,17 @@ export class SupabaseDocumentStore implements DocumentStore {
       state: "pending",
     });
     if (error) {
-      // Unique violation (the id, or the one-pending-per-proposer index) = another writer of OURS
-      // got there first; the park converges on whatever exists rather than failing.
-      if ((error as { code?: string }).code === "23505" && (await this.getProposal(id))) return { id };
+      if ((error as { code?: string }).code === "23505") {
+        // Unique violation = another writer of OURS got there first (the id, or the one-pending-
+        // per-proposer index). CONVERGE PROPERLY: re-run the pending-scoped update so the caller's
+        // content actually lands (returning bare {id} would silently drop it), tolerating a row
+        // that went terminal in the same window — the decision wins.
+        const { error: convergeErr } = await this.db
+          .from("proposals")
+          .update({ content: input.content, base_hash: input.baseHash, base_content: input.baseContent })
+          .match({ doc_id: this.docId, id, state: "pending", ...this.mineFilter() });
+        if (!convergeErr && (await this.getProposal(id))) return { id };
+      }
       throw new Error(`createProposal failed: ${error.message}`);
     }
     return { id };

--- a/packages/backend-supabase/src/supabaseDocumentStore.ts
+++ b/packages/backend-supabase/src/supabaseDocumentStore.ts
@@ -68,6 +68,11 @@ export class SupabaseDocumentStore implements DocumentStore {
 
   /** Filter for the caller's own proposal rows. */
   private mineFilter() {
+    // A user-kind identity without a userId would match every user sharing the client id — and
+    // on the service-role path (no RLS) that is a cross-user write filter. Refuse to build one.
+    if (this.proposer.kind === "user" && this.proposer.userId === undefined) {
+      throw new Error("proposer identity of kind 'user' requires a userId");
+    }
     const f: Record<string, string> = { proposer_kind: this.proposer.kind, client_id: this.proposer.clientId };
     if (this.proposer.userId !== undefined) f.proposer_user_id = this.proposer.userId;
     return f;

--- a/packages/backend-supabase/test/contract.ts
+++ b/packages/backend-supabase/test/contract.ts
@@ -92,13 +92,26 @@ export function runDocumentStoreContract(name: string, makeStore: Make<DocumentS
       expect(await s.getCanonical()).toBe("base");
     });
 
-    it("a proposed revision can be parked, read, and cleared", async () => {
+    it("a proposal can be parked, read back (mine + by id), superseded by a re-park, and decided terminally", async () => {
       const s = await makeStore();
-      expect(await s.getProposed()).toBeNull();
-      await s.setProposed("proposal");
-      expect(await s.getProposed()).toBe("proposal");
-      await s.clearProposed();
-      expect(await s.getProposed()).toBeNull();
+      expect(await s.myPendingProposal()).toBeNull();
+      const a = await s.createProposal({ content: "proposal", baseHash: "h", baseContent: "base" });
+      expect(await s.myPendingProposal()).toMatchObject({ id: a.id, content: "proposal", state: "pending" });
+      // Same id converges (idempotent retry).
+      await s.createProposal({ id: a.id, content: "proposal v2", baseHash: "h2", baseContent: "base" });
+      expect(await s.getProposal(a.id)).toMatchObject({ content: "proposal v2", state: "pending" });
+      // A new id supersedes the caller's own pending row.
+      const b = await s.createProposal({ content: "successor", baseHash: "h2", baseContent: "base" });
+      expect(await s.getProposal(a.id)).toMatchObject({ state: "superseded" });
+      // Deciding is terminal — a later re-park with the same id cannot resurrect it.
+      await s.decideProposal(b.id, "rejected");
+      await s.createProposal({ id: b.id, content: "sneaky", baseHash: "h3", baseContent: "base" });
+      expect(await s.getProposal(b.id)).toMatchObject({ state: "rejected", content: "successor" });
+      expect(await s.myPendingProposal()).toBeNull();
+      // Withdraw retracts a pending row.
+      const c = await s.createProposal({ content: "third", baseHash: "h3", baseContent: "base" });
+      await s.withdrawProposal(c.id);
+      expect(await s.getProposal(c.id)).toMatchObject({ state: "withdrawn" });
     });
 
     it("backup does not disturb the working document", async () => {

--- a/packages/backend-supabase/test/supabase.contract.test.ts
+++ b/packages/backend-supabase/test/supabase.contract.test.ts
@@ -51,7 +51,7 @@ if (env) {
     });
 
     runControlChannelContract("SupabaseControlChannel", async () => new SupabaseControlChannel(db, await freshDocId()));
-    runDocumentStoreContract("SupabaseDocumentStore", async () => new SupabaseDocumentStore(db, await freshDocId()));
+    runDocumentStoreContract("SupabaseDocumentStore", async () => new SupabaseDocumentStore(db, await freshDocId(), { kind: "user", userId: "00000000-0000-4000-8000-000000000001", clientId: "live-contract" }));
   });
 } else {
   describe.skip("live Supabase backend (set SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY to run)", () => {

--- a/packages/backend-supabase/test/supabaseFake.contract.test.ts
+++ b/packages/backend-supabase/test/supabaseFake.contract.test.ts
@@ -109,14 +109,14 @@ runControlChannelContract("Supabase (fake client)", () => new SupabaseControlCha
 runDocumentStoreContract("Supabase (fake client)", () => {
   const f = makeFakeSupabase();
   f.seedDoc("doc-1");
-  return new SupabaseDocumentStore(f.db, "doc-1");
+  return new SupabaseDocumentStore(f.db, "doc-1", { kind: "user", userId: "user-1", clientId: "test-client" });
 });
 
 describe("SupabaseDocumentStore version history", () => {
   it("backup dedups a no-op snapshot (same body as the latest) and records provenance", async () => {
     const f = makeFakeSupabase();
     f.seedDoc("d1");
-    const s = new SupabaseDocumentStore(f.db, "d1");
+    const s = new SupabaseDocumentStore(f.db, "d1", { kind: "user", userId: "user-1", clientId: "test-client" });
     await s.backup("v1", { actor: "agent", kind: "turn", author: "Opus 4.8" });
     await s.backup("v1"); // same body → skipped
     await s.backup("v2");
@@ -132,7 +132,7 @@ describe("SupabaseDocumentStore version history", () => {
       { id: 4, doc_id: "d1", body: "b2", created_at: "2026-01-02", actor: "user", kind: "manual", author: "me" }, // same created_at as id 2
       { id: 3, doc_id: "d2", body: "c", created_at: "2026-01-03", actor: "user", kind: "manual", author: "x" },
     );
-    const s = new SupabaseDocumentStore(f.db, "d1");
+    const s = new SupabaseDocumentStore(f.db, "d1", { kind: "user", userId: "user-1", clientId: "test-client" });
     expect((await s.listVersions(10)).map((v) => v.id)).toEqual([4, 2, 1]); // d1 only; created_at desc, then id desc
     expect((await s.listVersions(1)).map((v) => v.id)).toEqual([4]); // limit honored
   });
@@ -140,7 +140,7 @@ describe("SupabaseDocumentStore version history", () => {
   it("getVersion returns a version's body scoped to the doc; null when absent or another doc's", async () => {
     const f = makeFakeSupabase();
     f.tables.doc_versions.push({ id: 7, doc_id: "d1", body: "hello" }, { id: 8, doc_id: "other", body: "nope" });
-    const s = new SupabaseDocumentStore(f.db, "d1");
+    const s = new SupabaseDocumentStore(f.db, "d1", { kind: "user", userId: "user-1", clientId: "test-client" });
     expect(await s.getVersion(7)).toBe("hello");
     expect(await s.getVersion(8)).toBeNull(); // belongs to another doc
     expect(await s.getVersion(999)).toBeNull();
@@ -197,7 +197,7 @@ describe("SupabaseControlChannel error + presence paths", () => {
 });
 
 describe("SupabaseDocumentStore error paths", () => {
-  const store = () => new SupabaseDocumentStore(erroringDb(), "d");
+  const store = () => new SupabaseDocumentStore(erroringDb(), "d", { kind: "user", userId: "user-1", clientId: "test-client" });
   it("surfaces a Postgres error from reads, writes, and backup", async () => {
     await expect(store().loadDoc()).rejects.toThrow(/read body failed: boom/);
     await expect(store().getCanonical()).rejects.toThrow(/read canonical failed: boom/);

--- a/packages/backend-supabase/test/supabaseFake.contract.test.ts
+++ b/packages/backend-supabase/test/supabaseFake.contract.test.ts
@@ -211,7 +211,7 @@ describe("createSupabaseBackend", () => {
   it("wires a channel + store onto a created client", async () => {
     const { createSupabaseBackend } = await import("../src/client");
     const { createClient } = await import("@supabase/supabase-js");
-    const backend = createSupabaseBackend({ url: "https://x.supabase.co", key: "anon", docId: "doc-9", consumerId: "editor" });
+    const backend = createSupabaseBackend({ url: "https://x.supabase.co", key: "anon", docId: "doc-9", consumerId: "editor", proposer: { kind: "user", userId: "user-9", clientId: "test" } });
     expect(createClient).toHaveBeenCalledWith("https://x.supabase.co", "anon");
     expect(backend.channel).toBeInstanceOf(SupabaseControlChannel);
     expect(backend.store).toBeInstanceOf(SupabaseDocumentStore);

--- a/packages/backend-supabase/test/supabaseFake.contract.test.ts
+++ b/packages/backend-supabase/test/supabaseFake.contract.test.ts
@@ -19,7 +19,7 @@ type Row = Record<string, unknown>;
  *  adapters use: from().insert/upsert/update/select + eq/gt/order/single/maybeSingle,
  *  and channel().on().subscribe() / removeChannel() with INSERT notifications. */
 function makeFakeSupabase() {
-  const tables: Record<string, Row[]> = { events: [], cursors: [], locks: [], editor_presence: [], documents: [], doc_versions: [] };
+  const tables: Record<string, Row[]> = { events: [], cursors: [], locks: [], editor_presence: [], documents: [], doc_versions: [], proposals: [] };
   let seq = 0;
   const channels: Array<{ table: string | null; cb: (() => void) | null; subscribed: boolean }> = [];
 
@@ -30,6 +30,7 @@ function makeFakeSupabase() {
     private onConflict?: string;
     private wantSelect = false;
     private eqs: Array<[string, unknown]> = [];
+    private neqs: Array<[string, unknown]> = [];
     private gts: Array<[string, unknown]> = [];
     private ords: Array<{ col: string; asc: boolean }> = [];
     private lim?: number;
@@ -39,14 +40,16 @@ function makeFakeSupabase() {
     update(patch: Row) { this.op = "update"; this.patch = patch; return this; }
     select(_cols?: string) { this.wantSelect = true; return this; }
     eq(col: string, val: unknown) { this.eqs.push([col, val]); return this; }
+    match(filters: Row) { for (const [c, v] of Object.entries(filters)) this.eqs.push([c, v]); return this; }
+    neq(col: string, val: unknown) { this.neqs.push([col, val]); return this; }
     gt(col: string, val: unknown) { this.gts.push([col, val]); return this; }
     order(col: string, opts?: { ascending?: boolean }) { this.ords.push({ col, asc: opts?.ascending !== false }); return this; }
     limit(n: number) { this.lim = n; return this; }
     single() { const r = this.exec(); return Promise.resolve(r.error ? r : { data: (r.data as Row[])?.[0] ?? null, error: null }); }
     maybeSingle() { const r = this.exec(); return Promise.resolve({ data: (r.data as Row[])?.[0] ?? null, error: r.error }); }
     then<T>(resolve: (v: { data: unknown; error: unknown }) => T) { return Promise.resolve(this.exec()).then(resolve); }
-    private match(row: Row) {
-      return this.eqs.every(([c, v]) => row[c] === v) && this.gts.every(([c, v]) => (row[c] as number) > (v as number));
+    private rowMatches(row: Row) {
+      return this.eqs.every(([c, v]) => row[c] === v) && this.neqs.every(([c, v]) => row[c] !== v) && this.gts.every(([c, v]) => (row[c] as number) > (v as number));
     }
     private exec(): { data: unknown; error: unknown } {
       const t = tables[this.table]!;
@@ -54,6 +57,7 @@ function makeFakeSupabase() {
         const rows = (Array.isArray(this.payload) ? this.payload : [this.payload]).map((r) => {
           const row: Row = { ...r };
           if (this.table === "events") { row.seq = ++seq; row.ts = new Date().toISOString(); }
+          if (this.table === "proposals" && row.created_at === undefined) row.created_at = new Date().toISOString();
           return row;
         });
         t.push(...rows);
@@ -68,10 +72,11 @@ function makeFakeSupabase() {
         return { data: null, error: null };
       }
       if (this.op === "update") {
-        for (const row of t) if (this.match(row)) Object.assign(row, this.patch);
-        return { data: null, error: null };
+        const hit: Row[] = [];
+        for (const row of t) if (this.rowMatches(row)) { Object.assign(row, this.patch); hit.push(row); }
+        return { data: this.wantSelect ? hit : null, error: null };
       }
-      let rows = t.filter((r) => this.match(r));
+      let rows = t.filter((r) => this.rowMatches(r));
       if (this.ords.length) {
         // multi-column sort (priority order); generic compare so created_at (ISO strings) and
         // numeric ids/seq both order correctly.

--- a/packages/cli/src/applyEdit.ts
+++ b/packages/cli/src/applyEdit.ts
@@ -36,7 +36,7 @@ export async function applyGatedEdit(
     else {
       await store.saveDoc(ev.acceptedText);
       await store.setCanonical(ev.acceptedText);
-      await store.clearProposed();
+      await withdrawOwnPending(store);
     }
     await channel.append({ actor: "agent", type: LogEventType.DocumentEdited, payload: { removed: ev.removedIds } });
   } else if (ev.changed && quarantine) {
@@ -44,15 +44,16 @@ export async function applyGatedEdit(
     // sidecar is file-based either way; on the file path also revert the working file to canonical
     // (the human's accept later writes canonical). On the plugin path the plugin owns the working
     // doc, so there's no .md to revert.
+    let proposalId: string;
     try {
-      await store.setProposed(current);
+      ({ id: proposalId } = await store.createProposal({ content: current, baseHash: hashBody(canonicalText), baseContent: canonicalText }));
     } catch {
       // The push failed, so nothing is proposed anywhere: keep the working copy as the ONLY copy
       // (skipping the revert below — reverting would destroy the edit silently), log no event,
       // and let the caller report the degradation. The next run re-detects the divergence and
       // retries the park idempotently.
       //
-      // CONTRACT for composite stores: a `setProposed` rejection must mean NOTHING was committed.
+      // CONTRACT for composite stores: a `createProposal` rejection must mean NOTHING was committed.
       // A store that pushes remotely and then persists locally (runRemote's gateStore) must
       // contain its post-commit failures itself — the cloud proposal is live and the human can
       // see it, so surfacing that partial failure here would misreport a real park as a failed
@@ -78,7 +79,7 @@ export async function applyGatedEdit(
         type: LogEventType.AgentRevisionProposed,
         // The hash identifies WHICH proposal this event parked, so a later resolution can bind
         // decision events to this exact proposal (not merely the doc's latest park).
-        payload: { bytes: utf8Bytes(current), hash: hashBody(current) },
+        payload: { bytes: utf8Bytes(current), hash: hashBody(current), proposal_id: proposalId },
       });
     } catch {
       // The park stands without its event; resolution falls back to its lesser anchors, which is
@@ -94,9 +95,15 @@ export async function applyGatedEdit(
     if (gate) await gate.applyRevision(current);
     else {
       await store.setCanonical(current);
-      await store.clearProposed();
+      await withdrawOwnPending(store);
     }
     await channel.append({ actor: "agent", type: LogEventType.DocumentEdited, payload: { bytes: utf8Bytes(current) } });
   }
   return { proposed: false };
+}
+
+/** An edit that lands directly moots the caller's own parked proposal, if any — retract it. */
+async function withdrawOwnPending(store: DocumentStore): Promise<void> {
+  const mine = await store.myPendingProposal();
+  if (mine) await store.withdrawProposal(mine.id);
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1300,14 +1300,23 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
       getProposal: (id) => live.store.getProposal(id),
       // Cloud-side lifecycle transitions settle the LOCAL record too, or it would stay
       // pending_review while its cloud row is terminal — and the id-reuse on the next park
-      // would then converge against an immutable row and the content would never land.
+      // would then converge against an immutable row and the content would never land. The
+      // local record mirrors the row's ACTUAL terminal state, not the intended one: our
+      // transition is state-guarded and can lose a race (zero rows updated, no error) to a
+      // human decision that landed first — the decision wins, locally too.
       withdrawProposal: async (id) => {
         await live.store.withdrawProposal(id);
-        if (rds.pendingProposal()?.id === id) rds.resolveProposal("withdrawn");
+        if (rds.pendingProposal()?.id === id) {
+          const row = await live.store.getProposal(id).catch(() => null);
+          rds.resolveProposal(row && row.state !== "pending" ? row.state : "withdrawn");
+        }
       },
       decideProposal: async (id, st) => {
         await live.store.decideProposal(id, st);
-        if (rds.pendingProposal()?.id === id) rds.resolveProposal(st);
+        if (rds.pendingProposal()?.id === id) {
+          const row = await live.store.getProposal(id).catch(() => null);
+          rds.resolveProposal(row && row.state !== "pending" ? row.state : st);
+        }
       },
       createProposal: async (input) => {
         // Re-parking identical content reuses the LOCAL record's id, so a retry after a lost
@@ -1320,6 +1329,17 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
         let created: { id: string };
         try {
           created = await live.store.createProposal({ ...input, ...(id ? { id } : {}) });
+          // A reused id can be TERMINAL in the cloud (the human decided mid-session; the local
+          // record only settles at attach or via our own transitions). createProposal returns a
+          // terminal id untouched — verify the park actually landed pending, and if not, settle
+          // the local record from the cloud's terminal state and re-park under a fresh identity.
+          if (id) {
+            const row = await live.store.getProposal(created.id).catch(() => null);
+            if (row && row.state !== "pending") {
+              if (rds.pendingProposal()?.id === created.id) rds.resolveProposal(row.state);
+              created = await live.store.createProposal(input); // fresh id — a genuine successor
+            }
+          }
         } catch (e) {
           hubParkFailed = true;
           throw e;

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1306,16 +1306,19 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
       // human decision that landed first — the decision wins, locally too.
       withdrawProposal: async (id) => {
         await live.store.withdrawProposal(id);
+        // The local record settles ONLY from a read-back non-pending row: a transient or missing
+        // read must not stamp the requested outcome over a decision that won the state-guarded
+        // race. Left pending, the next attach reconciles from the cloud's truth.
         if (rds.pendingProposal()?.id === id) {
           const row = await live.store.getProposal(id).catch(() => null);
-          rds.resolveProposal(row && row.state !== "pending" ? row.state : "withdrawn");
+          if (row && row.state !== "pending") rds.resolveProposal(row.state);
         }
       },
       decideProposal: async (id, st) => {
         await live.store.decideProposal(id, st);
         if (rds.pendingProposal()?.id === id) {
           const row = await live.store.getProposal(id).catch(() => null);
-          rds.resolveProposal(row && row.state !== "pending" ? row.state : st);
+          if (row && row.state !== "pending") rds.resolveProposal(row.state);
         }
       },
       createProposal: async (input) => {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1337,7 +1337,10 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
             const row = await live.store.getProposal(created.id).catch(() => null);
             if (row && row.state !== "pending") {
               if (rds.pendingProposal()?.id === created.id) rds.resolveProposal(row.state);
-              created = await live.store.createProposal(input); // fresh id — a genuine successor
+              // Fresh id — a genuine successor. Strip any caller-supplied id: passing input
+              // unchanged would reuse the very terminal id we just detected, returning it
+              // untouched again and never landing the content.
+              created = await live.store.createProposal({ content: input.content, baseHash: input.baseHash, baseContent: input.baseContent });
             }
           }
         } catch (e) {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1333,8 +1333,10 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
           // record only settles at attach or via our own transitions). createProposal returns a
           // terminal id untouched — verify the park actually landed pending, and if not, settle
           // the local record from the cloud's terminal state and re-park under a fresh identity.
+          // The verification lookup is NOT allowed to fail silently: an unknown state must report
+          // an unconfirmed park (park_failed means exactly that), never a claimed pending_review.
           if (id) {
-            const row = await live.store.getProposal(created.id).catch(() => null);
+            const row = await live.store.getProposal(created.id);
             if (row && row.state !== "pending") {
               if (rds.pendingProposal()?.id === created.id) rds.resolveProposal(row.state);
               // Fresh id — a genuine successor. Strip any caller-supplied id: passing input
@@ -1342,6 +1344,14 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
               // untouched again and never landing the content.
               created = await live.store.createProposal({ content: input.content, baseHash: input.baseHash, baseContent: input.baseContent });
             }
+          }
+          // A DIFFERENT id displaces the prior local pending record — but the cloud may have
+          // DECIDED that prior mid-session (our supersede is state-guarded and skips terminal
+          // rows). Mirror the cloud's actual state before the local park would mark it
+          // superseded; the decision wins, locally too. Lookup failures degrade the park.
+          if (prior && prior.id !== created.id) {
+            const priorRow = await live.store.getProposal(prior.id);
+            if (priorRow && priorRow.state !== "pending" && priorRow.state !== "superseded") rds.resolveProposal(priorRow.state);
           }
         } catch (e) {
           hubParkFailed = true;

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1298,8 +1298,17 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
       backup: (c, m) => localStore.backup(c, m),
       myPendingProposal: () => live.store.myPendingProposal(),
       getProposal: (id) => live.store.getProposal(id),
-      withdrawProposal: (id) => live.store.withdrawProposal(id),
-      decideProposal: (id, st) => live.store.decideProposal(id, st),
+      // Cloud-side lifecycle transitions settle the LOCAL record too, or it would stay
+      // pending_review while its cloud row is terminal — and the id-reuse on the next park
+      // would then converge against an immutable row and the content would never land.
+      withdrawProposal: async (id) => {
+        await live.store.withdrawProposal(id);
+        if (rds.pendingProposal()?.id === id) rds.resolveProposal("withdrawn");
+      },
+      decideProposal: async (id, st) => {
+        await live.store.decideProposal(id, st);
+        if (rds.pendingProposal()?.id === id) rds.resolveProposal(st);
+      },
       createProposal: async (input) => {
         // Re-parking identical content reuses the LOCAL record's id, so a retry after a lost
         // response converges on the same row (client-generated-id idempotency). Only a failed

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1348,17 +1348,23 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
               created = await live.store.createProposal({ content: input.content, baseHash: input.baseHash, baseContent: input.baseContent });
             }
           }
-          // A DIFFERENT id displaces the prior local pending record — but the cloud may have
-          // DECIDED that prior mid-session (our supersede is state-guarded and skips terminal
-          // rows). Mirror the cloud's actual state before the local park would mark it
-          // superseded; the decision wins, locally too. Lookup failures degrade the park.
+        } catch (e) {
+          hubParkFailed = true;
+          throw e;
+        }
+        // A DIFFERENT id displaces the prior local pending record — but the cloud may have
+        // DECIDED that prior mid-session (our supersede is state-guarded and skips terminal
+        // rows). Mirror the cloud's actual state before the local park would mark it superseded;
+        // the decision wins, locally too. This reconciliation is OUTSIDE the park's failure
+        // envelope: the park is confirmed by now, and a transient lookup here must not
+        // masquerade as park_failed — on failure the next attach settles it from the cloud.
+        try {
           if (prior && prior.id !== created.id) {
             const priorRow = await live.store.getProposal(prior.id);
             if (priorRow && priorRow.state !== "pending" && priorRow.state !== "superseded") rds.resolveProposal(priorRow.state);
           }
-        } catch (e) {
-          hubParkFailed = true;
-          throw e;
+        } catch {
+          /* deferred to next-attach reconciliation */
         }
         try {
           rds.parkProposal(input.content, undefined, created.id);

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1239,7 +1239,7 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
               rds.recordSynced(canonical);
             }
           }
-          rds.parkProposal(slot);
+          rds.parkProposal(slot, undefined, slotRow!.id); // keep the CLOUD row's identity — a fresh local id would split them
         }
       } catch (e) {
         // Local persistence trouble must not stop the attach: the cloud proposal stays live and

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1203,7 +1203,8 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
     // an identical working copy is a deliberate re-edit (an agent may legitimately re-propose
     // byte-identical content after a rejection), and overwriting it would destroy real work.
     let justFinalized = false;
-    const slot = await live.store.getProposed().catch(() => undefined);
+    const slotRow = await live.store.myPendingProposal().catch(() => undefined);
+    const slot = slotRow === undefined ? undefined : (slotRow?.content ?? null);
     if (typeof slot === "string" && needsReparkFromSlot(rds.latestProposal(), slot)) {
       try {
         // A pending record the slot no longer matches was DISPLACED while we were away — but not
@@ -1295,26 +1296,32 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
       getCanonical: () => localStore.getCanonical(),
       setCanonical: (c) => localStore.setCanonical(c),
       backup: (c, m) => localStore.backup(c, m),
-      getProposed: () => live.store.getProposed(),
-      setProposed: async (c) => {
-        // Only a failed PUSH is a failed park (the edit's sole copy stays local; the post-turn
-        // path must keep-local). A failed local record write after a confirmed push is NOT — the
-        // proposal is live in the cloud, the human can already see it, and the record is
-        // reconciled from the slot at the next attach; masquerading it as a failed push would
-        // deny a park that actually happened.
+      myPendingProposal: () => live.store.myPendingProposal(),
+      getProposal: (id) => live.store.getProposal(id),
+      withdrawProposal: (id) => live.store.withdrawProposal(id),
+      decideProposal: (id, st) => live.store.decideProposal(id, st),
+      createProposal: async (input) => {
+        // Re-parking identical content reuses the LOCAL record's id, so a retry after a lost
+        // response converges on the same row (client-generated-id idempotency). Only a failed
+        // PUSH is a failed park (the edit's sole copy stays local; the post-turn path must
+        // keep-local). A failed local record write after a confirmed push is NOT — the proposal
+        // is live in the cloud, and the record is reconciled from it at the next attach.
+        const prior = rds.pendingProposal();
+        const id = input.id ?? (prior && prior.hash === hashBody(input.content) ? prior.id : undefined);
+        let created: { id: string };
         try {
-          await live.store.setProposed(c);
+          created = await live.store.createProposal({ ...input, ...(id ? { id } : {}) });
         } catch (e) {
           hubParkFailed = true;
           throw e;
         }
         try {
-          rds.parkProposal(c);
+          rds.parkProposal(input.content, undefined, created.id);
         } catch (e) {
           process.stderr.write(`inplan: could not write the local proposal record (${String(e)}); the proposal is live in the cloud and the record will be reconciled on the next run\n`);
         }
+        return created;
       },
-      clearProposed: () => live.store.clearProposed(),
     };
     // Save-local handoff on the gate path reads the HUB canonical (the source of truth here);
     // live.store isn't updated by gate.applyRevision, so reading it would write a stale doc. If

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1340,7 +1340,10 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
           // an unconfirmed park (park_failed means exactly that), never a claimed pending_review.
           if (id) {
             const row = await live.store.getProposal(created.id);
-            if (row && row.state !== "pending") {
+            // A row we cannot read back is an UNVERIFIED identity — publishing a local pending
+            // record under it would claim a landing nothing confirms. Unconfirmed = park_failed.
+            if (!row) throw new Error(`park verification found no row for reused id ${created.id}`);
+            if (row.state !== "pending") {
               if (rds.pendingProposal()?.id === created.id) rds.resolveProposal(row.state);
               // Fresh id — a genuine successor. Strip any caller-supplied id: passing input
               // unchanged would reuse the very terminal id we just detected, returning it

--- a/packages/cli/src/cliAuth.ts
+++ b/packages/cli/src/cliAuth.ts
@@ -327,22 +327,33 @@ export interface RemoteBackend {
 /** Stable per-machine proposer client id (proposals v1): minted once, kept beside the sidecars
  *  (INPLAN_HOME-aware, so tests stay isolated). Losing it merely orphans a pending row — which
  *  stays reviewable — and the next park mints a new row. */
+let cachedClientId: string | null = null;
 function machineClientId(): string {
+  // Process-lifetime cache: liveRemoteBackend re-mints the backend after token refreshes, and a
+  // changing identity mid-process would orphan the pending row it just parked.
+  if (cachedClientId) return cachedClientId;
   const p = join(dirname(sidecarRoot()), "proposer-client-id");
   try {
     const v = readFileSync(p, "utf8").trim();
-    if (v) return v;
+    if (v) return (cachedClientId = v);
   } catch {
     /* mint below */
   }
   const v = mintProposalId();
   try {
     mkdirSync(dirname(p), { recursive: true });
-    writeFileSync(p, v);
+    // Exclusive create: two processes racing the first mint must converge on ONE identity —
+    // last-writer-wins would leave the loser's future rows invisible to its own lookups.
+    writeFileSync(p, v, { flag: "wx" });
   } catch {
-    /* unwritable home: an ephemeral id still works for this process */
+    try {
+      const w = readFileSync(p, "utf8").trim();
+      if (w) return (cachedClientId = w); // the race winner's id
+    } catch {
+      /* unwritable home: an ephemeral id still works for this process (cached above) */
+    }
   }
-  return v;
+  return (cachedClientId = v);
 }
 
 /**

--- a/packages/cli/src/cliAuth.ts
+++ b/packages/cli/src/cliAuth.ts
@@ -12,7 +12,9 @@ import { dirname, join } from "node:path";
 import { createClient, type Session, type SupabaseClient } from "@supabase/supabase-js";
 import WebSocket from "ws";
 import type { ControlChannel, DocumentStore } from "@inplan/core";
+import { mintProposalId } from "@inplan/core";
 import { SupabaseControlChannel, SupabaseDocumentStore } from "@inplan/backend-supabase";
+import { sidecarRoot } from "./paths";
 
 // supabase-js builds a RealtimeClient eagerly in createClient, which throws on a
 // Node without a global WebSocket (e.g. Electron's bundled Node 20, used when the
@@ -322,6 +324,27 @@ export interface RemoteBackend {
   token: string;
 }
 
+/** Stable per-machine proposer client id (proposals v1): minted once, kept beside the sidecars
+ *  (INPLAN_HOME-aware, so tests stay isolated). Losing it merely orphans a pending row — which
+ *  stays reviewable — and the next park mints a new row. */
+function machineClientId(): string {
+  const p = join(dirname(sidecarRoot()), "proposer-client-id");
+  try {
+    const v = readFileSync(p, "utf8").trim();
+    if (v) return v;
+  } catch {
+    /* mint below */
+  }
+  const v = mintProposalId();
+  try {
+    mkdirSync(dirname(p), { recursive: true });
+    writeFileSync(p, v);
+  } catch {
+    /* unwritable home: an ephemeral id still works for this process */
+  }
+  return v;
+}
+
 /**
  * Bind an authenticated client to one cloud document. Returns null when not
  * logged in (the caller prints "run `inplan login`").
@@ -332,7 +355,9 @@ export async function remoteBackend(docId: string, consumerId = "cli-agent", ske
   return {
     db: s.db,
     channel: new SupabaseControlChannel(s.db, docId, consumerId),
-    store: new SupabaseDocumentStore(s.db, docId),
+    // The CLI proposes as the signed-in USER on this MACHINE: RLS scopes user-kind rows, and the
+    // stable client id keeps two of the same human's machines from superseding each other.
+    store: new SupabaseDocumentStore(s.db, docId, { kind: "user", userId: s.session.user.id, clientId: machineClientId() }),
     token: s.session.access_token,
   };
 }

--- a/packages/cli/src/cliAuth.ts
+++ b/packages/cli/src/cliAuth.ts
@@ -6,7 +6,7 @@
 // must belong to the document's org). The service-role key is NEVER used here:
 // the local CLI runs as the human, the same as the browser SPA.
 
-import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, linkSync, mkdirSync, readFileSync, renameSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { createClient, type Session, type SupabaseClient } from "@supabase/supabase-js";
@@ -342,13 +342,21 @@ function machineClientId(): string {
   const v = mintProposalId();
   try {
     mkdirSync(dirname(p), { recursive: true });
-    // Exclusive create: two processes racing the first mint must converge on ONE identity —
-    // last-writer-wins would leave the loser's future rows invisible to its own lookups.
-    writeFileSync(p, v, { flag: "wx" });
+    // Exclusive AND fully-written install: two processes racing the first mint must converge on
+    // ONE identity, and a reader must never observe a half-written marker. The content lands in a
+    // private temp file first; linkSync is the atomic-exclusive publish (EEXIST when the race was
+    // lost) — the marker only ever appears with its full content.
+    const tmp = `${p}.tmp-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
+    writeFileSync(tmp, v);
+    try {
+      linkSync(tmp, p);
+    } finally {
+      rmSync(tmp, { force: true });
+    }
   } catch {
     try {
       const w = readFileSync(p, "utf8").trim();
-      if (w) return (cachedClientId = w); // the race winner's id
+      if (w) return (cachedClientId = w); // the race winner's id (always complete — see above)
     } catch {
       /* unwritable home: an ephemeral id still works for this process (cached above) */
     }

--- a/packages/cli/src/cliAuth.ts
+++ b/packages/cli/src/cliAuth.ts
@@ -335,7 +335,7 @@ function machineClientId(): string {
   // Anchored to the stable INPLAN_HOME root, NOT sidecarRoot(): the sidecar dir has its own
   // documented override, and a proposer identity that moves with it would strand the previous
   // pending cloud row (invisible to its own lookups → duplicate pending rows on retry).
-  const home = process.env.INPLAN_HOME ?? join(homedir(), ".inplan");
+  const home = process.env.INPLAN_HOME || join(homedir(), ".inplan"); // `||`: an EMPTY env var must not anchor the identity to the cwd
   const p = join(home, "proposer-client-id");
   try {
     const v = readFileSync(p, "utf8").trim();

--- a/packages/cli/src/cliAuth.ts
+++ b/packages/cli/src/cliAuth.ts
@@ -332,7 +332,11 @@ function machineClientId(): string {
   // Process-lifetime cache: liveRemoteBackend re-mints the backend after token refreshes, and a
   // changing identity mid-process would orphan the pending row it just parked.
   if (cachedClientId) return cachedClientId;
-  const p = join(dirname(sidecarRoot()), "proposer-client-id");
+  // Anchored to the stable INPLAN_HOME root, NOT sidecarRoot(): the sidecar dir has its own
+  // documented override, and a proposer identity that moves with it would strand the previous
+  // pending cloud row (invisible to its own lookups → duplicate pending rows on retry).
+  const home = process.env.INPLAN_HOME ?? join(homedir(), ".inplan");
+  const p = join(home, "proposer-client-id");
   try {
     const v = readFileSync(p, "utf8").trim();
     if (v) return (cachedClientId = v);

--- a/packages/cli/src/cliAuth.ts
+++ b/packages/cli/src/cliAuth.ts
@@ -433,9 +433,11 @@ export function liveRemoteBackend(docId: string, consumerId = "cli-agent"): Live
     saveDoc: async (c) => (await need()).store.saveDoc(c),
     getCanonical: async () => (await need()).store.getCanonical(),
     setCanonical: async (c) => (await need()).store.setCanonical(c),
-    getProposed: async () => (await need()).store.getProposed(),
-    setProposed: async (c) => (await need()).store.setProposed(c),
-    clearProposed: async () => (await need()).store.clearProposed(),
+    createProposal: async (i) => (await need()).store.createProposal(i),
+    myPendingProposal: async () => (await need()).store.myPendingProposal(),
+    getProposal: async (id) => (await need()).store.getProposal(id),
+    withdrawProposal: async (id) => (await need()).store.withdrawProposal(id),
+    decideProposal: async (id, st) => (await need()).store.decideProposal(id, st),
     backup: async (c, m) => (await need()).store.backup(c, m),
   };
   return { channel, store, tokenNow: () => inner?.token ?? null };

--- a/packages/cli/src/remoteDocState.ts
+++ b/packages/cli/src/remoteDocState.ts
@@ -218,10 +218,10 @@ export class RemoteDocState {
    * so no record is ever silently lost; re-parking identical content keeps the existing pending
    * identity (same proposal, re-pushed) instead of minting a new one.
    */
-  parkProposal(text: string, at: Date = new Date()): ProposalRecord {
+  parkProposal(text: string, at: Date = new Date(), id?: string): ProposalRecord {
     const prior = this.pendingProposal();
     const hash = hashBody(text);
-    if (prior && prior.hash === hash) {
+    if (prior && prior.hash === hash && (id === undefined || id === prior.id)) {
       // Same proposal, re-pushed. A stale awaiting-outcome marker must not survive the re-push:
       // the slot is live again, so a later slot-clear deserves the full grace before degrading
       // to 'decided', not an immediate finalization off the old sighting.
@@ -235,7 +235,9 @@ export class RemoteDocState {
     }
     if (prior) this.finalize(prior, "superseded");
     const record: ProposalRecord = {
-      id: `${at.getTime().toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
+      // The id is the CLOUD row's id when the caller passes one (proposals v1 — one identity end
+      // to end); minted locally only for offline/desktop parks.
+      id: id ?? `${at.getTime().toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
       docId: this.docId,
       hash,
       bytes: utf8Bytes(text),

--- a/packages/cli/src/remoteDocState.ts
+++ b/packages/cli/src/remoteDocState.ts
@@ -226,7 +226,10 @@ export class RemoteDocState {
       // Same identity, updated content (the cloud converge-if-pending path): the record follows
       // in place. Superseding here would finalize the id into the history and then republish the
       // SAME id as pending — breaking terminal immutability and corrupting the history.
-      const updated: ProposalRecord = { ...prior, hash, bytes: utf8Bytes(text), at: at.toISOString() };
+      // The grace marker never survives updated content: the slot is live again, so a later
+      // empty-slot sighting earns the full grace, not an immediate 'decided' off the old one.
+      const { awaitingOutcomeSince: _stale, ...rest } = prior;
+      const updated: ProposalRecord = { ...rest, hash, bytes: utf8Bytes(text), at: at.toISOString() };
       this.publish({ ...updated, text });
       return updated;
     }
@@ -340,7 +343,7 @@ export class RemoteDocState {
     if (!existsSync(this.recordPath)) return null;
     try {
       const p = JSON.parse(readFileSync(this.recordPath, "utf8")) as Partial<StoredProposal>;
-      const validState = p.state === "pending_review" || p.state === "accepted" || p.state === "partially_accepted" || p.state === "rejected" || p.state === "decided" || p.state === "superseded";
+      const validState = p.state === "pending_review" || p.state === "accepted" || p.state === "partially_accepted" || p.state === "rejected" || p.state === "decided" || p.state === "superseded" || p.state === "withdrawn";
       if (typeof p.id !== "string" || p.docId !== this.docId || typeof p.hash !== "string" || !Number.isInteger(p.bytes) || (p.bytes as number) < 0 || !Number.isFinite(Date.parse(p.at ?? "")) || !validState || typeof p.text !== "string") return null;
       // A PENDING record's text is load-bearing (recovery, re-push, slot comparison), so a
       // valid-JSON-but-corrupted record whose hash/bytes disagree with its own text reads as

--- a/packages/cli/src/remoteDocState.ts
+++ b/packages/cli/src/remoteDocState.ts
@@ -32,8 +32,9 @@ import { hashBody, LogEventType, type LogEntry } from "@inplan/core/node";
 import type { HydrateInput } from "./liveSync";
 
 /** How a pending proposal ended. `decided` = the proposed slot emptied but no decision event was
- *  readable (the human acted; which way is unknown). `superseded` = a newer park replaced it. */
-export type ProposalOutcome = "accepted" | "partially_accepted" | "rejected" | "decided" | "superseded";
+ *  readable (the human acted; which way is unknown). `superseded` = a newer park replaced it;
+ *  `withdrawn` = the agent retracted its own proposal (a direct-landing edit mooted it). */
+export type ProposalOutcome = "accepted" | "partially_accepted" | "rejected" | "decided" | "superseded" | "withdrawn";
 
 /** UTF-8 byte length — the one sizing used by the proposal record, the wait output's `proposal`
  *  field, and the `agent_revision_proposed` payload, so the three never disagree. */
@@ -221,6 +222,14 @@ export class RemoteDocState {
   parkProposal(text: string, at: Date = new Date(), id?: string): ProposalRecord {
     const prior = this.pendingProposal();
     const hash = hashBody(text);
+    if (prior && id !== undefined && id === prior.id && prior.hash !== hash) {
+      // Same identity, updated content (the cloud converge-if-pending path): the record follows
+      // in place. Superseding here would finalize the id into the history and then republish the
+      // SAME id as pending — breaking terminal immutability and corrupting the history.
+      const updated: ProposalRecord = { ...prior, hash, bytes: utf8Bytes(text), at: at.toISOString() };
+      this.publish({ ...updated, text });
+      return updated;
+    }
     if (prior && prior.hash === hash && (id === undefined || id === prior.id)) {
       // Same proposal, re-pushed. A stale awaiting-outcome marker must not survive the re-push:
       // the slot is live again, so a later slot-clear deserves the full grace before degrading

--- a/packages/cli/test/acceptance.test.ts
+++ b/packages/cli/test/acceptance.test.ts
@@ -11,6 +11,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { LogEventType, MemoryControlChannel, MemoryDocumentStore, type LogEntry } from "@inplan/core/node";
 import { acceptanceFrom, waitCycle, type WaitBackend } from "../src/cli";
+import { proposedContent } from "./helpers";
 
 let home: string;
 beforeEach(() => {
@@ -26,11 +27,6 @@ afterEach(() => {
   rmSync(home, { recursive: true, force: true });
   vi.restoreAllMocks();
 });
-
-/** The caller-visible pending proposal content (proposals v1 surface). */
-async function proposedContent(store: { myPendingProposal(): Promise<{ content: string } | null> }): Promise<string | null> {
-  return (await store.myPendingProposal())?.content ?? null;
-}
 
 const globalAuto = () => writeFileSync(join(home, "settings.json"), JSON.stringify({ acceptance: "auto" }));
 

--- a/packages/cli/test/acceptance.test.ts
+++ b/packages/cli/test/acceptance.test.ts
@@ -27,6 +27,11 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+/** The caller-visible pending proposal content (proposals v1 surface). */
+async function proposedContent(store: { myPendingProposal(): Promise<{ content: string } | null> }): Promise<string | null> {
+  return (await store.myPendingProposal())?.content ?? null;
+}
+
 const globalAuto = () => writeFileSync(join(home, "settings.json"), JSON.stringify({ acceptance: "auto" }));
 
 let seq = 0;
@@ -104,7 +109,7 @@ describe("the bypass, end to end through waitCycle", () => {
       await expect(run).resolves.toBe("ok");
 
       expect(gate.applyRevision).not.toHaveBeenCalled(); // no direct canonical write — the gate held
-      expect(await store.getProposed()).toBe(DOC_B); // the edit is parked for the human
+      expect(await proposedContent(store)).toBe(DOC_B); // the edit is parked for the human
     } finally {
       so.mockRestore();
       se.mockRestore();

--- a/packages/cli/test/applyGatedEdit.test.ts
+++ b/packages/cli/test/applyGatedEdit.test.ts
@@ -5,11 +5,7 @@ import { MemoryControlChannel, MemoryDocumentStore, LogEventType } from "@inplan
 import { applyGatedEdit } from "../src/applyEdit";
 import type { AgentEditEvaluation } from "../src/gate";
 import type { PluginGate } from "../src/pluginGate";
-
-/** The caller-visible pending proposal content (proposals v1 surface). */
-async function proposedContent(store: { myPendingProposal(): Promise<{ content: string } | null> }): Promise<string | null> {
-  return (await store.myPendingProposal())?.content ?? null;
-}
+import { proposedContent } from "./helpers";
 
 const ev = (over: Partial<AgentEditEvaluation> = {}): AgentEditEvaluation => ({
   integrityOk: true,

--- a/packages/cli/test/applyGatedEdit.test.ts
+++ b/packages/cli/test/applyGatedEdit.test.ts
@@ -6,6 +6,11 @@ import { applyGatedEdit } from "../src/applyEdit";
 import type { AgentEditEvaluation } from "../src/gate";
 import type { PluginGate } from "../src/pluginGate";
 
+/** The caller-visible pending proposal content (proposals v1 surface). */
+async function proposedContent(store: { myPendingProposal(): Promise<{ content: string } | null> }): Promise<string | null> {
+  return (await store.myPendingProposal())?.content ?? null;
+}
+
 const ev = (over: Partial<AgentEditEvaluation> = {}): AgentEditEvaluation => ({
   integrityOk: true,
   integrityErrors: [],
@@ -39,7 +44,7 @@ describe("applyGatedEdit — file path (no plugin)", () => {
     const channel = new MemoryControlChannel();
     const applied = await applyGatedEdit(store, channel, ev({ changed: true }), { current: "agent body", canonicalText: "canon", quarantine: true, gate: null });
     expect(applied.proposed).toBe(true); // the caller surfaces the park (#88)
-    expect(await store.getProposed()).toBe("agent body");
+    expect(await proposedContent(store)).toBe("agent body");
     expect(await store.loadDoc()).toBe("canon"); // working file reverted to canonical
     expect(await types(channel)).toEqual([LogEventType.AgentRevisionProposed]);
   });
@@ -57,7 +62,7 @@ describe("applyGatedEdit — file path (no plugin)", () => {
     // A crashed park used to reject all the way out of waitCycle — no status, no marker — and a
     // continued turn would have re-synced the working copy over the ONLY copy of the edit.
     const store = new MemoryDocumentStore("agent body");
-    store.setProposed = async () => {
+    store.createProposal = async () => {
       throw new Error("hub down");
     };
     const channel = new MemoryControlChannel();
@@ -78,7 +83,7 @@ describe("applyGatedEdit — file path (no plugin)", () => {
     const channel = new MemoryControlChannel();
     const applied = await applyGatedEdit(store, channel, ev({ changed: true }), { current: "agent body", canonicalText: "canon", quarantine: true, gate: null });
     expect(applied).toEqual({ proposed: true });
-    expect(await store.getProposed()).toBe("agent body");
+    expect(await proposedContent(store)).toBe("agent body");
     expect(await store.loadDoc()).toBe("agent body"); // revert failed — edit stays put
     expect(await types(channel)).toEqual([LogEventType.AgentRevisionProposed]); // the park is logged
   });
@@ -91,7 +96,7 @@ describe("applyGatedEdit — file path (no plugin)", () => {
     };
     const applied = await applyGatedEdit(store, channel, ev({ changed: true }), { current: "agent body", canonicalText: "canon", quarantine: true, gate: null });
     expect(applied).toEqual({ proposed: true, eventLogged: false }); // no crash, no false failure — and the missing event is reported
-    expect(await store.getProposed()).toBe("agent body");
+    expect(await proposedContent(store)).toBe("agent body");
     expect(await store.loadDoc()).toBe("canon"); // the revert did run
   });
 
@@ -132,7 +137,7 @@ describe("applyGatedEdit — plugin path (a plugin gate is connected)", () => {
     const gate = fakeGate();
     const applied = await applyGatedEdit(store, channel, ev({ changed: true }), { current: "agent body", canonicalText: "canon", quarantine: true, gate });
     expect(applied.proposed).toBe(true);
-    expect(await store.getProposed()).toBe("agent body");
+    expect(await proposedContent(store)).toBe("agent body");
     expect(await store.loadDoc()).toBe("agent body"); // NOT reverted to canon
     expect(gate.applyRevision).not.toHaveBeenCalled();
     expect(await types(channel)).toEqual([LogEventType.AgentRevisionProposed]);

--- a/packages/cli/test/helpers.ts
+++ b/packages/cli/test/helpers.ts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Shared accessors for the proposals-v1 store surface, so tests track the surface in one place.
+
+/** The caller-visible pending proposal content (proposals v1 surface). */
+export async function proposedContent(store: { myPendingProposal(): Promise<{ content: string } | null> }): Promise<string | null> {
+  return (await store.myPendingProposal())?.content ?? null;
+}

--- a/packages/cli/test/waitCycleResume.test.ts
+++ b/packages/cli/test/waitCycleResume.test.ts
@@ -17,11 +17,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { LogEventType, MemoryControlChannel, MemoryDocumentStore, hashBody, type LogEntry } from "@inplan/core/node";
 import { waitCycle, type WaitBackend } from "../src/cli";
 import { utf8Bytes } from "../src/remoteDocState";
-
-/** The caller-visible pending proposal content (proposals v1 surface). */
-async function proposedContent(store: { myPendingProposal(): Promise<{ content: string } | null> }): Promise<string | null> {
-  return (await store.myPendingProposal())?.content ?? null;
-}
+import { proposedContent } from "./helpers";
 
 const DOC_A = "# Plan\n\nOriginal body.\n\n<!--inplan\n[]\n-->\n";
 const DOC_B = "# Plan\n\nAgent-edited body.\n\n<!--inplan\n[]\n-->\n";

--- a/packages/cli/test/waitCycleResume.test.ts
+++ b/packages/cli/test/waitCycleResume.test.ts
@@ -18,6 +18,11 @@ import { LogEventType, MemoryControlChannel, MemoryDocumentStore, hashBody, type
 import { waitCycle, type WaitBackend } from "../src/cli";
 import { utf8Bytes } from "../src/remoteDocState";
 
+/** The caller-visible pending proposal content (proposals v1 surface). */
+async function proposedContent(store: { myPendingProposal(): Promise<{ content: string } | null> }): Promise<string | null> {
+  return (await store.myPendingProposal())?.content ?? null;
+}
+
 const DOC_A = "# Plan\n\nOriginal body.\n\n<!--inplan\n[]\n-->\n";
 const DOC_B = "# Plan\n\nAgent-edited body.\n\n<!--inplan\n[]\n-->\n";
 
@@ -163,7 +168,7 @@ describe("waitCycle resume is a loop, not a re-entry", () => {
       const last = h.lastJson() as ReturnType<typeof h.lastJson> & { proposal?: { state: string; bytes: number; hash: string } };
       expect(last.proposal).toEqual({ state: "pending_review", bytes: utf8Bytes(DOC_B), hash: hashBody(DOC_B) });
       expect(h.stderr()).toContain("parked as a proposal");
-      expect(await h.store.getProposed()).toBe(DOC_B);
+      expect(await proposedContent(h.store)).toBe(DOC_B);
     } finally {
       h.restore();
     }
@@ -221,7 +226,7 @@ describe("waitCycle resume is a loop, not a re-entry", () => {
     // the wait completes and the JSON says exactly what happened, so an agent parsing only the
     // output (stderr discarded) can never read a failed push as a no-change turn.
     const h = harness(DOC_B);
-    h.store.setProposed = async () => {
+    h.store.createProposal = async () => {
       throw new Error("hub down");
     };
     const origAppend = h.channel.append.bind(h.channel);
@@ -239,7 +244,7 @@ describe("waitCycle resume is a loop, not a re-entry", () => {
       const last = h.lastJson() as ReturnType<typeof h.lastJson> & { proposal?: { state: string; hash: string } };
       expect(last.status).toBe("your_turn");
       expect(last.proposal).toMatchObject({ state: "park_failed", hash: hashBody(DOC_B) });
-      expect(await h.store.getProposed()).toBeNull(); // nothing landed anywhere
+      expect(await proposedContent(h.store)).toBeNull(); // nothing landed anywhere
     } finally {
       h.restore();
     }

--- a/packages/core/src/channel.ts
+++ b/packages/core/src/channel.ts
@@ -97,9 +97,11 @@ export interface ProposalRow {
 export function mintProposalId(): string {
   const c = (globalThis as { crypto?: { randomUUID?: () => string } }).crypto;
   if (c?.randomUUID) return c.randomUUID();
-  // Extremely defensive fallback (no secure-uuid runtime): time + randomness, still unique enough
-  // for a per-doc proposal namespace.
-  return `p-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+  // Fallback for runtimes without randomUUID: still RFC-4122 v4 SHAPED — the id lands in a
+  // Postgres uuid column, which rejects anything else. Uniqueness (not unguessability) is the
+  // requirement here; ids are scoped per doc and authorization never derives from them.
+  const hex = (n: number) => Math.floor(Math.random() * n).toString(16);
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (ch) => (ch === "x" ? hex(16) : ((Math.floor(Math.random() * 4) + 8).toString(16))));
 }
 
 export interface DocumentStore {

--- a/packages/core/src/channel.ts
+++ b/packages/core/src/channel.ts
@@ -71,7 +71,9 @@ export type ProposalState = "pending" | "accepted" | "partially_accepted" | "rej
 /** What a proposer parks (proposals v1 — see docs/proposals-v1.plan.md in the cloud repo). */
 export interface ProposalInput {
   /** Client-minted uuid. Re-parking with the SAME id is an idempotent upsert (a retried park
-   *  converges even when an earlier response was lost); omit to mint a fresh one. */
+   *  converges even when an earlier response was lost). When omitted, identical still-pending
+   *  content re-parks under ITS existing id (a retry, not a successor); only genuinely new
+   *  content mints a fresh identity. */
   id?: string;
   /** The full proposed serialization. */
   content: string;

--- a/packages/core/src/channel.ts
+++ b/packages/core/src/channel.ts
@@ -65,6 +65,43 @@ export interface VersionMeta {
   author?: string;
 }
 
+/** How a proposal's life ends (or hasn't yet). Terminal states are immutable. */
+export type ProposalState = "pending" | "accepted" | "partially_accepted" | "rejected" | "superseded" | "withdrawn";
+
+/** What a proposer parks (proposals v1 — see docs/proposals-v1.plan.md in the cloud repo). */
+export interface ProposalInput {
+  /** Client-minted uuid. Re-parking with the SAME id is an idempotent upsert (a retried park
+   *  converges even when an earlier response was lost); omit to mint a fresh one. */
+  id?: string;
+  /** The full proposed serialization. */
+  content: string;
+  /** hashBody of the canonical this proposal was written against. */
+  baseHash: string;
+  /** The base canonical itself — a 3-way merge at review time must never depend on a version
+   *  checkpoint happening to exist for `baseHash`. */
+  baseContent: string;
+}
+
+export interface ProposalRow {
+  id: string;
+  content: string;
+  baseHash: string;
+  baseContent: string;
+  state: ProposalState;
+  /** ISO-8601. */
+  createdAt: string;
+  decidedAt?: string;
+}
+
+/** Mint a proposal id (uuid) — client-generated so retries are idempotent by construction. */
+export function mintProposalId(): string {
+  const c = (globalThis as { crypto?: { randomUUID?: () => string } }).crypto;
+  if (c?.randomUUID) return c.randomUUID();
+  // Extremely defensive fallback (no secure-uuid runtime): time + randomness, still unique enough
+  // for a per-doc proposal namespace.
+  return `p-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
 export interface DocumentStore {
   /** Read the working document. */
   loadDoc(): Promise<string>;
@@ -73,10 +110,19 @@ export interface DocumentStore {
   /** The last canonical version (diff base / undo base), or null if unset. */
   getCanonical(): Promise<string | null>;
   setCanonical(content: string): Promise<void>;
-  /** The parked agent revision pending accept/reject (Review mode), or null. */
-  getProposed(): Promise<string | null>;
-  setProposed(content: string): Promise<void>;
-  clearProposed(): Promise<void>;
+  /** Park a proposal (Review mode): upsert by id — the same id converges, a NEW id supersedes the
+   *  caller's own previous pending proposal. Never touches another proposer's proposals. */
+  createProposal(input: ProposalInput): Promise<{ id: string }>;
+  /** The caller's own pending proposal, or null. */
+  myPendingProposal(): Promise<ProposalRow | null>;
+  /** Any visible proposal by id — the landing signal, as one lookup. */
+  getProposal(id: string): Promise<ProposalRow | null>;
+  /** Retract the caller's own pending proposal (state → withdrawn). No-op when it isn't pending
+   *  (a decision may have raced ahead — the decision wins). */
+  withdrawProposal(id: string): Promise<void>;
+  /** Record the human's decision on a pending proposal. No-op on a non-pending row (terminal
+   *  states are immutable). */
+  decideProposal(id: string, state: "accepted" | "partially_accepted" | "rejected"): Promise<void>;
   /** Write an autosave backup checkpoint. `meta` (optional) records its provenance for a history
    *  view; an implementation that keeps history should de-duplicate (skip a no-op snapshot whose
    *  body matches the most recent one). */

--- a/packages/core/src/fsBackend.ts
+++ b/packages/core/src/fsBackend.ts
@@ -182,14 +182,10 @@ export class FsDocumentStore implements DocumentStore {
       /* fall through to preservation */
     }
     // A damaged rows file must never be silently replaced by the next write — it is the proposal
-    // history. Move the bytes aside (evidence, hand-recoverable) and start fresh; if even the
-    // rename fails, leave it in place and still return empty (reads degrade, writes will attempt
-    // the tmp+rename publish and may fail loudly, which beats destroying the original).
-    try {
-      renameSync(this.proposalsPath(), `${this.proposalsPath()}.corrupt-${Date.now()}`);
-    } catch {
-      /* preserved in place */
-    }
+    // history. Move the bytes aside (evidence, hand-recoverable) and start fresh. If even the
+    // rename fails, FAIL the operation: returning [] here would let the next writeRows publish an
+    // empty replacement over the original via tmp+rename, destroying the history it exists to keep.
+    renameSync(this.proposalsPath(), `${this.proposalsPath()}.corrupt-${Date.now()}`);
     return [];
   }
 

--- a/packages/core/src/fsBackend.ts
+++ b/packages/core/src/fsBackend.ts
@@ -13,7 +13,7 @@ import {
   readdirSync,
   readFileSync,
   renameSync,
-  rmdirSync,
+  rmSync,
   statSync,
   unlinkSync,
   unwatchFile,
@@ -213,10 +213,13 @@ export class FsDocumentStore implements DocumentStore {
    */
   private withRowsLock<T>(run: () => T): T {
     const lockDir = `${this.proposalsPath()}.lock`;
+    const ownerPath = join(lockDir, "owner");
+    const token = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     const deadline = Date.now() + 2_000;
     for (;;) {
       try {
         mkdirSync(lockDir);
+        writeFileSync(ownerPath, token);
         break;
       } catch {
         let stale = false;
@@ -227,7 +230,7 @@ export class FsDocumentStore implements DocumentStore {
         }
         if (stale) {
           try {
-            rmdirSync(lockDir);
+            rmSync(lockDir, { recursive: true, force: true });
           } catch {
             /* someone else broke it first */
           }
@@ -241,10 +244,13 @@ export class FsDocumentStore implements DocumentStore {
     try {
       return run();
     } finally {
+      // Ownership-checked release: if a holder overstays the staleness window and its lock was
+      // broken, its release must not tear down the NEW holder's lock (that would readmit a third
+      // process mid-mutation and lose rows to last-write-wins).
       try {
-        rmdirSync(lockDir);
+        if (readFileSync(ownerPath, "utf8") === token) rmSync(lockDir, { recursive: true, force: true });
       } catch {
-        /* released by staleness-breaking — nothing to do */
+        /* broken by staleness — the lock is someone else's now */
       }
     }
   }
@@ -308,7 +314,9 @@ export class FsDocumentStore implements DocumentStore {
   }
 
   getProposal(id: string): Promise<ProposalRow | null> {
-    return Promise.resolve(this.readRows().find((r) => r.id === id) ?? null);
+    // Under the lock like every other rows access: a lookup must not race a concurrent
+    // quarantine-recovery rename from another process mid-publish.
+    return Promise.resolve(this.withRowsLock(() => this.readRows().find((r) => r.id === id) ?? null));
   }
 
   withdrawProposal(id: string): Promise<void> {

--- a/packages/core/src/fsBackend.ts
+++ b/packages/core/src/fsBackend.ts
@@ -283,9 +283,10 @@ export class FsDocumentStore implements DocumentStore {
     }
   }
 
-  createProposal(input: ProposalInput): Promise<{ id: string }> {
-    return Promise.resolve(
-      this.withRowsLock(() => {
+  async createProposal(input: ProposalInput): Promise<{ id: string }> {
+    // async so a sync throw (lock contention, unpreservable corruption) REJECTS as the interface
+    // promises, instead of escaping a caller that chained .catch() without awaiting.
+    return this.withRowsLock(() => {
         const rows = this.readRowsAdoptingLegacy();
         // Identical content with no explicit id re-parks the SAME proposal (a retry, not a
         // successor): minting a fresh id would supersede the original identity on every retry.
@@ -300,8 +301,7 @@ export class FsDocumentStore implements DocumentStore {
         }
         this.writeRows(rows);
         return { id };
-      }),
-    );
+      });
   }
 
   /** Rows, adopting a legacy pre-rows sidecar exactly once: a `proposedPath` content file with no
@@ -315,25 +315,23 @@ export class FsDocumentStore implements DocumentStore {
     return [{ id: mintProposalId(), content: legacy, baseHash: "", baseContent: "", state: "pending", createdAt: new Date().toISOString() }];
   }
 
-  myPendingProposal(): Promise<ProposalRow | null> {
-    return Promise.resolve(
-      this.withRowsLock(() => {
+  async myPendingProposal(): Promise<ProposalRow | null> {
+    return this.withRowsLock(() => {
         const rows = this.readRowsAdoptingLegacy();
         const pending = rows.find((r) => r.state === "pending") ?? null;
         // Persist an adoption so the minted identity is stable across calls.
         if (pending && !this.hasProposalHistory()) this.writeRows(rows);
         return pending;
-      }),
-    );
+      });
   }
 
-  getProposal(id: string): Promise<ProposalRow | null> {
+  async getProposal(id: string): Promise<ProposalRow | null> {
     // Under the lock like every other rows access: a lookup must not race a concurrent
     // quarantine-recovery rename from another process mid-publish.
-    return Promise.resolve(this.withRowsLock(() => this.readRows().find((r) => r.id === id) ?? null));
+    return this.withRowsLock(() => this.readRows().find((r) => r.id === id) ?? null);
   }
 
-  withdrawProposal(id: string): Promise<void> {
+  async withdrawProposal(id: string): Promise<void> {
     this.withRowsLock(() => {
       const rows = this.readRowsAdoptingLegacy();
       const r = rows.find((x) => x.id === id);
@@ -342,10 +340,9 @@ export class FsDocumentStore implements DocumentStore {
         this.writeRows(rows);
       }
     });
-    return Promise.resolve();
   }
 
-  decideProposal(id: string, state: "accepted" | "partially_accepted" | "rejected"): Promise<void> {
+  async decideProposal(id: string, state: "accepted" | "partially_accepted" | "rejected"): Promise<void> {
     this.withRowsLock(() => {
       const rows = this.readRowsAdoptingLegacy();
       const r = rows.find((x) => x.id === id);
@@ -355,7 +352,6 @@ export class FsDocumentStore implements DocumentStore {
         this.writeRows(rows);
       }
     });
-    return Promise.resolve();
   }
 
   backup(content: string): Promise<void> {

--- a/packages/core/src/fsBackend.ts
+++ b/packages/core/src/fsBackend.ts
@@ -12,6 +12,7 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
+  renameSync,
   unlinkSync,
   unwatchFile,
   watch,
@@ -19,7 +20,8 @@ import {
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
-import type { ControlChannel, DocumentStore, WaitToken } from "./channel";
+import type { ControlChannel, DocumentStore, ProposalInput, ProposalRow, WaitToken } from "./channel";
+import { mintProposalId } from "./channel";
 import { LogEventType, type LogEntry, type NewLogEntry } from "./controlLog";
 import { appendLog, readLog, readLogIncrement } from "./controlLogFs";
 
@@ -163,17 +165,78 @@ export class FsDocumentStore implements DocumentStore {
     return Promise.resolve();
   }
 
-  getProposed(): Promise<string | null> {
-    return Promise.resolve(this.readOrNull(this.paths.proposedPath));
+  // Proposal rows live in a JSON file beside the other sidecars; `proposedPath` stays as a
+  // derived copy of the CURRENT pending content (readable at a glance, and what pre-rows code
+  // wrote). A single local proposer, so "mine" is unqualified.
+  private proposalsPath(): string {
+    return `${this.paths.proposedPath}.rows.json`;
   }
 
-  setProposed(content: string): Promise<void> {
-    writeFileSync(this.paths.proposedPath, content);
+  private readRows(): ProposalRow[] {
+    const raw = this.readOrNull(this.proposalsPath());
+    if (raw === null) return [];
+    try {
+      const rows = JSON.parse(raw) as ProposalRow[];
+      return Array.isArray(rows) ? rows : [];
+    } catch {
+      return [];
+    }
+  }
+
+  private writeRows(rows: ProposalRow[]): void {
+    // Atomic publish (tmp + rename), then refresh the derived pending-content file.
+    const tmp = `${this.proposalsPath()}.tmp`;
+    writeFileSync(tmp, JSON.stringify(rows, null, 2));
+    renameSync(tmp, this.proposalsPath());
+    const pending = rows.find((r) => r.state === "pending");
+    try {
+      if (pending) writeFileSync(this.paths.proposedPath, pending.content);
+      else if (existsSync(this.paths.proposedPath)) unlinkSync(this.paths.proposedPath);
+    } catch {
+      /* derived copy only */
+    }
+  }
+
+  createProposal(input: ProposalInput): Promise<{ id: string }> {
+    const rows = this.readRows();
+    const id = input.id ?? mintProposalId();
+    const existing = rows.find((r) => r.id === id);
+    if (existing) {
+      if (existing.state === "pending") Object.assign(existing, { content: input.content, baseHash: input.baseHash, baseContent: input.baseContent });
+    } else {
+      for (const r of rows) if (r.state === "pending") r.state = "superseded";
+      rows.push({ id, content: input.content, baseHash: input.baseHash, baseContent: input.baseContent, state: "pending", createdAt: new Date().toISOString() });
+    }
+    this.writeRows(rows);
+    return Promise.resolve({ id });
+  }
+
+  myPendingProposal(): Promise<ProposalRow | null> {
+    return Promise.resolve(this.readRows().find((r) => r.state === "pending") ?? null);
+  }
+
+  getProposal(id: string): Promise<ProposalRow | null> {
+    return Promise.resolve(this.readRows().find((r) => r.id === id) ?? null);
+  }
+
+  withdrawProposal(id: string): Promise<void> {
+    const rows = this.readRows();
+    const r = rows.find((x) => x.id === id);
+    if (r && r.state === "pending") {
+      r.state = "withdrawn";
+      this.writeRows(rows);
+    }
     return Promise.resolve();
   }
 
-  clearProposed(): Promise<void> {
-    if (existsSync(this.paths.proposedPath)) unlinkSync(this.paths.proposedPath);
+  decideProposal(id: string, state: "accepted" | "partially_accepted" | "rejected"): Promise<void> {
+    const rows = this.readRows();
+    const r = rows.find((x) => x.id === id);
+    if (r && r.state === "pending") {
+      r.state = state;
+      r.decidedAt = new Date().toISOString();
+      this.writeRows(rows);
+    }
     return Promise.resolve();
   }
 

--- a/packages/core/src/fsBackend.ts
+++ b/packages/core/src/fsBackend.ts
@@ -244,13 +244,27 @@ export class FsDocumentStore implements DocumentStore {
     try {
       return run();
     } finally {
-      // Ownership-checked release: if a holder overstays the staleness window and its lock was
-      // broken, its release must not tear down the NEW holder's lock (that would readmit a third
-      // process mid-mutation and lose rows to last-write-wins).
+      // Release by ATOMIC TAKE: rename the lock dir to a private name (rename is atomic — nobody
+      // can be mid-acquisition inside it), verify ownership there, and only then delete. A plain
+      // read-check-then-rm had a window where a broken-and-replaced lock could be read as ours a
+      // beat before recovery swapped it, deleting the NEW holder's lock and readmitting a third
+      // writer. If the taken lock turns out not to be ours, it is restored by the reverse rename;
+      // the restore can only collide if a third acquisition raced the gap, in which case the
+      // taken (stale-broken) copy is discarded and the live lock is theirs — never deleted here.
+      const releasing = `${lockDir}.releasing-${token}`;
       try {
-        if (readFileSync(ownerPath, "utf8") === token) rmSync(lockDir, { recursive: true, force: true });
+        renameSync(lockDir, releasing);
+        if (readFileSync(join(releasing, "owner"), "utf8") === token) {
+          rmSync(releasing, { recursive: true, force: true });
+        } else {
+          try {
+            renameSync(releasing, lockDir); // not ours — put the live lock back
+          } catch {
+            rmSync(releasing, { recursive: true, force: true }); // a fresh lock exists; drop the stale copy
+          }
+        }
       } catch {
-        /* broken by staleness — the lock is someone else's now */
+        /* the lock was already broken and replaced or removed — nothing of ours to release */
       }
     }
   }

--- a/packages/core/src/fsBackend.ts
+++ b/packages/core/src/fsBackend.ts
@@ -13,6 +13,8 @@ import {
   readdirSync,
   readFileSync,
   renameSync,
+  rmdirSync,
+  statSync,
   unlinkSync,
   unwatchFile,
   watch,
@@ -172,12 +174,26 @@ export class FsDocumentStore implements DocumentStore {
     return `${this.paths.proposedPath}.rows.json`;
   }
 
+  /** Whether row-backed proposal state exists for this doc at all (vs the legacy content file). */
+  hasProposalHistory(): boolean {
+    return existsSync(this.proposalsPath());
+  }
+
+  private static readonly STATES = new Set(["pending", "accepted", "partially_accepted", "rejected", "superseded", "withdrawn"]);
+
+  private static isValidRow(r: unknown): r is ProposalRow {
+    const x = r as Partial<ProposalRow> | null;
+    return !!x && typeof x.id === "string" && typeof x.content === "string" && typeof x.baseHash === "string" && typeof x.baseContent === "string" && typeof x.state === "string" && FsDocumentStore.STATES.has(x.state) && typeof x.createdAt === "string";
+  }
+
   private readRows(): ProposalRow[] {
     const raw = this.readOrNull(this.proposalsPath());
     if (raw === null) return [];
     try {
-      const rows = JSON.parse(raw) as ProposalRow[];
-      if (Array.isArray(rows)) return rows;
+      const rows = JSON.parse(raw) as unknown;
+      // Valid JSON is not integrity: every row must carry the full lifecycle shape, or lookups
+      // would serve invalid state downstream. Anything else is quarantined like a parse failure.
+      if (Array.isArray(rows) && rows.every((r) => FsDocumentStore.isValidRow(r))) return rows as ProposalRow[];
     } catch {
       /* fall through to preservation */
     }
@@ -187,6 +203,50 @@ export class FsDocumentStore implements DocumentStore {
     // empty replacement over the original via tmp+rename, destroying the history it exists to keep.
     renameSync(this.proposalsPath(), `${this.proposalsPath()}.corrupt-${Date.now()}`);
     return [];
+  }
+
+  /**
+   * Advisory per-doc lock around every read-modify-publish of the rows file: the desktop editor
+   * (main process) and a CLI can share one sidecar, and interleaved mutations would lose a
+   * lifecycle update. mkdir is the atomic primitive; a stale lock (a crashed holder) is broken
+   * after 2s. Mutations here are a few file ops — well under the staleness window.
+   */
+  private withRowsLock<T>(run: () => T): T {
+    const lockDir = `${this.proposalsPath()}.lock`;
+    const deadline = Date.now() + 2_000;
+    for (;;) {
+      try {
+        mkdirSync(lockDir);
+        break;
+      } catch {
+        let stale = false;
+        try {
+          stale = Date.now() - statSync(lockDir).mtime.getTime() > 2_000;
+        } catch {
+          continue; // holder released between our attempt and the stat — retry immediately
+        }
+        if (stale) {
+          try {
+            rmdirSync(lockDir);
+          } catch {
+            /* someone else broke it first */
+          }
+          continue;
+        }
+        if (Date.now() > deadline) throw new Error(`proposal rows lock is held: ${lockDir}`);
+        const buf = new SharedArrayBuffer(4);
+        Atomics.wait(new Int32Array(buf), 0, 0, 25); // sync sleep without spinning a core
+      }
+    }
+    try {
+      return run();
+    } finally {
+      try {
+        rmdirSync(lockDir);
+      } catch {
+        /* released by staleness-breaking — nothing to do */
+      }
+    }
   }
 
   private writeRows(rows: ProposalRow[]): void {
@@ -204,21 +264,47 @@ export class FsDocumentStore implements DocumentStore {
   }
 
   createProposal(input: ProposalInput): Promise<{ id: string }> {
+    return Promise.resolve(
+      this.withRowsLock(() => {
+        const rows = this.readRowsAdoptingLegacy();
+        // Identical content with no explicit id re-parks the SAME proposal (a retry, not a
+        // successor): minting a fresh id would supersede the original identity on every retry.
+        const pendingSame = input.id ? undefined : rows.find((r) => r.state === "pending" && r.content === input.content);
+        const id = input.id ?? pendingSame?.id ?? mintProposalId();
+        const existing = rows.find((r) => r.id === id);
+        if (existing) {
+          if (existing.state === "pending") Object.assign(existing, { content: input.content, baseHash: input.baseHash, baseContent: input.baseContent });
+        } else {
+          for (const r of rows) if (r.state === "pending") r.state = "superseded";
+          rows.push({ id, content: input.content, baseHash: input.baseHash, baseContent: input.baseContent, state: "pending", createdAt: new Date().toISOString() });
+        }
+        this.writeRows(rows);
+        return { id };
+      }),
+    );
+  }
+
+  /** Rows, adopting a legacy pre-rows sidecar exactly once: a `proposedPath` content file with no
+   *  rows file is an old park — it becomes a real pending row (minted id) so the full lifecycle
+   *  (withdraw/decide/supersede) applies to it instead of the file lingering forever. */
+  private readRowsAdoptingLegacy(): ProposalRow[] {
     const rows = this.readRows();
-    const id = input.id ?? mintProposalId();
-    const existing = rows.find((r) => r.id === id);
-    if (existing) {
-      if (existing.state === "pending") Object.assign(existing, { content: input.content, baseHash: input.baseHash, baseContent: input.baseContent });
-    } else {
-      for (const r of rows) if (r.state === "pending") r.state = "superseded";
-      rows.push({ id, content: input.content, baseHash: input.baseHash, baseContent: input.baseContent, state: "pending", createdAt: new Date().toISOString() });
-    }
-    this.writeRows(rows);
-    return Promise.resolve({ id });
+    if (rows.length > 0 || this.hasProposalHistory()) return rows;
+    const legacy = this.readOrNull(this.paths.proposedPath);
+    if (legacy === null) return rows;
+    return [{ id: mintProposalId(), content: legacy, baseHash: "", baseContent: "", state: "pending", createdAt: new Date().toISOString() }];
   }
 
   myPendingProposal(): Promise<ProposalRow | null> {
-    return Promise.resolve(this.readRows().find((r) => r.state === "pending") ?? null);
+    return Promise.resolve(
+      this.withRowsLock(() => {
+        const rows = this.readRowsAdoptingLegacy();
+        const pending = rows.find((r) => r.state === "pending") ?? null;
+        // Persist an adoption so the minted identity is stable across calls.
+        if (pending && !this.hasProposalHistory()) this.writeRows(rows);
+        return pending;
+      }),
+    );
   }
 
   getProposal(id: string): Promise<ProposalRow | null> {
@@ -226,23 +312,27 @@ export class FsDocumentStore implements DocumentStore {
   }
 
   withdrawProposal(id: string): Promise<void> {
-    const rows = this.readRows();
-    const r = rows.find((x) => x.id === id);
-    if (r && r.state === "pending") {
-      r.state = "withdrawn";
-      this.writeRows(rows);
-    }
+    this.withRowsLock(() => {
+      const rows = this.readRowsAdoptingLegacy();
+      const r = rows.find((x) => x.id === id);
+      if (r && r.state === "pending") {
+        r.state = "withdrawn";
+        this.writeRows(rows);
+      }
+    });
     return Promise.resolve();
   }
 
   decideProposal(id: string, state: "accepted" | "partially_accepted" | "rejected"): Promise<void> {
-    const rows = this.readRows();
-    const r = rows.find((x) => x.id === id);
-    if (r && r.state === "pending") {
-      r.state = state;
-      r.decidedAt = new Date().toISOString();
-      this.writeRows(rows);
-    }
+    this.withRowsLock(() => {
+      const rows = this.readRowsAdoptingLegacy();
+      const r = rows.find((x) => x.id === id);
+      if (r && r.state === "pending") {
+        r.state = state;
+        r.decidedAt = new Date().toISOString();
+        this.writeRows(rows);
+      }
+    });
     return Promise.resolve();
   }
 

--- a/packages/core/src/fsBackend.ts
+++ b/packages/core/src/fsBackend.ts
@@ -177,10 +177,20 @@ export class FsDocumentStore implements DocumentStore {
     if (raw === null) return [];
     try {
       const rows = JSON.parse(raw) as ProposalRow[];
-      return Array.isArray(rows) ? rows : [];
+      if (Array.isArray(rows)) return rows;
     } catch {
-      return [];
+      /* fall through to preservation */
     }
+    // A damaged rows file must never be silently replaced by the next write — it is the proposal
+    // history. Move the bytes aside (evidence, hand-recoverable) and start fresh; if even the
+    // rename fails, leave it in place and still return empty (reads degrade, writes will attempt
+    // the tmp+rename publish and may fail loudly, which beats destroying the original).
+    try {
+      renameSync(this.proposalsPath(), `${this.proposalsPath()}.corrupt-${Date.now()}`);
+    } catch {
+      /* preserved in place */
+    }
+    return [];
   }
 
   private writeRows(rows: ProposalRow[]): void {

--- a/packages/core/src/memoryBackend.ts
+++ b/packages/core/src/memoryBackend.ts
@@ -7,7 +7,8 @@
 // can run against `Fs`, `Memory` (and later `Supabase`) to prove the backends are
 // interchangeable. Pure and browser-safe (exported from the package root).
 
-import type { ControlChannel, DocumentStore, WaitToken } from "./channel";
+import type { ControlChannel, DocumentStore, ProposalInput, ProposalRow, WaitToken } from "./channel";
+import { mintProposalId } from "./channel";
 import type { LogEntry, NewLogEntry } from "./controlLog";
 
 export class MemoryControlChannel implements ControlChannel {
@@ -78,7 +79,7 @@ export class MemoryControlChannel implements ControlChannel {
 export class MemoryDocumentStore implements DocumentStore {
   private doc: string;
   private canonical: string | null = null;
-  private proposed: string | null = null;
+  private proposals: ProposalRow[] = [];
   private backups: string[] = [];
 
   constructor(initial = "") {
@@ -99,15 +100,35 @@ export class MemoryDocumentStore implements DocumentStore {
     this.canonical = content;
     return Promise.resolve();
   }
-  getProposed(): Promise<string | null> {
-    return Promise.resolve(this.proposed);
+  createProposal(input: ProposalInput): Promise<{ id: string }> {
+    const id = input.id ?? mintProposalId();
+    const existing = this.proposals.find((r) => r.id === id);
+    if (existing) {
+      // Idempotent re-park: converge content/base while still pending; a decided row is immutable.
+      if (existing.state === "pending") Object.assign(existing, { content: input.content, baseHash: input.baseHash, baseContent: input.baseContent });
+      return Promise.resolve({ id });
+    }
+    for (const r of this.proposals) if (r.state === "pending") r.state = "superseded";
+    this.proposals.push({ id, content: input.content, baseHash: input.baseHash, baseContent: input.baseContent, state: "pending", createdAt: new Date().toISOString() });
+    return Promise.resolve({ id });
   }
-  setProposed(content: string): Promise<void> {
-    this.proposed = content;
+  myPendingProposal(): Promise<ProposalRow | null> {
+    return Promise.resolve(this.proposals.find((r) => r.state === "pending") ?? null);
+  }
+  getProposal(id: string): Promise<ProposalRow | null> {
+    return Promise.resolve(this.proposals.find((r) => r.id === id) ?? null);
+  }
+  withdrawProposal(id: string): Promise<void> {
+    const r = this.proposals.find((x) => x.id === id);
+    if (r && r.state === "pending") r.state = "withdrawn";
     return Promise.resolve();
   }
-  clearProposed(): Promise<void> {
-    this.proposed = null;
+  decideProposal(id: string, state: "accepted" | "partially_accepted" | "rejected"): Promise<void> {
+    const r = this.proposals.find((x) => x.id === id);
+    if (r && r.state === "pending") {
+      r.state = state;
+      r.decidedAt = new Date().toISOString();
+    }
     return Promise.resolve();
   }
   backup(content: string): Promise<void> {

--- a/packages/core/src/memoryBackend.ts
+++ b/packages/core/src/memoryBackend.ts
@@ -101,7 +101,10 @@ export class MemoryDocumentStore implements DocumentStore {
     return Promise.resolve();
   }
   createProposal(input: ProposalInput): Promise<{ id: string }> {
-    const id = input.id ?? mintProposalId();
+    // Identical content with no explicit id re-parks the SAME proposal (a retry, not a successor):
+    // minting a fresh id would supersede the original identity on every retry.
+    const pendingSame = input.id ? undefined : this.proposals.find((r) => r.state === "pending" && r.content === input.content);
+    const id = input.id ?? pendingSame?.id ?? mintProposalId();
     const existing = this.proposals.find((r) => r.id === id);
     if (existing) {
       // Idempotent re-park: converge content/base while still pending; a decided row is immutable.

--- a/packages/core/src/memoryBackend.ts
+++ b/packages/core/src/memoryBackend.ts
@@ -113,10 +113,12 @@ export class MemoryDocumentStore implements DocumentStore {
     return Promise.resolve({ id });
   }
   myPendingProposal(): Promise<ProposalRow | null> {
-    return Promise.resolve(this.proposals.find((r) => r.state === "pending") ?? null);
+    const r = this.proposals.find((x) => x.state === "pending");
+    return Promise.resolve(r ? { ...r } : null); // copies — callers must not bypass the lifecycle
   }
   getProposal(id: string): Promise<ProposalRow | null> {
-    return Promise.resolve(this.proposals.find((r) => r.id === id) ?? null);
+    const r = this.proposals.find((x) => x.id === id);
+    return Promise.resolve(r ? { ...r } : null);
   }
   withdrawProposal(id: string): Promise<void> {
     const r = this.proposals.find((x) => x.id === id);

--- a/packages/core/test/channelContract.test.ts
+++ b/packages/core/test/channelContract.test.ts
@@ -94,6 +94,13 @@ for (const [name, make] of Object.entries(BACKENDS)) {
       expect(await b.store.getProposal(id)).toMatchObject({ id, state: "pending" });
     });
 
+    it("re-parking IDENTICAL content with no id keeps the same proposal identity (a retry, not a successor)", async () => {
+      const a = await b.store.createProposal({ content: "same text", baseHash: "h", baseContent: "c" });
+      const again = await b.store.createProposal({ content: "same text", baseHash: "h", baseContent: "c" });
+      expect(again.id).toBe(a.id);
+      expect(await b.store.getProposal(a.id)).toMatchObject({ state: "pending" }); // never superseded by its own retry
+    });
+
     it("re-parking with the SAME id converges (idempotent retry), updating content and base", async () => {
       const { id } = await b.store.createProposal({ id: "p-fixed", content: "v1", baseHash: "h1", baseContent: "c1" });
       expect(id).toBe("p-fixed");

--- a/packages/core/test/channelContract.test.ts
+++ b/packages/core/test/channelContract.test.ts
@@ -78,17 +78,53 @@ for (const [name, make] of Object.entries(BACKENDS)) {
     beforeEach(() => (b = make()));
     afterEach(() => b.cleanup());
 
-    it("round-trips doc, canonical, and proposed (null when absent)", async () => {
+    it("round-trips doc and canonical (null when absent)", async () => {
       expect(await b.store.getCanonical()).toBeNull();
-      expect(await b.store.getProposed()).toBeNull();
       await b.store.saveDoc("# body");
       await b.store.setCanonical("# canon");
-      await b.store.setProposed("# proposed");
       expect(await b.store.loadDoc()).toBe("# body");
       expect(await b.store.getCanonical()).toBe("# canon");
-      expect(await b.store.getProposed()).toBe("# proposed");
-      await b.store.clearProposed();
-      expect(await b.store.getProposed()).toBeNull();
+    });
+
+    it("parks a proposal and reads it back as the pending row, by id and as mine", async () => {
+      expect(await b.store.myPendingProposal()).toBeNull();
+      const { id } = await b.store.createProposal({ content: "# proposed", baseHash: "h1", baseContent: "# canon" });
+      const mine = await b.store.myPendingProposal();
+      expect(mine).toMatchObject({ id, content: "# proposed", baseHash: "h1", baseContent: "# canon", state: "pending" });
+      expect(await b.store.getProposal(id)).toMatchObject({ id, state: "pending" });
+    });
+
+    it("re-parking with the SAME id converges (idempotent retry), updating content and base", async () => {
+      const { id } = await b.store.createProposal({ id: "p-fixed", content: "v1", baseHash: "h1", baseContent: "c1" });
+      expect(id).toBe("p-fixed");
+      await b.store.createProposal({ id: "p-fixed", content: "v2", baseHash: "h2", baseContent: "c2" });
+      expect(await b.store.myPendingProposal()).toMatchObject({ id: "p-fixed", content: "v2", baseHash: "h2" });
+    });
+
+    it("a NEW id supersedes the caller's own previous pending proposal — history is kept", async () => {
+      const a = await b.store.createProposal({ content: "first", baseHash: "h", baseContent: "c" });
+      const c = await b.store.createProposal({ content: "second", baseHash: "h", baseContent: "c" });
+      expect(await b.store.myPendingProposal()).toMatchObject({ id: c.id, content: "second" });
+      expect(await b.store.getProposal(a.id)).toMatchObject({ state: "superseded", content: "first" });
+    });
+
+    it("deciding a pending proposal is terminal — later decisions, withdraws, and re-parks are no-ops on it", async () => {
+      const { id } = await b.store.createProposal({ content: "v1", baseHash: "h", baseContent: "c" });
+      await b.store.decideProposal(id, "accepted");
+      expect(await b.store.getProposal(id)).toMatchObject({ state: "accepted" });
+      expect((await b.store.getProposal(id))?.decidedAt).toBeTruthy();
+      await b.store.decideProposal(id, "rejected"); // immutable
+      await b.store.withdrawProposal(id); // immutable
+      await b.store.createProposal({ id, content: "sneaky rewrite", baseHash: "h2", baseContent: "c2" });
+      expect(await b.store.getProposal(id)).toMatchObject({ state: "accepted", content: "v1" });
+      expect(await b.store.myPendingProposal()).toBeNull(); // the decided row never reappears as pending
+    });
+
+    it("withdraw retracts the caller's own pending proposal", async () => {
+      const { id } = await b.store.createProposal({ content: "v1", baseHash: "h", baseContent: "c" });
+      await b.store.withdrawProposal(id);
+      expect(await b.store.getProposal(id)).toMatchObject({ state: "withdrawn" });
+      expect(await b.store.myPendingProposal()).toBeNull();
     });
   });
 }

--- a/packages/core/test/fsBackend.test.ts
+++ b/packages/core/test/fsBackend.test.ts
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { FsControlChannel, FsDocumentStore, LogEventType, type FsBackendPaths } from "../src/node";
 
@@ -96,6 +96,31 @@ describe("FsDocumentStore", () => {
     await reopened.decideProposal(id, "rejected");
     expect(await new FsDocumentStore(paths).getProposal(id)).toMatchObject({ state: "rejected" });
     expect(await new FsDocumentStore(paths).myPendingProposal()).toBeNull();
+  });
+
+  it("a rows file with valid JSON but invalid row shapes is quarantined — and the pending park recovers via the derived file", async () => {
+    const store = new FsDocumentStore(paths);
+    const a = await store.createProposal({ content: "good", baseHash: "h", baseContent: "c" });
+    const rowsPath = `${paths.proposedPath}.rows.json`;
+    writeFileSync(rowsPath, JSON.stringify([{ id: a.id, state: "pending" }])); // shape-invalid rows
+    const recovered = await store.myPendingProposal();
+    // Invalid lifecycle rows are never served: the file is preserved aside as evidence, and the
+    // derived pending-content file (which only exists while something is pending) is ADOPTED — the
+    // park survives with its content intact under a fresh identity.
+    expect(readdirSync(dirname(rowsPath)).some((f) => f.includes(".rows.json.corrupt-"))).toBe(true);
+    expect(recovered).toMatchObject({ content: "good", state: "pending" });
+    expect(recovered?.id).not.toBe(a.id);
+  });
+
+  it("a legacy pre-rows proposedPath park is ADOPTED as a real pending row with a stable identity", async () => {
+    writeFileSync(paths.proposedPath, "legacy parked content");
+    const store = new FsDocumentStore(paths);
+    const adopted = await store.myPendingProposal();
+    expect(adopted).toMatchObject({ content: "legacy parked content", state: "pending" });
+    expect((await store.myPendingProposal())?.id).toBe(adopted?.id); // identity is stable across reads
+    await store.withdrawProposal(adopted!.id); // the full lifecycle applies to it now
+    expect(await store.myPendingProposal()).toBeNull();
+    expect(existsSync(paths.proposedPath)).toBe(false); // the derived file follows the lifecycle
   });
 
   it("caps autosave backups at the retention limit", async () => {

--- a/packages/core/test/fsBackend.test.ts
+++ b/packages/core/test/fsBackend.test.ts
@@ -82,18 +82,20 @@ describe("FsControlChannel", () => {
 });
 
 describe("FsDocumentStore", () => {
-  it("round-trips doc, canonical, and proposed (null when absent)", async () => {
+  it("round-trips doc and canonical; a parked proposal survives a NEW STORE INSTANCE (durability)", async () => {
     const store = new FsDocumentStore(paths);
     expect(await store.getCanonical()).toBeNull();
-    expect(await store.getProposed()).toBeNull();
     await store.saveDoc("# body");
     await store.setCanonical("# canon");
-    await store.setProposed("# proposed");
+    const { id } = await store.createProposal({ content: "# proposed", baseHash: "h", baseContent: "# canon" });
     expect(await store.loadDoc()).toBe("# body");
     expect(await store.getCanonical()).toBe("# canon");
-    expect(await store.getProposed()).toBe("# proposed");
-    await store.clearProposed();
-    expect(await store.getProposed()).toBeNull();
+    // The rows persist on disk — a fresh instance (a later process) sees the same state.
+    const reopened = new FsDocumentStore(paths);
+    expect(await reopened.myPendingProposal()).toMatchObject({ id, content: "# proposed", state: "pending" });
+    await reopened.decideProposal(id, "rejected");
+    expect(await new FsDocumentStore(paths).getProposal(id)).toMatchObject({ state: "rejected" });
+    expect(await new FsDocumentStore(paths).myPendingProposal()).toBeNull();
   });
 
   it("caps autosave backups at the retention limit", async () => {

--- a/packages/renderer/src/App.tsx
+++ b/packages/renderer/src/App.tsx
@@ -1301,7 +1301,7 @@ export function App(props: EditorProps = {}): JSX.Element {
       } else {
         void hostApi().save(serialized, { kind: "apply", cadence }).then(() => setCheckpoint(serialized));
       }
-      void hostApi().clearProposal();
+      void hostApi().clearProposal(acceptedCount === accepted.length ? "accepted" : acceptedCount === 0 ? "rejected" : "partially_accepted");
       void hostApi().logAction(acceptedCount === accepted.length ? "revision_accepted_all" : acceptedCount === 0 ? "revision_rejected_all" : "revision_hunk_accepted", { accepted: acceptedCount, total: accepted.length });
       setStatus(`applied agent revision (${acceptedCount}/${accepted.length} hunks)`);
     },

--- a/packages/renderer/src/App.tsx
+++ b/packages/renderer/src/App.tsx
@@ -1304,7 +1304,12 @@ export function App(props: EditorProps = {}): JSX.Element {
       } else {
         void hostApi().save(serialized, { kind: "apply", cadence }).then(() => setCheckpoint(serialized));
       }
-      void hostApi().clearProposal(acceptedCount === accepted.length ? "accepted" : acceptedCount === 0 ? "rejected" : "partially_accepted", proposal.id);
+      // A failed settlement must be visible: the content is applied and the review UI is gone, but
+      // the row stays pending and WILL resurface for review on the next launch — announce that
+      // (the resurfacing is the retry) instead of letting it look like a mystery double-review.
+      hostApi()
+        .clearProposal(acceptedCount === accepted.length ? "accepted" : acceptedCount === 0 ? "rejected" : "partially_accepted", proposal.id)
+        .catch(() => setStatus("the decision could not be recorded — this proposal will reappear for review"));
       void hostApi().logAction(acceptedCount === accepted.length ? "revision_accepted_all" : acceptedCount === 0 ? "revision_rejected_all" : "revision_hunk_accepted", { accepted: acceptedCount, total: accepted.length });
       setStatus(`applied agent revision (${acceptedCount}/${accepted.length} hunks)`);
     },

--- a/packages/renderer/src/App.tsx
+++ b/packages/renderer/src/App.tsx
@@ -162,6 +162,9 @@ interface OrderedThread {
 }
 
 interface Proposal {
+  /** The proposal row's id (proposals v1) — the decision must settle THIS proposal, not
+   *  whichever row happens to be pending by then. Absent only on legacy hosts. */
+  id?: string;
   baseBody: string;
   next: ParsedDocument;
 }
@@ -334,10 +337,10 @@ export function App(props: EditorProps = {}): JSX.Element {
 
   // --- load + agent signals ---
   useEffect(() => {
-    const showProposal = (content: string) => {
-      // The agent's version is parked in `.proposed.md`; review it against the
+    const showProposal = (content: string, id?: string) => {
+      // The agent's version is parked as a proposal row; review it against the
       // current (canonical) body. The working doc stays unchanged until Apply.
-      setProposal({ baseBody: docRef.current.body, next: parse(content) });
+      setProposal({ ...(id ? { id } : {}), baseBody: docRef.current.body, next: parse(content) });
       setReviewOpen(true);
       setAgentThinking(false);
       setStatus(t("msg.proposedReview"));
@@ -360,7 +363,7 @@ export function App(props: EditorProps = {}): JSX.Element {
         setLoaded(true);
         // Durable re-show: if a proposal was parked (e.g. the app was closed
         // mid-review), surface it again rather than silently accepting it.
-        void hostApi().getProposal().then((parked) => parked != null && showProposal(parked));
+        void hostApi().getProposal().then((parked) => parked != null && showProposal(parked.content, parked.id));
       })
       .catch(() => setLoaded(true));
 
@@ -388,7 +391,7 @@ export function App(props: EditorProps = {}): JSX.Element {
         setStatus(t("msg.agentUpdated"));
       }),
       // Review-mode body changes arrive parked, as a proposal to accept/reject.
-      hostApi().onProposal(({ content }) => showProposal(content)),
+      hostApi().onProposal(({ content, id }) => showProposal(content, id)),
       hostApi().onAgentDone(() => setAgentDone(true)),
       hostApi().onReload(() => {
         setReloadReady(true);
@@ -431,7 +434,7 @@ export function App(props: EditorProps = {}): JSX.Element {
         setAgentMessages([]); // notes belong to the doc we just left — don't carry them over
         setActivePreviewLine(null); // a synced line belongs to the doc we just left, not this one
         setStatus(`opened ${path.split("/").pop() ?? path}`);
-        void hostApi().getProposal().then((parked) => parked != null && showProposal(parked));
+        void hostApi().getProposal().then((parked) => parked != null && showProposal(parked.content, parked.id));
       }),
       hostApi().onNavState?.((s) => setNavState(s)),
       // Desktop only: a newer npm version is available.
@@ -1301,7 +1304,7 @@ export function App(props: EditorProps = {}): JSX.Element {
       } else {
         void hostApi().save(serialized, { kind: "apply", cadence }).then(() => setCheckpoint(serialized));
       }
-      void hostApi().clearProposal(acceptedCount === accepted.length ? "accepted" : acceptedCount === 0 ? "rejected" : "partially_accepted");
+      void hostApi().clearProposal(acceptedCount === accepted.length ? "accepted" : acceptedCount === 0 ? "rejected" : "partially_accepted", proposal.id);
       void hostApi().logAction(acceptedCount === accepted.length ? "revision_accepted_all" : acceptedCount === 0 ? "revision_rejected_all" : "revision_hunk_accepted", { accepted: acceptedCount, total: accepted.length });
       setStatus(`applied agent revision (${acceptedCount}/${accepted.length} hunks)`);
     },

--- a/packages/renderer/src/api.ts
+++ b/packages/renderer/src/api.ts
@@ -296,8 +296,9 @@ export interface Api {
   closeWindow(): Promise<void>;
   /** Read the parked Review-mode proposal pending decision (null if none) — for durable re-show on launch. */
   getProposal(): Promise<string | null>;
-  /** Discard the parked proposal after the human accepts/rejects it. */
-  clearProposal(): Promise<void>;
+  /** Settle the parked proposal after the human decides. The outcome is recorded on the
+   *  proposal itself (proposals v1); omitted = legacy callers, treated as accepted. */
+  clearProposal(outcome?: "accepted" | "partially_accepted" | "rejected"): Promise<void>;
   /** A Review-mode proposal was parked by the agent this session — surface it for review. */
   onProposal(cb: (payload: { content: string }) => void): () => void;
   /**

--- a/packages/renderer/src/api.ts
+++ b/packages/renderer/src/api.ts
@@ -295,12 +295,12 @@ export interface Api {
   /** Close the editor window (used by the reload countdown's auto-close). */
   closeWindow(): Promise<void>;
   /** Read the parked Review-mode proposal pending decision (null if none) — for durable re-show on launch. */
-  getProposal(): Promise<string | null>;
+  getProposal(): Promise<{ id?: string; content: string } | null>;
   /** Settle the parked proposal after the human decides. The outcome is recorded on the
    *  proposal itself (proposals v1); omitted = legacy callers, treated as accepted. */
-  clearProposal(outcome?: "accepted" | "partially_accepted" | "rejected"): Promise<void>;
+  clearProposal(outcome?: "accepted" | "partially_accepted" | "rejected", id?: string): Promise<void>;
   /** A Review-mode proposal was parked by the agent this session — surface it for review. */
-  onProposal(cb: (payload: { content: string }) => void): () => void;
+  onProposal(cb: (payload: { content: string; id?: string }) => void): () => void;
   /**
    * Open another document by its resolved path (a relative Markdown link, joined
    * against this doc's path). Local: the sibling file; web: /docs/<org>/<repo>/<path>.

--- a/packages/renderer/src/memoryApi.ts
+++ b/packages/renderer/src/memoryApi.ts
@@ -11,6 +11,17 @@
 // raced by a working-file watcher — the Review-mode adopt race can't occur here.
 
 import { LogEventType, MemoryControlChannel, MemoryDocumentStore, type LogEntry } from "@inplan/core";
+
+// Browser-safe content hash for the harness's proposal metadata (core's hashBody is sha256 via
+// node:crypto, unavailable here; the harness only needs a stable fingerprint, not crypto).
+function harnessHash(text: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < text.length; i++) {
+    h ^= text.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return `fnv1a-${(h >>> 0).toString(16)}`;
+}
 import type { Acceptance, Api, Cadence, DocPayload, SaveOptions, Settings } from "./api";
 import type { ModePolicy } from "./mode";
 
@@ -19,7 +30,9 @@ export interface MemoryAgent {
   /** Auto-accept: the agent rewrote the document (fires onExternalChange). */
   externalChange(content: string): void;
   /** Review mode: park a proposed revision (fires onProposal; getProposal returns it). */
-  proposeRevision(content: string): void;
+  /** Park a Review-mode proposal. The review banner surfaces synchronously; the returned
+   *  promise settles when the proposal row + event are durably recorded. */
+  proposeRevision(content: string): Promise<void>;
   /** The agent re-engaged this round (clears the editor's "thinking" state). */
   markActive(): void;
   /** The agent suggests the plan is ready. */
@@ -130,10 +143,11 @@ export function createMemoryApi(opts: { content: string; settings?: Settings; ba
       closed = true;
     },
     async getProposal(): Promise<string | null> {
-      return store.getProposed();
+      return (await store.myPendingProposal())?.content ?? null;
     },
-    async clearProposal(): Promise<void> {
-      await store.clearProposed();
+    async clearProposal(outcome?: "accepted" | "partially_accepted" | "rejected"): Promise<void> {
+      const mine = await store.myPendingProposal();
+      if (mine) await store.decideProposal(mine.id, outcome ?? "accepted");
     },
     async openDoc(): Promise<void> {
       /* in-memory harness: no navigation */
@@ -148,9 +162,13 @@ export function createMemoryApi(opts: { content: string; settings?: Settings; ba
       for (const cb of external) cb({ path: "memory://doc", content });
     },
     proposeRevision(content: string) {
-      void store.setProposed(content);
-      void channel.append({ actor: "agent", type: LogEventType.AgentRevisionProposed, payload: { bytes: content.length } });
+      // Surface synchronously (the review banner must not lag the call), persist behind it.
       for (const cb of proposal) cb({ content });
+      return (async () => {
+        const base = (await store.getCanonical()) ?? (await store.loadDoc());
+        const { id } = await store.createProposal({ content, baseHash: harnessHash(base), baseContent: base });
+        await channel.append({ actor: "agent", type: LogEventType.AgentRevisionProposed, payload: { bytes: content.length, hash: harnessHash(content), proposal_id: id } });
+      })();
     },
     markActive() {
       void channel.append({ actor: "agent", type: LogEventType.AgentRevised });

--- a/packages/renderer/src/memoryApi.ts
+++ b/packages/renderer/src/memoryApi.ts
@@ -12,9 +12,15 @@
 
 import { LogEventType, MemoryControlChannel, MemoryDocumentStore, type LogEntry } from "@inplan/core";
 
-// Browser-safe content hash for the harness's proposal metadata (core's hashBody is sha256 via
-// node:crypto, unavailable here; the harness only needs a stable fingerprint, not crypto).
-function harnessHash(text: string): string {
+// Browser-safe sha-256 hex, matching core's node-only hashBody byte for byte so the harness's
+// proposal metadata is format-compatible with what durable stores and the CLI record. Falls back
+// to a marked FNV fingerprint only where WebCrypto is missing entirely.
+async function harnessHash(text: string): Promise<string> {
+  const subtle = (globalThis as { crypto?: { subtle?: SubtleCrypto } }).crypto?.subtle;
+  if (subtle) {
+    const digest = await subtle.digest("SHA-256", new TextEncoder().encode(text));
+    return Array.from(new Uint8Array(digest), (b) => b.toString(16).padStart(2, "0")).join("");
+  }
   let h = 0x811c9dc5;
   for (let i = 0; i < text.length; i++) {
     h ^= text.charCodeAt(i);
@@ -167,8 +173,8 @@ export function createMemoryApi(opts: { content: string; settings?: Settings; ba
     proposeRevision(content: string) {
       return (async () => {
         const base = (await store.getCanonical()) ?? (await store.loadDoc());
-        const { id } = await store.createProposal({ content, baseHash: harnessHash(base), baseContent: base });
-        await channel.append({ actor: "agent", type: LogEventType.AgentRevisionProposed, payload: { bytes: content.length, hash: harnessHash(content), proposal_id: id } });
+        const { id } = await store.createProposal({ content, baseHash: await harnessHash(base), baseContent: base });
+        await channel.append({ actor: "agent", type: LogEventType.AgentRevisionProposed, payload: { bytes: content.length, hash: await harnessHash(content), proposal_id: id } });
         // Surfaced AFTER the row exists so the payload carries the identity the decision needs.
         for (const cb of proposal) cb({ content, id });
       })();

--- a/packages/renderer/src/memoryApi.ts
+++ b/packages/renderer/src/memoryApi.ts
@@ -36,8 +36,9 @@ export interface MemoryAgent {
   /** Auto-accept: the agent rewrote the document (fires onExternalChange). */
   externalChange(content: string): void;
   /** Review mode: park a proposed revision (fires onProposal; getProposal returns it). */
-  /** Park a Review-mode proposal. The review banner surfaces synchronously; the returned
-   *  promise settles when the proposal row + event are durably recorded. */
+  /** Park a Review-mode proposal. The returned promise settles once the proposal row and its
+   *  event are durably recorded — the review banner surfaces at that point (after persistence),
+   *  carrying the row's identity. */
   proposeRevision(content: string): Promise<void>;
   /** The agent re-engaged this round (clears the editor's "thinking" state). */
   markActive(): void;
@@ -174,7 +175,7 @@ export function createMemoryApi(opts: { content: string; settings?: Settings; ba
       return (async () => {
         const base = (await store.getCanonical()) ?? (await store.loadDoc());
         const { id } = await store.createProposal({ content, baseHash: await harnessHash(base), baseContent: base });
-        await channel.append({ actor: "agent", type: LogEventType.AgentRevisionProposed, payload: { bytes: content.length, hash: await harnessHash(content), proposal_id: id } });
+        await channel.append({ actor: "agent", type: LogEventType.AgentRevisionProposed, payload: { bytes: new TextEncoder().encode(content).byteLength, hash: await harnessHash(content), proposal_id: id } });
         // Surfaced AFTER the row exists so the payload carries the identity the decision needs.
         for (const cb of proposal) cb({ content, id });
       })();

--- a/packages/renderer/src/memoryApi.ts
+++ b/packages/renderer/src/memoryApi.ts
@@ -69,7 +69,7 @@ export function createMemoryApi(opts: { content: string; settings?: Settings; ba
   const telemetryEvents: MemorySession["telemetryEvents"] = [];
 
   const external: Array<(p: DocPayload) => void> = [];
-  const proposal: Array<(p: { content: string }) => void> = [];
+  const proposal: Array<(p: { content: string; id?: string }) => void> = [];
   const done: Array<() => void> = [];
   const active: Array<() => void> = [];
   const reload: Array<() => void> = [];
@@ -142,12 +142,15 @@ export function createMemoryApi(opts: { content: string; settings?: Settings; ba
     async closeWindow(): Promise<void> {
       closed = true;
     },
-    async getProposal(): Promise<string | null> {
-      return (await store.myPendingProposal())?.content ?? null;
-    },
-    async clearProposal(outcome?: "accepted" | "partially_accepted" | "rejected"): Promise<void> {
+    async getProposal(): Promise<{ id?: string; content: string } | null> {
       const mine = await store.myPendingProposal();
-      if (mine) await store.decideProposal(mine.id, outcome ?? "accepted");
+      return mine ? { id: mine.id, content: mine.content } : null;
+    },
+    async clearProposal(outcome?: "accepted" | "partially_accepted" | "rejected", id?: string): Promise<void> {
+      // Settle the EXACT reviewed proposal when its id is known — deciding a row that has since
+      // been superseded is a state-guarded no-op, which beats landing the outcome on a newer row.
+      const target = id ?? (await store.myPendingProposal())?.id;
+      if (target) await store.decideProposal(target, outcome ?? "accepted");
     },
     async openDoc(): Promise<void> {
       /* in-memory harness: no navigation */
@@ -162,12 +165,12 @@ export function createMemoryApi(opts: { content: string; settings?: Settings; ba
       for (const cb of external) cb({ path: "memory://doc", content });
     },
     proposeRevision(content: string) {
-      // Surface synchronously (the review banner must not lag the call), persist behind it.
-      for (const cb of proposal) cb({ content });
       return (async () => {
         const base = (await store.getCanonical()) ?? (await store.loadDoc());
         const { id } = await store.createProposal({ content, baseHash: harnessHash(base), baseContent: base });
         await channel.append({ actor: "agent", type: LogEventType.AgentRevisionProposed, payload: { bytes: content.length, hash: harnessHash(content), proposal_id: id } });
+        // Surfaced AFTER the row exists so the payload carries the identity the decision needs.
+        for (const cb of proposal) cb({ content, id });
       })();
     },
     markActive() {

--- a/packages/renderer/test/App.reviewDiff.test.tsx
+++ b/packages/renderer/test/App.reviewDiff.test.tsx
@@ -30,7 +30,7 @@ const REVISED = "# Plan\n\nAlpha CHANGED.\n\nBeta CHANGED.\n\n<!--inplan v1\n[]\
 let agent: MemoryAgent;
 
 type Win = {
-  api: { getProposal(): Promise<string | null> };
+  api: { getProposal(): Promise<{ id?: string; content: string } | null> };
 };
 
 function mount(content: string) {
@@ -274,6 +274,6 @@ describe("App review diff controls (memory-backed)", () => {
     await waitFor(() => expect(document.body.textContent).toContain("Agent proposed changes"));
     expect(document.body.textContent).not.toContain("awaiting your review.");
     // The proposal is still parked (not yet decided).
-    expect(await (window as unknown as Win).api.getProposal()).toBe(REVISED);
+    expect((await (window as unknown as Win).api.getProposal())?.content).toBe(REVISED);
   });
 });

--- a/packages/renderer/test/memoryApi.test.ts
+++ b/packages/renderer/test/memoryApi.test.ts
@@ -16,7 +16,7 @@ describe("createMemoryApi", () => {
     let surfaced: string | null = null;
     api.onProposal((p) => (surfaced = p.content));
 
-    agent.proposeRevision("# Plan\n\nnew");
+    await agent.proposeRevision("# Plan\n\nnew");
     expect(surfaced).toBe("# Plan\n\nnew"); // onProposal fired with the proposed content
     expect(await api.getProposal()).toBe("# Plan\n\nnew"); // durable, re-readable
 

--- a/packages/renderer/test/memoryApi.test.ts
+++ b/packages/renderer/test/memoryApi.test.ts
@@ -18,7 +18,7 @@ describe("createMemoryApi", () => {
 
     await agent.proposeRevision("# Plan\n\nnew");
     expect(surfaced).toBe("# Plan\n\nnew"); // onProposal fired with the proposed content
-    expect(await api.getProposal()).toBe("# Plan\n\nnew"); // durable, re-readable
+    expect((await api.getProposal())?.content).toBe("# Plan\n\nnew"); // durable, re-readable (with its row id)
 
     // Accepting = a silent "apply" save: writes canonical, does NOT wake the agent.
     await api.save("# Plan\n\nnew", { kind: "apply", cadence: "turn" });


### PR DESCRIPTION
Proposals get first-class identity: a proposal stops being a bare text slot and becomes an object with identity, proposer, base, and a terminal-immutable state — the substrate for multi-agent safety and for deleting the landing-signal's inferential machinery in a follow-up.

**What a proposal becomes:** an object with a client-minted id, content, base hash AND base content (a 3-way merge at review time must never depend on a version checkpoint existing), and a terminal-immutable state (`pending → accepted / partially_accepted / rejected / superseded / withdrawn`).

**The store surface** replaces `getProposed`/`setProposed`/`clearProposed`:
- `createProposal` — upsert by id: the same id converges (a retried park is idempotent even across a lost response — `getProposal(id)` then answers definitively whether the earlier push landed), a new id supersedes the caller's OWN pending proposal, never anyone else's.
- `myPendingProposal` / `getProposal(id)` — the landing signal as one lookup.
- `withdrawProposal` / `decideProposal` — decisions land on the row; terminal states are immutable.

**Implementations:** memory, fs sidecar (atomically published rows JSON; the legacy `proposedPath` stays as the derived pending-content file so the desktop's file-exists logic keeps working), and Supabase against a `proposals` table — with converge-if-pending BEFORE insert, because a plain upsert would resurrect a decided row back to `pending` (caught by the contract suite against the fake client).

**Contracts:** the shared store contract suites (core + backend-supabase) pin idempotent same-id re-park, supersede-own-only, terminal immutability against decisions/withdraws/re-parks, and fs durability across store instances.

**Events + decisions:** `agent_revision_proposed` carries `proposal_id` at every append site; the renderer's `clearProposal` now carries the human's outcome through the desktop IPC and the memory harness to `decideProposal`.

**CLI:** mechanical, behavior-preserving adaptation only — the inferential machinery still runs and is deleted in a follow-up once every backing store serves the row surface. Full workspace green: 1283 tests, all packages typechecking.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/98?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Proposals now have stable IDs and support full lifecycle tracking: pending, withdrawn, accepted, partially accepted, or rejected.
  * Proposal decisions persist across sessions and synchronize across every backing store.
  * Retried proposals are handled safely without creating duplicates.
  * Parked edits can be withdrawn when applied directly.
* **Bug Fixes**
  * Prevented completed proposals from being overwritten or restored.
  * Improved recovery when proposal creation or synchronization fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

