### PR TITLE
the landing signal is a lookup, not an inference

### DIFF
--- a/packages/cli/src/applyEdit.ts
+++ b/packages/cli/src/applyEdit.ts
@@ -27,7 +27,7 @@ export async function applyGatedEdit(
   channel: ControlChannel,
   ev: AgentEditEvaluation,
   ctx: { current: string; canonicalText: string; quarantine: boolean; gate: PluginGate | null },
-): Promise<{ proposed: boolean; parkFailed?: boolean; eventLogged?: boolean }> {
+): Promise<{ proposed: boolean; proposalId?: string; parkFailed?: boolean; eventLogged?: boolean }> {
   const { current, canonicalText, quarantine, gate } = ctx;
   if (ev.removedIds.length > 0) {
     // Confirmed deletions: drop the orphaned comment objects. On the plugin path push the result
@@ -58,7 +58,7 @@ export async function applyGatedEdit(
       // contain its post-commit failures itself — the cloud proposal is live and the human can
       // see it, so surfacing that partial failure here would misreport a real park as a failed
       // push. The gateStore does exactly that: it swallows the local record-write failure and
-      // relies on slot reconciliation at the next attach.
+      // relies on row reconciliation at the next attach.
       return { proposed: false, parkFailed: true };
     }
     // From here the park is REAL — the store holds the proposal (and on the remote path the
@@ -77,18 +77,18 @@ export async function applyGatedEdit(
       await channel.append({
         actor: "agent",
         type: LogEventType.AgentRevisionProposed,
-        // The hash identifies WHICH proposal this event parked, so a later resolution can bind
-        // decision events to this exact proposal (not merely the doc's latest park).
+        // proposal_id names WHICH proposal this event parked — the row/record id, the same one
+        // the wait output carries. bytes/hash stay as human-auditable descriptors of the text.
         payload: { bytes: utf8Bytes(current), hash: hashBody(current), proposal_id: proposalId },
       });
     } catch {
-      // The park stands without its event; resolution falls back to its lesser anchors, which is
-      // exactly what those fallbacks exist for. Report it, though: the event is also what nudges
-      // a live editor to show the review panel, so the caller should tell the agent the proposal
-      // may stay invisible to the human until their editor next reloads.
-      return { proposed: true, eventLogged: false };
+      // The park stands without its event — the proposal row/record is the durable signal now.
+      // Report it, though: the event is also what nudges a live editor to show the review panel,
+      // so the caller should tell the agent the proposal may stay invisible to the human until
+      // their editor next reloads.
+      return { proposed: true, proposalId, eventLogged: false };
     }
-    return { proposed: true };
+    return { proposed: true, proposalId };
   } else if (ev.changed) {
     // Auto-accept (auto mode, or review mode with comment-only changes): advance the base. On the
     // plugin path that means pushing into the plugin's doc; otherwise advance the persisted canonical.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -39,7 +39,7 @@ import { addComment, AddCommentError } from "./commentAdd";
 import { docPaths, sidecarRoot, type DocPaths } from "./paths";
 import { loadPluginGate, loadPluginGateOutcome, resolveHubUrl, type PluginAbsenceReason, type PluginGate } from "./pluginGate";
 import { demoteSource, shouldHydrateWorkFile, pendingRequiresReplay, postTurnAction, trackGateDegradations, type WaitOutcome } from "./liveSync";
-import { RemoteDocState, isDecidedProposalCorpse, needsReparkFromSlot, resolutionFromEvents, utf8Bytes, type ProposalOutcome } from "./remoteDocState";
+import { RemoteDocState, isDecidedProposalCorpse, utf8Bytes } from "./remoteDocState";
 import { announcePresence, presenceTokenResolver } from "./presence";
 import { awaitReopen, wakePredicate, waitForActions } from "./wait";
 import { versionFromModule } from "./version";
@@ -351,7 +351,7 @@ export interface WaitBackend {
    *  and that event wakes the wait, this runs instead of the normal status output
    *  and is responsible for emitting its own result — including the turn's landing
    *  signal, passed through `info`, so the handoff can't hide a parked proposal. */
-  onSaveLocally?: (info: { proposal?: { state: "pending_review" | "park_failed"; bytes: number; hash: string } }) => Promise<void>;
+  onSaveLocally?: (info: { proposal?: { state: "pending_review" | "park_failed"; id?: string; bytes: number; hash: string } }) => Promise<void>;
 }
 
 /** Local sidecar-file backend for a document on disk. */
@@ -459,11 +459,15 @@ export async function waitCycle(backend: WaitBackend, explicitCursor: number | n
   // including wait_failed and superseded, where mistaking a parked edit for a failed sync is
   // exactly the misread this field exists to prevent. A FAILED park is machine-readable too
   // (state "park_failed"): an agent parsing only the JSON must never read a failed push as a
-  // no-change turn — stderr alone is not a signal contract.
-  const proposalOut: { proposal?: { state: "pending_review" | "park_failed"; bytes: number; hash: string } } = applied.proposed
-    ? { proposal: { state: "pending_review", bytes: utf8Bytes(current), hash: hashBody(current) } }
+  // no-change turn — stderr alone is not a signal contract. The id makes the later audit a
+  // lookup (getProposal / the .proposed.json record share it); a failed park has no confirmed
+  // identity of its own, so it carries the STILL-PENDING prior proposal's id when one exists
+  // (the failed re-push left that proposal live) and omits the field otherwise.
+  const parkFailedId = applied.parkFailed ? await store.myPendingProposal().then((r) => r?.id, () => undefined) : undefined;
+  const proposalOut: { proposal?: { state: "pending_review" | "park_failed"; id?: string; bytes: number; hash: string } } = applied.proposed
+    ? { proposal: { state: "pending_review", ...(applied.proposalId ? { id: applied.proposalId } : {}), bytes: utf8Bytes(current), hash: hashBody(current) } }
     : applied.parkFailed
-      ? { proposal: { state: "park_failed", bytes: utf8Bytes(current), hash: hashBody(current) } }
+      ? { proposal: { state: "park_failed", ...(parkFailedId ? { id: parkFailedId } : {}), bytes: utf8Bytes(current), hash: hashBody(current) } }
       : {};
 
   // Signal the agent has (re)engaged this round so the editor can clear its
@@ -1186,77 +1190,59 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
       exitAfterFlush(EXIT_PLUGIN_UNAVAILABLE);
       return; // the `finally` below tears presence down on the way out
     }
-    // A proposal parked on an EARLIER run resolves here (#88): if the cloud's proposed slot has
-    // emptied, the human decided — finalize the record with the outcome the decision events name
-    // (accepted / partially_accepted / rejected), so "did my edit land?" stays answerable from
-    // disk even though agent_revision_proposed left the wait output long ago. A transient slot
-    // read failure just retries next run; the record stays pending.
-    // Reconcile with the CLOUD slot first (#88): the slot is the authoritative side of a park, so
-    // a proposal it holds that this machine has no live record of (a crash between the confirmed
-    // push and the record publish, a re-park after a finalization) is re-parked from the slot's
-    // own text, recreating the truthful pending record. Then resolve a pending record whose slot
-    // has emptied: the decision events name the outcome; when none is readable yet, the record
-    // waits one more run (a slot-clear can race ahead of its decision event) before degrading to
-    // 'decided'. A transient slot read failure skips both — retry next run.
+    // A proposal parked on an EARLIER run resolves here (#88 → proposals v1): the local record's
+    // id IS the cloud row's id, so "did my edit land?" is a lookup, never an inference. My own
+    // pending ROW is the authoritative live side — a record this machine lost (a crash between
+    // the confirmed push and the record publish) is rebuilt from it; a pending record whose row
+    // has gone terminal mirrors the row's actual outcome verbatim. A transient read failure
+    // skips reconciliation — the record stays pending and the next attach retries.
     // Whether THIS attach transitioned a record pending → terminal. The corpse restore below is
     // gated on it: only a just-decided proposal's leftover text is a corpse — on any later attach
     // an identical working copy is a deliberate re-edit (an agent may legitimately re-propose
     // byte-identical content after a rejection), and overwriting it would destroy real work.
     let justFinalized = false;
-    const slotRow = await live.store.myPendingProposal().catch(() => undefined);
-    const slot = slotRow === undefined ? undefined : (slotRow?.content ?? null);
-    if (typeof slot === "string" && needsReparkFromSlot(rds.latestProposal(), slot)) {
+    const myRow = await live.store.myPendingProposal().catch(() => undefined); // undefined = unreadable this run
+    if (myRow !== undefined) {
       try {
-        // A pending record the slot no longer matches was DISPLACED while we were away — but not
-        // necessarily superseded: the human may have decided it before another machine parked the
-        // slot's new content. Resolve it from the decision events FIRST, so a real acceptance is
-        // never mislabeled. When no decision is readable, the record gets the same one-run grace
-        // as the empty-slot path (the decision event can lag the slot change) — the repark is
-        // deferred with it, and a still-unreadable outcome next run finalizes as 'superseded'.
-        const displaced = rds.pendingProposal();
-        let outcome: ProposalOutcome | null = "superseded";
-        if (displaced) {
-          try {
-            const { entries } = await live.channel.readSince(0);
-            const resolved = resolutionFromEvents(entries, displaced);
-            if (resolved !== "decided") outcome = resolved;
-            else if (!displaced.awaitingOutcomeSince) outcome = null; // first sighting — grace
-          } catch {
-            if (!displaced.awaitingOutcomeSince) outcome = null; // unreadable — same grace
-          }
-        }
-        if (displaced && outcome === null) {
-          rds.noteOutcomeMissing(); // defer both the finalization and the repark one run
-        } else {
-          if (displaced && outcome) {
-            const finalized = rds.resolveProposal(outcome);
+        const pending = rds.pendingProposal();
+        if (myRow && pending?.id !== myRow.id) {
+          // The cloud holds a pending proposal of mine this machine has no live record of. A
+          // DIFFERENT local pending record settles from ITS OWN row first — the human may have
+          // decided it before this newer proposal displaced it, and the row names which. A row
+          // that is missing (never created — the id was minted for a park whose push then took a
+          // fresh identity) or still pending finalizes as superseded: my one-pending-per-proposer
+          // row is now `myRow`, so the old record is displaced either way.
+          if (pending) {
+            const priorRow = await live.store.getProposal(pending.id).catch(() => null);
+            const finalized = rds.resolveProposal(priorRow && priorRow.state !== "pending" ? priorRow.state : "superseded");
             // Corpse-restore for the DISPLACED record must run HERE, against the record we just
-            // finalized: parking the slot's content below makes latestProposal() the NEW pending
-            // record, so the generic check after this block could never match — leaving a stale
-            // working copy that next turn would quarantine and push OVER the slot's proposal.
+            // finalized: adopting the row below makes latestProposal() the NEW pending record,
+            // so the generic check after this block could never match — leaving a stale working
+            // copy that next turn would quarantine and push OVER the row's proposal.
             if (finalized && !rds.replayPending() && isDecidedProposalCorpse(finalized, rds.readWorkFile())) {
               rds.writeWorkFile(canonical);
               rds.recordSynced(canonical);
             }
           }
-          rds.parkProposal(slot, undefined, slotRow!.id); // keep the CLOUD row's identity — a fresh local id would split them
+          rds.parkProposal(myRow.content, undefined, myRow.id); // adopt the row's identity — a fresh local id would split them
+        } else if (myRow && pending && pending.hash !== hashBody(myRow.content)) {
+          // Same identity, different content: the row is the pushed side of the pair — a crash
+          // after the push but before the record write left the record on the older text. The
+          // record follows the row in place (same id, converged content).
+          rds.parkProposal(myRow.content, undefined, myRow.id);
+        } else if (!myRow && pending) {
+          // No pending row of mine, but a pending local record: its row names the outcome.
+          // `null` (row gone — a legacy park with no row, or a purged doc) degrades to 'decided':
+          // the human acted, which way is unknowable. A row still pending under an identity
+          // myPendingProposal no longer matches is left alone — the next attach retries.
+          const row = await live.store.getProposal(pending.id).catch(() => undefined);
+          if (row === null) justFinalized = rds.resolveProposal("decided") !== null;
+          else if (row && row.state !== "pending") justFinalized = rds.resolveProposal(row.state) !== null;
         }
       } catch (e) {
         // Local persistence trouble must not stop the attach: the cloud proposal stays live and
         // reconciliation retries on the next run.
         process.stderr.write(`inplan: could not reconcile the local proposal record (${String(e)}); continuing — it will retry next run\n`);
-      }
-    }
-    const parkedEarlier = rds.pendingProposal();
-    if (parkedEarlier && slot === null) {
-      try {
-        const { entries } = await live.channel.readSince(0);
-        const outcome = resolutionFromEvents(entries, parkedEarlier);
-        if (outcome !== "decided") justFinalized = rds.resolveProposal(outcome) !== null;
-        else if (parkedEarlier.awaitingOutcomeSince) justFinalized = rds.resolveProposal("decided") !== null;
-        else rds.noteOutcomeMissing();
-      } catch {
-        /* transient history read failure: leave the record pending and retry next run */
       }
     }
 
@@ -1381,7 +1367,7 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
     // live.store isn't updated by gate.applyRevision, so reading it would write a stale doc. If
     // the hub read fails we throw BEFORE writing status, so the doc isn't switched to local.
     const onSaveLocallyGate = localFile
-      ? async (info: { proposal?: { state: "pending_review" | "park_failed"; bytes: number; hash: string } }) => {
+      ? async (info: { proposal?: { state: "pending_review" | "park_failed"; id?: string; bytes: number; hash: string } }) => {
           const body = await gate.readCanonical();
           // The handoff writes CANONICAL to the local file. A working copy diverging from the
           // last sync at this moment holds an edit that never reached the hub (e.g. this turn's

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1208,23 +1208,30 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
         if (myRow && pending?.id !== myRow.id) {
           // The cloud holds a pending proposal of mine this machine has no live record of. A
           // DIFFERENT local pending record settles from ITS OWN row first — the human may have
-          // decided it before this newer proposal displaced it, and the row names which. A row
-          // that is missing (never created — the id was minted for a park whose push then took a
+          // decided it before this newer proposal displaced it, and the row names which. Only a
+          // DEFINITIVE lookup may finalize: a transient failure (undefined) defers the whole
+          // reconciliation — finalizing on it could append an irreversible wrong outcome, and
+          // adopting the row would supersede the record locally through the park. A row that is
+          // definitively missing (null — the id was minted for a park whose push then took a
           // fresh identity) or still pending finalizes as superseded: my one-pending-per-proposer
           // row is now `myRow`, so the old record is displaced either way.
+          let settled = true;
           if (pending) {
-            const priorRow = await live.store.getProposal(pending.id).catch(() => null);
-            const finalized = rds.resolveProposal(priorRow && priorRow.state !== "pending" ? priorRow.state : "superseded");
-            // Corpse-restore for the DISPLACED record must run HERE, against the record we just
-            // finalized: adopting the row below makes latestProposal() the NEW pending record,
-            // so the generic check after this block could never match — leaving a stale working
-            // copy that next turn would quarantine and push OVER the row's proposal.
-            if (finalized && !rds.replayPending() && isDecidedProposalCorpse(finalized, rds.readWorkFile())) {
-              rds.writeWorkFile(canonical);
-              rds.recordSynced(canonical);
+            const priorRow = await live.store.getProposal(pending.id).catch(() => undefined);
+            if (priorRow === undefined) settled = false; // transient — retry the whole block next attach
+            else {
+              const finalized = rds.resolveProposal(priorRow && priorRow.state !== "pending" ? priorRow.state : "superseded");
+              // Corpse-restore for the DISPLACED record must run HERE, against the record we just
+              // finalized: adopting the row below makes latestProposal() the NEW pending record,
+              // so the generic check after this block could never match — leaving a stale working
+              // copy that next turn would quarantine and push OVER the row's proposal.
+              if (finalized && !rds.replayPending() && isDecidedProposalCorpse(finalized, rds.readWorkFile())) {
+                rds.writeWorkFile(canonical);
+                rds.recordSynced(canonical);
+              }
             }
           }
-          rds.parkProposal(myRow.content, undefined, myRow.id); // adopt the row's identity — a fresh local id would split them
+          if (settled) rds.parkProposal(myRow.content, undefined, myRow.id); // adopt the row's identity — a fresh local id would split them
         } else if (myRow && pending && pending.hash !== hashBody(myRow.content)) {
           // Same identity, different content: the row is the pushed side of the pair — a crash
           // after the push but before the record write left the record on the older text. The

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -352,6 +352,11 @@ export interface WaitBackend {
    *  and is responsible for emitting its own result — including the turn's landing
    *  signal, passed through `info`, so the handoff can't hide a parked proposal. */
   onSaveLocally?: (info: { proposal?: { state: "pending_review" | "park_failed"; id?: string; bytes: number; hash: string } }) => Promise<void>;
+  /** The still-pending prior proposal's id, from LOCAL state only — read when a park fails, to
+   *  name the proposal that remains live in the `park_failed` output. Must never touch the
+   *  network: the park just failed, so a remote read here would stall the failure report on the
+   *  very outage it is reporting. Unset (or undefined) simply omits the id. */
+  localPendingProposalId?: () => string | undefined;
 }
 
 /** Local sidecar-file backend for a document on disk. */
@@ -462,8 +467,10 @@ export async function waitCycle(backend: WaitBackend, explicitCursor: number | n
   // no-change turn — stderr alone is not a signal contract. The id makes the later audit a
   // lookup (getProposal / the .proposed.json record share it); a failed park has no confirmed
   // identity of its own, so it carries the STILL-PENDING prior proposal's id when one exists
-  // (the failed re-push left that proposal live) and omits the field otherwise.
-  const parkFailedId = applied.parkFailed ? await store.myPendingProposal().then((r) => r?.id, () => undefined) : undefined;
+  // (the failed re-push left that proposal live) and omits the field otherwise. The id comes
+  // from LOCAL state only (backend.localPendingProposalId) — never a remote read, which would
+  // stall the park_failed report on the very outage it is reporting.
+  const parkFailedId = applied.parkFailed ? backend.localPendingProposalId?.() : undefined;
   const proposalOut: { proposal?: { state: "pending_review" | "park_failed"; id?: string; bytes: number; hash: string } } = applied.proposed
     ? { proposal: { state: "pending_review", ...(applied.proposalId ? { id: applied.proposalId } : {}), bytes: utf8Bytes(current), hash: hashBody(current) } }
     : applied.parkFailed
@@ -1408,6 +1415,7 @@ async function runRemote(cmd: string, docId: string, explicitCursor: number | nu
         store: gateStore, // …the agent reads/edits a local working copy; proposals go to the cloud…
         history: async () => (await live.channel.readSince(0)).entries,
         logExit: () => {},
+        localPendingProposalId: () => rds.pendingProposal()?.id, // local file read only — see WaitBackend
         ...(onSaveLocallyGate ? { onSaveLocally: onSaveLocallyGate } : {}),
       },
       explicitCursor,

--- a/packages/cli/src/remoteDocState.ts
+++ b/packages/cli/src/remoteDocState.ts
@@ -22,18 +22,19 @@
 //    advertise a proposal without its text (or vice versa);
 //  - each park carries a unique `id`, so history idempotency and supersede detection never
 //    confuse two proposals that happen to share content;
-//  - anything this machine still misses after a crash is reconciled from the CLOUD's proposed
-//    slot at the next attach (see `needsReparkFromSlot`) — the slot is the authoritative side
-//    of the push, so it, not local heuristics, is the recovery source.
+//  - anything this machine still misses after a crash is reconciled from the CLOUD's proposal
+//    ROW at the next attach — the record's id is the row's id (proposals v1), so recovery is a
+//    lookup of the authoritative side, never a local heuristic.
 
 import { appendFileSync, closeSync, existsSync, fstatSync, mkdirSync, openSync, readFileSync, readSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
-import { hashBody, LogEventType, type LogEntry } from "@inplan/core/node";
+import { hashBody } from "@inplan/core/node";
 import type { HydrateInput } from "./liveSync";
 
-/** How a pending proposal ended. `decided` = the proposed slot emptied but no decision event was
- *  readable (the human acted; which way is unknown). `superseded` = a newer park replaced it;
- *  `withdrawn` = the agent retracted its own proposal (a direct-landing edit mooted it). */
+/** How a pending proposal ended. `accepted`/`partially_accepted`/`rejected`/`superseded`/
+ *  `withdrawn` mirror the cloud row's terminal state verbatim. `decided` = the row itself is
+ *  gone (a legacy or purged proposal with no row to name the outcome) — the human acted; which
+ *  way is unknown. */
 export type ProposalOutcome = "accepted" | "partially_accepted" | "rejected" | "decided" | "superseded" | "withdrawn";
 
 /** UTF-8 byte length — the one sizing used by the proposal record, the wait output's `proposal`
@@ -51,88 +52,11 @@ export interface ProposalRecord {
   /** ISO-8601 park time. */
   at: string;
   state: "pending_review" | ProposalOutcome;
-  /** Set when the cloud slot was seen empty but no decision event was readable yet — the record
-   *  stays pending for one more look before degrading to `decided`, so a slot-clear racing ahead
-   *  of its decision event can't permanently erase the real outcome. */
-  awaitingOutcomeSince?: string;
 }
 
 /** The persisted shape of `.proposed.json`: the record plus its exact text, one atomic unit. */
 interface StoredProposal extends ProposalRecord {
   text: string;
-}
-
-/**
- * Map decision events to THIS proposal's outcome, newest-first so the human's most recent decision
- * wins. Binding is by the log's own order, not the clock: the park appended
- * `agent_revision_proposed` carrying the proposal's hash, so the decision window is (this park's
- * event, the next park event] — decisions for a LATER proposal (parked and decided by another
- * machine while this one was offline) can never be misattributed to this record. When no event
- * carries this hash (the append failed, or an older CLI wrote no hash), the anchor degrades to
- * the newest park event that does not POSTDATE this record's park time — a later machine's park
- * must not become our window — and the timestamp filter stays on inside a weak window, preferring
- * a degraded "decided" over finalizing this record with another proposal's outcome.
- */
-export function resolutionFromEvents(entries: LogEntry[], park: { at: string; hash: string }): ProposalOutcome {
-  const parkedAt = Date.parse(park.at);
-  let start = -1;
-  let matched = false;
-  for (let i = entries.length - 1; i >= 0; i--) {
-    const e = entries[i]!;
-    if (e.type !== LogEventType.AgentRevisionProposed) continue;
-    // Any candidate — hash-matched or weak — must plausibly BE this park: an event stamped after
-    // our recorded park time (5s slack for CLI-vs-server clock disagreement) is someone else's
-    // LATER park, even when its content hash matches ours (identical text is not identity — a
-    // newer proposal repeating our text must not donate its decision window to this record).
-    const ts = Date.parse(e.ts);
-    if (Number.isFinite(parkedAt) && Number.isFinite(ts) && ts > parkedAt + 5_000) continue;
-    // A hash match must also not PREDATE us by more than clock skew plausibly allows (10 min —
-    // generous for unsynced clocks): an OLDER proposal that happened to carry identical content
-    // is not our park either, and binding to its event would hand us its decision. Outside the
-    // near window, an identical-hash event only qualifies as a weak anchor like any other park.
-    const nearOurPark = !Number.isFinite(parkedAt) || !Number.isFinite(ts) || ts >= parkedAt - 600_000;
-    if (nearOurPark && (e.payload as { hash?: unknown } | undefined)?.hash === park.hash) {
-      start = i;
-      matched = true;
-      break;
-    }
-    if (start < 0) start = i; // newest eligible park: the weak-anchor candidate
-  }
-  // The window closes at the NEXT park event after the anchor: decisions beyond it belong to a
-  // newer proposal. This applies even with NO anchor (every park event postdates us): the first
-  // park event still starts someone else's window, and a later proposal's decision carries a
-  // later timestamp too — the timestamp filter alone could not exclude it.
-  let end = entries.length;
-  for (let i = start + 1; i < entries.length; i++) {
-    if (entries[i]!.type === LogEventType.AgentRevisionProposed) {
-      end = i;
-      break;
-    }
-  }
-  for (let i = end - 1; i > start; i--) {
-    const e = entries[i]!;
-    if (!matched) {
-      const ts = Date.parse(e.ts);
-      if (Number.isFinite(parkedAt) && Number.isFinite(ts) && ts < parkedAt) break;
-    }
-    if (e.type === LogEventType.RevisionAcceptedAll) return "accepted";
-    if (e.type === LogEventType.RevisionRejectedAll) return "rejected";
-    if (e.type === LogEventType.RevisionHunkAccepted || e.type === LogEventType.RevisionHunkRejected) return "partially_accepted";
-  }
-  return "decided";
-}
-
-/**
- * Whether the CLOUD's proposed slot holds a proposal this machine has no live record of — the
- * reconciliation check run at attach. True when a slot exists but the latest local record is
- * absent, terminal, or about different content: whatever local write was lost (a crash between
- * the confirmed push and the record publish, a re-park of identical text after a finalization),
- * re-parking the slot's own text recreates the truthful pending record from the authoritative
- * side. Cheap and idempotent — a healthy pending record simply returns false.
- */
-export function needsReparkFromSlot(latest: ProposalRecord | null, slotText: string | null | undefined): boolean {
-  if (typeof slotText !== "string") return false;
-  return latest === null || latest.state !== "pending_review" || latest.hash !== hashBody(slotText);
 }
 
 /**
@@ -226,22 +150,12 @@ export class RemoteDocState {
       // Same identity, updated content (the cloud converge-if-pending path): the record follows
       // in place. Superseding here would finalize the id into the history and then republish the
       // SAME id as pending — breaking terminal immutability and corrupting the history.
-      // The grace marker never survives updated content: the slot is live again, so a later
-      // empty-slot sighting earns the full grace, not an immediate 'decided' off the old one.
-      const { awaitingOutcomeSince: _stale, ...rest } = prior;
-      const updated: ProposalRecord = { ...rest, hash, bytes: utf8Bytes(text), at: at.toISOString() };
+      const updated: ProposalRecord = { ...prior, hash, bytes: utf8Bytes(text), at: at.toISOString() };
       this.publish({ ...updated, text });
       return updated;
     }
     if (prior && prior.hash === hash && (id === undefined || id === prior.id)) {
-      // Same proposal, re-pushed. A stale awaiting-outcome marker must not survive the re-push:
-      // the slot is live again, so a later slot-clear deserves the full grace before degrading
-      // to 'decided', not an immediate finalization off the old sighting.
-      if (prior.awaitingOutcomeSince) {
-        const { awaitingOutcomeSince: _stale, ...rest } = prior;
-        this.publish({ ...rest, text });
-        return rest;
-      }
+      // Same proposal, re-pushed: keep the existing pending identity.
       this.writeDerivedText(text);
       return prior;
     }
@@ -282,20 +196,6 @@ export class RemoteDocState {
   }
 
   /**
-   * First sighting of "slot empty but no decision event readable yet": mark the record instead of
-   * finalizing, so a slot-clear that races ahead of its decision event gets one more run to
-   * surface the real outcome. Returns the updated record (or null when nothing is pending).
-   */
-  noteOutcomeMissing(at: Date = new Date()): ProposalRecord | null {
-    const stored = this.readStored();
-    if (!stored || stored.state !== "pending_review" || stored.awaitingOutcomeSince) return null;
-    const updated: StoredProposal = { ...stored, awaitingOutcomeSince: at.toISOString() };
-    this.publish(updated);
-    const { text: _text, ...record } = updated;
-    return record;
-  }
-
-  /**
    * Finalize the pending record with the human's decision: append it to the never-pruned history
    * log FIRST (metadata only — an accepted text's fate is canonical history's job), then
    * republish the record. A crash between the writes leaves the record pending, so the next
@@ -309,8 +209,7 @@ export class RemoteDocState {
   }
 
   private finalize(record: ProposalRecord, outcome: ProposalOutcome): ProposalRecord {
-    const { awaitingOutcomeSince: _grace, ...rest } = record;
-    const finalized: ProposalRecord = { ...rest, state: outcome };
+    const finalized: ProposalRecord = { ...record, state: outcome };
     // Idempotency is by identity AND outcome: a crash-retried finalization with the same result
     // appends nothing, but a retry that resolved to a DIFFERENT outcome appends the correction —
     // the history must never disagree with the record it claims to log.
@@ -345,16 +244,11 @@ export class RemoteDocState {
       const p = JSON.parse(readFileSync(this.recordPath, "utf8")) as Partial<StoredProposal>;
       const validState = p.state === "pending_review" || p.state === "accepted" || p.state === "partially_accepted" || p.state === "rejected" || p.state === "decided" || p.state === "superseded" || p.state === "withdrawn";
       if (typeof p.id !== "string" || p.docId !== this.docId || typeof p.hash !== "string" || !Number.isInteger(p.bytes) || (p.bytes as number) < 0 || !Number.isFinite(Date.parse(p.at ?? "")) || !validState || typeof p.text !== "string") return null;
-      // A PENDING record's text is load-bearing (recovery, re-push, slot comparison), so a
+      // A PENDING record's text is load-bearing (recovery, re-push, row comparison), so a
       // valid-JSON-but-corrupted record whose hash/bytes disagree with its own text reads as
-      // absent — reconciliation from the cloud slot rebuilds the truth. Finalized records
+      // absent — reconciliation from the cloud row rebuilds the truth. Finalized records
       // tolerate the mismatch: their text is historical convenience, not a recovery input.
       if (p.state === "pending_review" && (hashBody(p.text) !== p.hash || utf8Bytes(p.text) !== p.bytes)) return null;
-      // The optional grace marker must be a real timestamp or absent: a malformed truthy value
-      // would read as "already waited one run" and finalize 'decided' on the first slot clear,
-      // skipping the grace entirely. Strip it rather than reject the record — the pending
-      // proposal itself is intact; only the marker is damaged.
-      if (p.awaitingOutcomeSince !== undefined && !Number.isFinite(Date.parse(p.awaitingOutcomeSince))) delete p.awaitingOutcomeSince;
       return p as StoredProposal;
     } catch {
       return null;

--- a/packages/cli/src/remoteDocState.ts
+++ b/packages/cli/src/remoteDocState.ts
@@ -149,8 +149,10 @@ export class RemoteDocState {
     if (prior && id !== undefined && id === prior.id && prior.hash !== hash) {
       // Same identity, updated content (the cloud converge-if-pending path): the record follows
       // in place. Superseding here would finalize the id into the history and then republish the
-      // SAME id as pending — breaking terminal immutability and corrupting the history.
-      const updated: ProposalRecord = { ...prior, hash, bytes: utf8Bytes(text), at: at.toISOString() };
+      // SAME id as pending — breaking terminal immutability and corrupting the history. `at`
+      // stays the ORIGINAL park time — it documents when the proposal was parked, not when a
+      // reconciliation last touched the record.
+      const updated: ProposalRecord = { ...prior, hash, bytes: utf8Bytes(text) };
       this.publish({ ...updated, text });
       return updated;
     }

--- a/packages/cli/test/applyGatedEdit.test.ts
+++ b/packages/cli/test/applyGatedEdit.test.ts
@@ -78,7 +78,7 @@ describe("applyGatedEdit — file path (no plugin)", () => {
     };
     const channel = new MemoryControlChannel();
     const applied = await applyGatedEdit(store, channel, ev({ changed: true }), { current: "agent body", canonicalText: "canon", quarantine: true, gate: null });
-    expect(applied).toEqual({ proposed: true });
+    expect(applied).toEqual({ proposed: true, proposalId: (await store.myPendingProposal())?.id }); // the id names the parked row
     expect(await proposedContent(store)).toBe("agent body");
     expect(await store.loadDoc()).toBe("agent body"); // revert failed — edit stays put
     expect(await types(channel)).toEqual([LogEventType.AgentRevisionProposed]); // the park is logged
@@ -91,7 +91,7 @@ describe("applyGatedEdit — file path (no plugin)", () => {
       throw new Error("log unavailable");
     };
     const applied = await applyGatedEdit(store, channel, ev({ changed: true }), { current: "agent body", canonicalText: "canon", quarantine: true, gate: null });
-    expect(applied).toEqual({ proposed: true, eventLogged: false }); // no crash, no false failure — and the missing event is reported
+    expect(applied).toEqual({ proposed: true, proposalId: (await store.myPendingProposal())?.id, eventLogged: false }); // no crash, no false failure — and the missing event is reported
     expect(await proposedContent(store)).toBe("agent body");
     expect(await store.loadDoc()).toBe("canon"); // the revert did run
   });

--- a/packages/cli/test/remoteDocState.test.ts
+++ b/packages/cli/test/remoteDocState.test.ts
@@ -2,15 +2,15 @@
 //
 // RemoteDocState — the durable "did my edit land?" state (#88). The properties pinned here are
 // the ones whose absence caused the 2026-08-11 work-deletion: a parked proposal must survive the
-// end-of-turn working-copy overwrite, must be auditable turns later, and must resolve to the
-// human's actual decision (including partial hunk acceptance), never silently vanish.
+// end-of-turn working-copy overwrite, must be auditable turns later, and must mirror the human's
+// actual decision (the cloud row's terminal state), never silently vanish.
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, existsSync, utimesSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, existsSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { LogEventType, hashBody, type LogEntry } from "@inplan/core/node";
-import { RemoteDocState, isDecidedProposalCorpse, needsReparkFromSlot, resolutionFromEvents, utf8Bytes } from "../src/remoteDocState";
+import { hashBody } from "@inplan/core/node";
+import { RemoteDocState, isDecidedProposalCorpse, utf8Bytes } from "../src/remoteDocState";
 import { shouldHydrateWorkFile } from "../src/liveSync";
 
 let dir: string;
@@ -22,109 +22,7 @@ beforeEach(() => {
 });
 afterEach(() => rmSync(dir, { recursive: true, force: true }));
 
-const entry = (type: string, ts: string): LogEntry => ({ seq: 1, ts, actor: "user", type });
-
-describe("resolutionFromEvents", () => {
-  const PARK = { at: "2026-08-15T12:00:00.000Z", hash: "hash-P1" };
-  const parkEvent = (ts: string, hash?: string): LogEntry => ({ seq: 1, ts, actor: "agent", type: LogEventType.AgentRevisionProposed, ...(hash ? { payload: { bytes: 1, hash } } : {}) });
-
-  it.each([
-    ["accepted", LogEventType.RevisionAcceptedAll, "accepted"],
-    ["rejected", LogEventType.RevisionRejectedAll, "rejected"],
-    ["hunk-accepted → partial", LogEventType.RevisionHunkAccepted, "partially_accepted"],
-    ["hunk-rejected → partial", LogEventType.RevisionHunkRejected, "partially_accepted"],
-  ])("%s", (_label, type, want) => {
-    expect(resolutionFromEvents([entry(type, "2026-08-15T12:05:00.000Z")], PARK)).toBe(want);
-  });
-
-  it("no decision event readable → 'decided' (the slot emptied; which way is unknown)", () => {
-    expect(resolutionFromEvents([entry(LogEventType.AgentRevised, "2026-08-15T12:05:00.000Z")], PARK)).toBe("decided");
-  });
-
-  it("a decision OLDER than the park belongs to a previous proposal and is ignored", () => {
-    expect(resolutionFromEvents([entry(LogEventType.RevisionAcceptedAll, "2026-08-15T11:00:00.000Z")], PARK)).toBe("decided");
-  });
-
-  it("the newest decision wins when several exist since the park", () => {
-    const entries = [
-      entry(LogEventType.RevisionRejectedAll, "2026-08-15T12:01:00.000Z"),
-      entry(LogEventType.RevisionAcceptedAll, "2026-08-15T12:09:00.000Z"),
-    ];
-    expect(resolutionFromEvents(entries, PARK)).toBe("accepted");
-  });
-
-  it("log order beats the clock: a decision after the park EVENT counts even when server timestamps lag the CLI clock", () => {
-    // The CLI records the park time from its own clock; Supabase stamps events server-side. With
-    // the CLI clock ahead, a fast acceptance can carry a ts EARLIER than the recorded park — the
-    // agent_revision_proposed event's position in the log is the boundary that cannot skew.
-    const entries = [
-      entry(LogEventType.RevisionRejectedAll, "2026-08-15T11:50:00.000Z"), // a PREVIOUS proposal's decision
-      parkEvent("2026-08-15T11:58:00.000Z", "hash-P1"), // this park (server ts behind PARK)
-      entry(LogEventType.RevisionAcceptedAll, "2026-08-15T11:59:00.000Z"), // fast acceptance, ts still < PARK
-    ];
-    expect(resolutionFromEvents(entries, PARK)).toBe("accepted");
-  });
-
-  it("a previous proposal's decision BEFORE the park event is never misattributed", () => {
-    const entries = [
-      entry(LogEventType.RevisionAcceptedAll, "2026-08-15T12:30:00.000Z"), // late server ts, but before the park in log order
-      parkEvent("2026-08-15T12:00:02.000Z", "hash-P1"), // ours (within clock slack)
-    ];
-    expect(resolutionFromEvents(entries, PARK)).toBe("decided");
-  });
-
-  it("decisions bind to THIS proposal's park event by hash — a later proposal's decision is never claimed", () => {
-    // Machine A parks P1 and goes offline; the human rejects P1; machine B parks P2 which is
-    // accepted. When A finally resolves P1 it must read P1's rejection, not P2's acceptance.
-    const entries = [
-      parkEvent("2026-08-15T12:00:02.000Z", "hash-P1"), // ours (within clock slack)
-      entry(LogEventType.RevisionRejectedAll, "2026-08-15T12:05:00.000Z"), // P1's decision
-      parkEvent("2026-08-15T12:10:00.000Z", "hash-P2"),
-      entry(LogEventType.RevisionAcceptedAll, "2026-08-15T12:15:00.000Z"), // P2's decision
-    ];
-    expect(resolutionFromEvents(entries, PARK)).toBe("rejected");
-    expect(resolutionFromEvents(entries, { at: "2026-08-15T12:10:00.000Z", hash: "hash-P2" })).toBe("accepted");
-  });
-
-  it("a later proposal with no decision for ours → 'decided', never the newer proposal's outcome", () => {
-    const entries = [
-      parkEvent("2026-08-15T12:00:02.000Z", "hash-P1"), // ours (within clock slack)
-      parkEvent("2026-08-15T12:10:00.000Z", "hash-P2"),
-      entry(LogEventType.RevisionAcceptedAll, "2026-08-15T12:15:00.000Z"), // P2's decision only
-    ];
-    expect(resolutionFromEvents(entries, PARK)).toBe("decided");
-  });
-
-  it("an un-hashed park event (older CLI) still anchors when it plausibly IS this park (within clock slack)", () => {
-    const entries = [
-      parkEvent("2026-08-15T12:00:03.000Z"), // no hash payload; stamped ~our park time
-      entry(LogEventType.RevisionAcceptedAll, "2026-08-15T12:05:00.000Z"),
-    ];
-    expect(resolutionFromEvents(entries, PARK)).toBe("accepted");
-  });
-
-  it("a WEAK anchor (our park's event never appended) keeps the timestamp filter — an older proposal's decision is never claimed", () => {
-    // Our park's append failed; the last park event in the log is a PREVIOUS proposal's, and its
-    // decision sits inside that window. Only a hash-matched anchor earns pure log-order trust;
-    // here the decision predates our recorded park time, so it must not finalize our record.
-    const entries = [
-      parkEvent("2026-08-15T11:00:00.000Z", "hash-OLD"),
-      entry(LogEventType.RevisionAcceptedAll, "2026-08-15T11:30:00.000Z"), // the OLD proposal's decision
-    ];
-    expect(resolutionFromEvents(entries, PARK)).toBe("decided");
-  });
-
-  it("a hash match far PREDATING our park is an OLDER identical-text proposal — never our anchor", () => {
-    // The backward twin of the postdating case: our event never appended, and an old proposal
-    // with identical content was decided hours ago. Its event must not bind our window — outside
-    // the near window it only weak-anchors, and the timestamp filter then excludes its decision.
-    const entries = [
-      parkEvent("2026-08-15T08:00:00.000Z", "hash-P1"), // an OLD proposal, same content
-      entry(LogEventType.RevisionAcceptedAll, "2026-08-15T08:30:00.000Z"), // ITS decision
-    ];
-    expect(resolutionFromEvents(entries, PARK)).toBe("decided"); // ours at 12:00 — never 'accepted'
-  });
-
+describe("park / audit / resolve", () => {
   it("a retried finalization with a DIFFERENT outcome appends the correction to the history", () => {
     s.parkProposal("v1");
     s.resolveProposal("accepted");
@@ -140,33 +38,6 @@ describe("resolutionFromEvents", () => {
     expect(JSON.parse(lines[1]!)).toMatchObject({ id: stored.id, state: "rejected" });
     expect(s.latestProposal()?.state).toBe("rejected"); // record and history tail agree
   });
-
-  it("a hash match POSTDATING our park is someone else's identical-text proposal — never our anchor", () => {
-    // Identical text is not identity: a newer proposal repeating our content must not donate its
-    // decision window to this record. Our own (eligible) park event still anchors correctly.
-    const entries = [
-      parkEvent("2026-08-15T11:58:00.000Z", "hash-P1"), // ours (within clock slack of PARK.at)
-      entry(LogEventType.RevisionRejectedAll, "2026-08-15T11:59:00.000Z"), // OUR decision
-      parkEvent("2026-08-15T12:10:00.000Z", "hash-P1"), // another machine's park, SAME text
-      entry(LogEventType.RevisionAcceptedAll, "2026-08-15T12:15:00.000Z"), // THEIR decision
-    ];
-    expect(resolutionFromEvents(entries, PARK)).toBe("rejected");
-  });
-
-  it("a LATER machine's park never becomes our weak anchor — its decision postdates us but is still not ours", () => {
-    // Our park's append failed AND another machine parked after us. The later park event must not
-    // anchor our window (its ts postdates our recorded park time), and the window must close at
-    // that park even without an anchor — the timestamp filter alone cannot exclude the later
-    // decision, because it genuinely postdates our park.
-    const entries = [
-      parkEvent("2026-08-15T12:10:00.000Z", "hash-P2"), // the other machine's park, after ours (12:00)
-      entry(LogEventType.RevisionAcceptedAll, "2026-08-15T12:15:00.000Z"), // P2's decision
-    ];
-    expect(resolutionFromEvents(entries, PARK)).toBe("decided");
-  });
-});
-
-describe("park / audit / resolve", () => {
   it("a parked proposal survives the end-of-turn working-copy overwrite (the #88 clobber)", () => {
     s.writeWorkFile("agent's 48KB of work");
     s.parkProposal("agent's 48KB of work");
@@ -242,7 +113,7 @@ describe("park / audit / resolve", () => {
     expect(existsSync(join(dir, "remote", "doc-1.plan.md.proposed.json.tmp"))).toBe(false);
     const recordPath = join(dir, "remote", "doc-1.plan.md.proposed.json");
     writeFileSync(recordPath, "{ this is not json"); // external damage
-    expect(s.latestProposal()).toBeNull(); // no heuristics — reconciliation from the cloud slot heals this
+    expect(s.latestProposal()).toBeNull(); // no heuristics — reconciliation from the cloud row heals this
     expect(s.pendingProposal()).toBeNull();
   });
 
@@ -268,43 +139,8 @@ describe("park / audit / resolve", () => {
     expect(JSON.parse(history[1]!)).toMatchObject({ id: second.id, state: "rejected" });
   });
 
-  it("noteOutcomeMissing marks once, keeps the record pending, and finalize clears the marker", () => {
-    s.parkProposal("v1");
-    const marked = s.noteOutcomeMissing(new Date("2026-08-15T01:00:00.000Z"));
-    expect(marked?.awaitingOutcomeSince).toBe("2026-08-15T01:00:00.000Z");
-    expect(s.pendingProposal()?.awaitingOutcomeSince).toBe("2026-08-15T01:00:00.000Z"); // still pending
-    expect(s.noteOutcomeMissing()).toBeNull(); // already marked — second sighting is the caller's cue to finalize
-    const finalized = s.resolveProposal("decided");
-    expect(finalized?.awaitingOutcomeSince).toBeUndefined(); // the grace marker never outlives the decision
-    expect(s.latestProposal()?.state).toBe("decided");
-  });
-
-  it("a malformed awaiting-outcome marker is stripped, never treated as an elapsed grace", () => {
-    // A truthy-but-garbage marker would read as "already waited one run" and finalize 'decided'
-    // on the first slot clear. The pending proposal itself is intact — only the marker drops.
-    s.parkProposal("v1");
-    const recordPath = join(dir, "remote", "doc-1.plan.md.proposed.json");
-    const stored = JSON.parse(readFileSync(recordPath, "utf8"));
-    writeFileSync(recordPath, JSON.stringify({ ...stored, awaitingOutcomeSince: "not-a-timestamp" }, null, 2));
-    const pending = s.pendingProposal();
-    expect(pending).not.toBeNull();
-    expect(pending?.awaitingOutcomeSince).toBeUndefined(); // stripped → the caller grants the full grace
-    expect(s.noteOutcomeMissing(new Date("2026-08-15T01:00:00.000Z"))?.awaitingOutcomeSince).toBe("2026-08-15T01:00:00.000Z");
-  });
-
-  it("re-pushing identical text RESETS a stale awaiting-outcome marker — the slot is live again", () => {
-    // Without the reset, a later slot-clear would finalize 'decided' immediately off the old
-    // sighting instead of granting the full grace for the decision event to surface.
-    const first = s.parkProposal("v1");
-    s.noteOutcomeMissing();
-    const repushed = s.parkProposal("v1");
-    expect(repushed.id).toBe(first.id); // same proposal, re-pushed
-    expect(repushed.awaitingOutcomeSince).toBeUndefined();
-    expect(s.pendingProposal()?.awaitingOutcomeSince).toBeUndefined();
-  });
-
   it("a pending record whose hash/bytes disagree with its own text reads as absent", () => {
-    // Valid JSON is not integrity: a corrupted pending record must not feed re-push or slot
+    // Valid JSON is not integrity: a corrupted pending record must not feed re-push or row
     // comparison with text it doesn't actually describe. Finalized records tolerate the mismatch
     // (their text is historical convenience, not a recovery input).
     const recordPath = join(dir, "remote", "doc-1.plan.md.proposed.json");
@@ -361,40 +197,23 @@ describe("isDecidedProposalCorpse — the working copy after a park-then-crash-t
   });
 });
 
-describe("needsReparkFromSlot — reconciliation from the cloud's authoritative side", () => {
-  const pendingV1 = () => s.parkProposal("v1");
-
-  it("no slot → nothing to reconcile, regardless of local state", () => {
-    expect(needsReparkFromSlot(null, null)).toBe(false);
-    expect(needsReparkFromSlot(null, undefined)).toBe(false); // transient read failure — retry later
-    expect(needsReparkFromSlot(pendingV1(), null)).toBe(false);
-  });
-
-  it("a slot with NO local record re-parks (the push landed; the record publish crashed)", () => {
-    expect(needsReparkFromSlot(null, "v1")).toBe(true);
-  });
-
-  it("a slot with a TERMINAL local record re-parks — even for identical content (a re-park after a finalization)", () => {
-    pendingV1();
-    const finalized = s.resolveProposal("accepted")!;
-    expect(needsReparkFromSlot(finalized, "v1")).toBe(true);
-    expect(needsReparkFromSlot(finalized, "v2")).toBe(true);
-  });
-
-  it("a slot about DIFFERENT content than the pending record re-parks (the newer park's publish was lost)", () => {
-    expect(needsReparkFromSlot(pendingV1(), "v2")).toBe(true);
-  });
-
-  it("a healthy pending record matching the slot does nothing", () => {
-    expect(needsReparkFromSlot(pendingV1(), "v1")).toBe(false);
-  });
-
-  it("re-parking from the slot recreates a truthful pending record", () => {
-    pendingV1();
+describe("row adoption — reconciliation from the cloud's authoritative side", () => {
+  it("adopting the cloud row after a finalization recreates a truthful pending record under the row's id", () => {
+    s.parkProposal("v1");
     s.resolveProposal("accepted");
-    const rec = s.parkProposal("v1"); // what runRemote does when needsReparkFromSlot says true
+    const rec = s.parkProposal("v1", undefined, "row-7"); // what runRemote does when my pending row has no live record
     expect(rec.state).toBe("pending_review");
+    expect(rec.id).toBe("row-7");
     expect(s.pendingProposal()?.hash).toBe(hashBody("v1"));
+  });
+
+  it("a pending record follows its own row's converged content in place — same id, no supersede", () => {
+    const first = s.parkProposal("old text", undefined, "row-7");
+    const followed = s.parkProposal("new text", undefined, "row-7");
+    expect(followed.id).toBe(first.id);
+    expect(followed.hash).toBe(hashBody("new text"));
+    expect(s.proposedText()).toBe("new text");
+    expect(existsSync(join(dir, "remote", "doc-1.plan.md.proposals.jsonl"))).toBe(false); // nothing finalized
   });
 });
 

--- a/packages/cli/test/remoteDocState.test.ts
+++ b/packages/cli/test/remoteDocState.test.ts
@@ -208,10 +208,11 @@ describe("row adoption — reconciliation from the cloud's authoritative side", 
   });
 
   it("a pending record follows its own row's converged content in place — same id, no supersede", () => {
-    const first = s.parkProposal("old text", undefined, "row-7");
-    const followed = s.parkProposal("new text", undefined, "row-7");
+    const first = s.parkProposal("old text", new Date("2026-08-15T00:00:00.000Z"), "row-7");
+    const followed = s.parkProposal("new text", new Date("2026-08-16T00:00:00.000Z"), "row-7");
     expect(followed.id).toBe(first.id);
     expect(followed.hash).toBe(hashBody("new text"));
+    expect(followed.at).toBe(first.at); // the ORIGINAL park time — convergence is not a new park
     expect(s.proposedText()).toBe("new text");
     expect(existsSync(join(dir, "remote", "doc-1.plan.md.proposals.jsonl"))).toBe(false); // nothing finalized
   });

--- a/packages/cli/test/waitCycleResume.test.ts
+++ b/packages/cli/test/waitCycleResume.test.ts
@@ -161,8 +161,9 @@ describe("waitCycle resume is a loop, not a re-entry", () => {
       await reloadThenAct(h.channel);
       await expect(run).resolves.toBe("ok");
 
-      const last = h.lastJson() as ReturnType<typeof h.lastJson> & { proposal?: { state: string; bytes: number; hash: string } };
-      expect(last.proposal).toEqual({ state: "pending_review", bytes: utf8Bytes(DOC_B), hash: hashBody(DOC_B) });
+      const last = h.lastJson() as ReturnType<typeof h.lastJson> & { proposal?: { state: string; id?: string; bytes: number; hash: string } };
+      // The id in the output is the parked row's own id — the audit lookup key (proposals v1).
+      expect(last.proposal).toEqual({ state: "pending_review", id: (await h.store.myPendingProposal())?.id, bytes: utf8Bytes(DOC_B), hash: hashBody(DOC_B) });
       expect(h.stderr()).toContain("parked as a proposal");
       expect(await proposedContent(h.store)).toBe(DOC_B);
     } finally {

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -75,44 +75,49 @@ history the CLI maintains).
 
 **Review mode parks your edit — that is success, not failure.** Most cloud docs are in review
 mode: your body edit is NOT applied to the canonical; it is pushed to the cloud as a
-**proposal** for the human to accept or reject in their editor. When that happens the wait
-output carries `proposal: { state: "pending_review", bytes, hash }`, an
-`agent_revision_proposed` entry appears in `entries`, and stderr says the edit was parked.
+**proposal** for the human to accept or reject in their editor. Every proposal is a
+first-class object with its own **id** — the same id names it in the wait output, in the local
+record, and in the cloud. When a park happens the wait output carries
+`proposal: { state: "pending_review", id, bytes, hash }`, an `agent_revision_proposed` entry
+(payload `proposal_id`) appears in `entries`, and stderr says the edit was parked.
 
-How to audit "did my edit land?", in order:
-1. **This turn:** the `proposal` field in the wait JSON (`pending_review` = safely parked), or
-   a `document_edited` entry (= applied directly to canonical). The `proposal` field rides
-   **every** turn-ending output when a park happened this turn — `your_turn`/`activity`,
-   `closed`, `navigated`, `wait_failed`, `superseded`, and `moved_local` — losing or handing
-   off the wait afterwards does not un-park your edit, so check the field (and the record
-   below) before classifying it.
-2. **Any later turn:** read `<workingCopy>.proposed.json` — the durable record. Its `state`
-   becomes `accepted`, `partially_accepted`, or `rejected` once the human decides (or
-   `decided` when history is readable but no usable outcome event can be recovered — a
-   transient history-read failure instead leaves the record pending and retries next run), and
-   `superseded` when a newer proposal of yours replaced it — the newest record is the
-   authoritative one. The exact text you pushed is embedded in the record itself (its `text`
-   field — audit from there); `<workingCopy>.proposed.md` is only a derived, read-convenience
-   copy that can be missing or stale until the next run reconciles it. Every finalized record
-   is appended to `<workingCopy>.proposals.jsonl`.
-3. A later wait's `entries` may also carry the decision itself: `revision_accepted_all`,
-   `revision_hunk_accepted`, or `revision_rejected_all`.
+How to audit "did my edit land?" — the answer is a **lookup by that id**, never an inference:
+1. **This turn:** the `proposal` field in the wait JSON (`pending_review` = safely parked, and
+   `id` is the proposal's identity), or a `document_edited` entry (= applied directly to
+   canonical). The `proposal` field rides **every** turn-ending output when a park happened
+   this turn — `your_turn`/`activity`, `closed`, `navigated`, `wait_failed`, `superseded`, and
+   `moved_local` — losing or handing off the wait afterwards does not un-park your edit, so
+   check the field (and the record below) before classifying it.
+2. **Any later turn:** read `<workingCopy>.proposed.json` — the durable record, keyed by the
+   same id. Its `state` mirrors the cloud proposal's own state verbatim once the next
+   `wait --remote` run reconciles: `accepted`, `partially_accepted`, or `rejected` when the
+   human decides, `superseded` when a newer proposal of yours replaced it, `withdrawn` when
+   the agent retracted it — the newest record is the authoritative one. (`decided` appears
+   only when the proposal itself is gone from the cloud — a legacy park with no row — and
+   means the human acted but which way is unknowable.) The exact text you pushed is embedded
+   in the record itself (its `text` field — audit from there); `<workingCopy>.proposed.md` is
+   only a derived, read-convenience copy that can be missing or stale until the next run
+   reconciles it. Every finalized record is appended to `<workingCopy>.proposals.jsonl`.
+3. A later wait's `entries` may also carry the decision event, whose payload names the decided
+   proposal: `revision_accepted_all`, `revision_hunk_accepted`, or `revision_rejected_all`.
 
 If the park itself fails, the wait JSON carries `proposal: { state: "park_failed", bytes,
 hash }` (and stderr says the push FAILED) — `park_failed` means exactly that the **cloud push
 was not confirmed**. It does NOT prove the push didn't land: a lost response can leave the
-proposal live in the cloud while the local event and record are missing. Either way the retry
-is safe and automatic — the next `wait` run first reconciles the cloud's proposal slot (a
-landed push is adopted as the pending record, not re-sent), and re-pushing identical content
-is idempotent (same proposal identity, no duplicate). Your edit stays in the working copy;
-do not re-create it — just re-run.
+proposal live in the cloud while the local event and record are missing. (When an EARLIER
+proposal of yours is still pending — the failed push was a re-push — the field carries that
+proposal's `id`.) Either way the retry is safe and automatic — the next `wait` run first
+reconciles from your own pending proposal in the cloud (a landed push is adopted as the
+pending record under its cloud id, not re-sent), and re-pushing identical content is
+idempotent (same proposal identity, no duplicate). Your edit stays in the working copy; do
+not re-create it — just re-run.
 
 The converse also holds: a CONFIRMED push stays parked even when a piece of local bookkeeping
 failed around it. The event append or the local record write can fail after the push landed —
-stderr says so when it happens — and the next `wait --remote` run reconciles the missing
-artifacts from the cloud's own proposed slot. A temporarily missing event or record therefore
-never means the park failed; only `park_failed` (or the absence of any park signal plus a
-still-diverged working copy) means that.
+stderr says so when it happens — and the next `wait --remote` run rebuilds the missing record
+from the cloud proposal itself. A temporarily missing event or record therefore never means
+the park failed; only `park_failed` (or the absence of any park signal plus a still-diverged
+working copy) means that.
 
 Two things are **normal and must never be read as data loss**: after a healthy turn the
 working copy is re-synced to the current canonical (so your parked edit is no longer in it —


### PR DESCRIPTION
The proposal row (#98) carries identity and a terminal-immutable state, so the CLI stops reconstructing outcomes from event windows and reads the row instead.

## What changes

- **Attach reconciliation is row-backed.** `runRemote` reads my pending proposal row and the local record's own row by id: a record this machine lost (crash between the confirmed push and the record publish) is rebuilt under the row's identity; a displaced pending record settles from *its* row's actual state (the human may have decided it before a newer proposal displaced it); a pending record whose row went terminal mirrors the row's state verbatim. `decided` survives only for a record whose row is gone entirely (legacy park) — the human acted, which way is unknowable.
- **Deleted outright**: `resolutionFromEvents` with its window anchoring and clock-skew bounds, `needsReparkFromSlot` content matching, the awaiting-outcome grace (`awaitingOutcomeSince`, `noteOutcomeMissing`, all marker handling), and their tests. The row's atomic state makes the slot-clear/decision-event race they compensated for unrepresentable.
- **Kept**: the atomic record publish, the hydration rules, the corpse restore (now triggered by the row's terminal state instead of event inference), `park_failed` signaling, and the append-only local history.
- **The wait output's `proposal` field carries the id** in both states — `pending_review` names the parked row; `park_failed` names the still-pending prior proposal when the failed push was a re-push (a first failed park has no confirmed identity, so the field is omitted). The audit is now a `getProposal(id)` lookup, and SKILL.md's audit chain is rewritten around it.

## Notes for review

- Net −295 lines; the deletions are the point. The two record-lifecycle tests that lived inside the deleted describes (history-correction retry, row adoption after finalization) were kept and re-homed.
- Downstream integration suites exercise the real reconciliation path end to end (two proposers, idempotent re-park, decision isolation) and are green.
