### PR TITLE
open: never wipe a working file by reverting to a blank canonical

### DIFF
--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -376,11 +376,19 @@ function navigateTo(file: string): boolean {
  *  new hub) and re-mounts just the editor — far cheaper than a full `webContents.reload()`. With no
  *  plugin, take the light file-backed path (send the new doc to the existing renderer). */
 async function refreshPluginAndView(file: string): Promise<void> {
+  // Capture the session this refresh serves: load() awaits the proposal lookup, and a later
+  // navigation can replace `session` in that window — a stale refresh must never send the OLD
+  // document as `doc:navigated` for the new one.
+  const forSession = session;
   await stopDesktopPlugin();
   await startDesktopPlugin(file, pluginToken);
-  if (!win || !session) return;
+  if (!win || !session || session !== forSession) return;
   if (pluginInfo()) win.webContents.send("plugin:reactivate"); // renderer re-binds + re-mounts the editor
-  else win.webContents.send("doc:navigated", await session.load());
+  else {
+    const payload = await session.load();
+    if (!win || session !== forSession) return; // replaced while loading — the newer refresh owns the send
+    win.webContents.send("doc:navigated", payload);
+  }
 }
 
 /** Record the close reason once and exit, bypassing the confirm-quit dialog.

--- a/packages/app/src/main/index.ts
+++ b/packages/app/src/main/index.ts
@@ -380,7 +380,7 @@ async function refreshPluginAndView(file: string): Promise<void> {
   await startDesktopPlugin(file, pluginToken);
   if (!win || !session) return;
   if (pluginInfo()) win.webContents.send("plugin:reactivate"); // renderer re-binds + re-mounts the editor
-  else win.webContents.send("doc:navigated", session.load());
+  else win.webContents.send("doc:navigated", await session.load());
 }
 
 /** Record the close reason once and exit, bypassing the confirm-quit dialog.

--- a/packages/app/src/main/session.ts
+++ b/packages/app/src/main/session.ts
@@ -65,10 +65,24 @@ export class Session {
     }
   }
 
-  load(): { path: string; content: string } {
+  async load(): Promise<{ path: string; content: string }> {
     const content = readFileSync(this.paths.file, "utf8");
     if (!existsSync(this.paths.canonicalPath)) {
       writeFileSync(this.paths.canonicalPath, content);
+      return { path: this.paths.file, content };
+    }
+    // When the working file IS the pending proposal — the CLI's #95 wipe guard leaves the parked
+    // text in place rather than materializing a blank canonical over it — the editor's baseline
+    // must be the CANONICAL: the file's content is the proposal under review, not the accepted
+    // document. Served as-is, the re-shown proposal (pendingProposal) would diff against itself
+    // (an empty diff) instead of proposal-vs-canonical. The equality check keeps every other
+    // shape untouched: a file the human has since edited, or an accepted doc with a stale
+    // sidecar, still loads as the file. Covers the legacy no-rows park too — pendingProposal()
+    // already falls back to the derived proposed.md, and "the file equals the parked text"
+    // means the same thing there.
+    const pending = await this.pendingProposal();
+    if (pending !== null && pending.content === content) {
+      return { path: this.paths.file, content: readFileSync(this.paths.canonicalPath, "utf8") };
     }
     return { path: this.paths.file, content };
   }

--- a/packages/app/src/main/session.ts
+++ b/packages/app/src/main/session.ts
@@ -80,7 +80,16 @@ export class Session {
     // sidecar, still loads as the file. Covers the legacy no-rows park too — pendingProposal()
     // already falls back to the derived proposed.md, and "the file equals the parked text"
     // means the same thing there.
-    const pending = await this.pendingProposal();
+    // A FAILED lookup (rows-lock contention past its deadline, an unreadable sidecar) must never
+    // block opening the document: fall back to the working content already read. Worst case is
+    // the pre-substitution behavior — a re-shown review may diff empty until the next dispatch —
+    // never a document that won't load.
+    let pending: { id?: string; content: string } | null;
+    try {
+      pending = await this.pendingProposal();
+    } catch {
+      return { path: this.paths.file, content };
+    }
     if (pending !== null && pending.content === content) {
       return { path: this.paths.file, content: readFileSync(this.paths.canonicalPath, "utf8") };
     }

--- a/packages/app/src/main/session.ts
+++ b/packages/app/src/main/session.ts
@@ -81,19 +81,24 @@ export class Session {
     // already falls back to the derived proposed.md, and "the file equals the parked text"
     // means the same thing there.
     // A FAILED lookup (rows-lock contention past its deadline, an unreadable sidecar) must never
-    // block opening the document: fall back to the working content already read. Worst case is
-    // the pre-substitution behavior — a re-shown review may diff empty until the next dispatch —
+    // block opening the document: fall back to the working file. Worst case is the
+    // pre-substitution behavior — a re-shown review may diff empty until the next dispatch —
     // never a document that won't load.
     let pending: { id?: string; content: string } | null;
     try {
       pending = await this.pendingProposal();
     } catch {
-      return { path: this.paths.file, content };
+      pending = null;
     }
-    if (pending !== null && pending.content === content) {
+    // Re-read the working file AFTER the awaited lookup: a CLI process can rewrite it while the
+    // lookup is in flight, and comparing the proposal against the PRE-await snapshot would mask
+    // that fresh edit behind the canonical. The substitution keys on what the file holds NOW —
+    // and either way the freshest content is what gets served.
+    const current = readFileSync(this.paths.file, "utf8");
+    if (pending !== null && pending.content === current) {
       return { path: this.paths.file, content: readFileSync(this.paths.canonicalPath, "utf8") };
     }
-    return { path: this.paths.file, content };
+    return { path: this.paths.file, content: current };
   }
 
   save(content: string, options: SaveOptions): void {

--- a/packages/app/test/session.test.ts
+++ b/packages/app/test/session.test.ts
@@ -10,7 +10,7 @@ import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { LogEventType, type LogEntry } from "@inplan/core/node";
+import { FsDocumentStore, hashBody, LogEventType, type LogEntry } from "@inplan/core/node";
 import { Session } from "../src/main/session";
 
 let dir: string;
@@ -100,6 +100,42 @@ describe("Session.dispatchLog", () => {
     const h = handlers();
     session.dispatchLog([], h);
     expect(h.onExternalChange).not.toHaveBeenCalled();
+  });
+});
+
+describe("Session.load with a parked proposal (#95)", () => {
+  it("blank canonical + working file holding the parked text → load serves the canonical; the proposal stays reviewable", async () => {
+    // The CLI's #95 wipe guard keeps the parked text in the working file instead of materializing
+    // a blank canonical over it. The editor must then baseline on the CANONICAL: served as the
+    // file, the re-shown proposal would diff against itself — no hunks for what is an
+    // all-additions review against the blank canonical.
+    const parked = "# Plan\n\nfirst content, straight from the agent.\n";
+    const file = join(dir, "FRESH.md");
+    writeFileSync(file, parked);
+    const s = new Session(file);
+    writeFileSync(s.paths.canonicalPath, ""); // `open` seeded an authoritative-empty canonical
+    // Park the proposal exactly as the CLI gate does (row-backed, base = the blank canonical).
+    await new FsDocumentStore(s.paths).createProposal({ content: parked, baseHash: hashBody(""), baseContent: "" });
+
+    const loaded = await s.load();
+    expect(loaded.content).toBe(""); // the baseline is the canonical, not the proposal under review
+    expect((await s.pendingProposal())?.content).toBe(parked); // and the review still shows the parked text
+    expect(readFileSync(file, "utf8")).toBe(parked); // load never rewrites the working file
+  });
+
+  it("load still serves the working file when it differs from the pending proposal", async () => {
+    // The substitution is strictly for "the file IS the proposal": a file the human has since
+    // edited (or any accepted doc with a stale sidecar) must load as-is.
+    const file = join(dir, "EDITED.md");
+    writeFileSync(file, "# Plan\n\nthe human's own edit.\n");
+    const s = new Session(file);
+    writeFileSync(s.paths.canonicalPath, "");
+    await new FsDocumentStore(s.paths).createProposal({ content: "# Plan\n\nsomething else entirely.\n", baseHash: hashBody(""), baseContent: "" });
+    expect((await s.load()).content).toBe("# Plan\n\nthe human's own edit.\n");
+  });
+
+  it("load with no pending proposal serves the working file unchanged", async () => {
+    expect((await session.load()).content).toBe("# Plan\n\nACCEPTED body.\n");
   });
 });
 

--- a/packages/app/test/session.test.ts
+++ b/packages/app/test/session.test.ts
@@ -148,6 +148,23 @@ describe("Session.load with a parked proposal (#95)", () => {
     vi.spyOn(session, "pendingProposal").mockRejectedValue(new Error("rows lock timeout"));
     expect((await session.load()).content).toBe("# Plan\n\nACCEPTED body.\n");
   });
+
+  it("a rewrite while the lookup is in flight is served, not masked by the canonical", async () => {
+    // The proposal must be compared against what the file holds AFTER the await: a CLI process
+    // can rewrite the file mid-lookup, and matching the pre-await snapshot would serve the
+    // canonical over a fresh edit that is no longer the proposal.
+    const parked = "# Plan\n\nthe parked text.\n";
+    const fresh = "# Plan\n\na newer CLI write, landed mid-lookup.\n";
+    const file = join(dir, "RACE.md");
+    writeFileSync(file, parked);
+    const s = new Session(file);
+    writeFileSync(s.paths.canonicalPath, "");
+    vi.spyOn(s, "pendingProposal").mockImplementation(async () => {
+      writeFileSync(file, fresh); // the CLI rewrites the file while the lookup is in flight
+      return { id: "p-race", content: parked }; // the proposal equals the PRE-await snapshot
+    });
+    expect((await s.load()).content).toBe(fresh); // the fresh edit is served, not the blank canonical
+  });
 });
 
 describe("Session.complete clears the unsaved flag", () => {

--- a/packages/app/test/session.test.ts
+++ b/packages/app/test/session.test.ts
@@ -136,9 +136,10 @@ describe("Session.load with a parked proposal (#95)", () => {
 
   it("load with no pending proposal serves the working file unchanged", async () => {
     // Seed the canonical first: with it missing, load() short-circuits on the seed branch and
-    // this test would never reach the pendingProposal branch it exists to exercise.
-    writeFileSync(session.paths.canonicalPath, "# Plan\n\nACCEPTED body.\n");
-    expect((await session.load()).content).toBe("# Plan\n\nACCEPTED body.\n");
+    // this test would never reach the pendingProposal branch it exists to exercise. Seed it with
+    // DISTINCT content — identical strings could not tell which of the two load() served.
+    writeFileSync(session.paths.canonicalPath, "# Plan\n\nan older accepted base.\n");
+    expect((await session.load()).content).toBe("# Plan\n\nACCEPTED body.\n"); // the file, not the canonical
   });
 
   it("a failed proposal lookup never blocks loading — load falls back to the working file", async () => {

--- a/packages/app/test/session.test.ts
+++ b/packages/app/test/session.test.ts
@@ -135,6 +135,17 @@ describe("Session.load with a parked proposal (#95)", () => {
   });
 
   it("load with no pending proposal serves the working file unchanged", async () => {
+    // Seed the canonical first: with it missing, load() short-circuits on the seed branch and
+    // this test would never reach the pendingProposal branch it exists to exercise.
+    writeFileSync(session.paths.canonicalPath, "# Plan\n\nACCEPTED body.\n");
+    expect((await session.load()).content).toBe("# Plan\n\nACCEPTED body.\n");
+  });
+
+  it("a failed proposal lookup never blocks loading — load falls back to the working file", async () => {
+    // The lookup can reject (rows-lock contention past its deadline, an unreadable sidecar).
+    // Sidecar availability must not decide whether the document opens.
+    writeFileSync(session.paths.canonicalPath, ""); // canonical present, so the lookup branch runs
+    vi.spyOn(session, "pendingProposal").mockRejectedValue(new Error("rows lock timeout"));
     expect((await session.load()).content).toBe("# Plan\n\nACCEPTED body.\n");
   });
 });

--- a/packages/cli/src/applyEdit.ts
+++ b/packages/cli/src/applyEdit.ts
@@ -4,7 +4,7 @@
 // edit lands in the file model or a runtime plugin's document. Split out of cli.ts so it's
 // unit-testable without running the CLI's top-level main().
 
-import { type ControlChannel, type DocumentStore, LogEventType, hashBody } from "@inplan/core/node";
+import { type ControlChannel, type DocumentStore, LogEventType, hashBody, parse } from "@inplan/core/node";
 import type { AgentEditEvaluation } from "./gate";
 import type { PluginGate } from "./pluginGate";
 import { utf8Bytes } from "./remoteDocState";
@@ -42,8 +42,9 @@ export async function applyGatedEdit(
   } else if (ev.changed && quarantine) {
     // Quarantine: park the proposal for the human to accept/reject in the editor. The proposal
     // sidecar is file-based either way; on the file path also revert the working file to canonical
-    // (the human's accept later writes canonical). On the plugin path the plugin owns the working
-    // doc, so there's no .md to revert.
+    // (the human's accept later writes canonical) — unless the revert would wipe real content
+    // with a blank canonical, the #95 clobber (see revertWouldWipe). On the plugin path the
+    // plugin owns the working doc, so there's no .md to revert.
     let proposalId: string;
     try {
       ({ id: proposalId } = await store.createProposal({ content: current, baseHash: hashBody(canonicalText), baseContent: canonicalText }));
@@ -65,7 +66,7 @@ export async function applyGatedEdit(
     // durable record is already on disk). Every failure below is local housekeeping and must not
     // be reported as a failed park: claiming "FAILED, will be re-pushed" for a proposal the human
     // can already see in their editor is the same class of false signal #88 exists to kill.
-    if (!gate) {
+    if (!gate && !revertWouldWipe(canonicalText, current)) {
       try {
         await store.saveDoc(canonicalText);
       } catch {
@@ -100,6 +101,29 @@ export async function applyGatedEdit(
     await channel.append({ actor: "agent", type: LogEventType.DocumentEdited, payload: { bytes: utf8Bytes(current) } });
   }
   return { proposed: false };
+}
+
+/**
+ * Would reverting the working file to `canonicalText` replace real content with a blank body?
+ * (#95) `open` on a fresh path seeds an EMPTY canonical, so on a brand-new doc whose first
+ * content arrives from the agent, the quarantine revert used to materialize that empty canonical
+ * over the only copy of the text — killing the session (SIGTERM) before the first human action
+ * then left the working file at 0 bytes, with the content surviving only in the proposal sidecar.
+ * When the revert would be a total wipe (blank canonical body over a non-blank working body),
+ * skip it: the proposal is already parked and the working file keeps the text, exactly like the
+ * failed-revert path below — the next turn re-parks the identical text as a no-op, and the
+ * human's accept still writes canonical. An open/wait must never write the working file emptier
+ * than what it read; only a real human decision may.
+ */
+function revertWouldWipe(canonicalText: string, current: string): boolean {
+  const blank = (text: string): boolean => {
+    try {
+      return parse(text).body.trim() === "";
+    } catch {
+      return text.trim() === ""; // unparseable comment block — judge the raw text
+    }
+  };
+  return blank(canonicalText) && !blank(current);
 }
 
 /** An edit that lands directly moots the caller's own parked proposal, if any — retract it. */

--- a/packages/cli/test/applyGatedEdit.test.ts
+++ b/packages/cli/test/applyGatedEdit.test.ts
@@ -45,6 +45,28 @@ describe("applyGatedEdit — file path (no plugin)", () => {
     expect(await types(channel)).toEqual([LogEventType.AgentRevisionProposed]);
   });
 
+  it("quarantine with a BLANK canonical parks the proposal but never wipes the working file (#95)", async () => {
+    // `open` on a fresh path seeds an empty canonical; the agent's first fill is the only copy of
+    // the text. The revert used to materialize the empty canonical over it — a total wipe.
+    const store = new MemoryDocumentStore("the whole plan body");
+    const channel = new MemoryControlChannel();
+    const applied = await applyGatedEdit(store, channel, ev({ changed: true }), { current: "the whole plan body", canonicalText: "", quarantine: true, gate: null });
+    expect(applied.proposed).toBe(true); // review semantics intact: the park still happens
+    expect(await proposedContent(store)).toBe("the whole plan body");
+    expect(await store.loadDoc()).toBe("the whole plan body"); // NOT reverted — this is the only copy
+    expect(await types(channel)).toEqual([LogEventType.AgentRevisionProposed]);
+  });
+
+  it("the wipe guard judges the BODY, not the raw text: a comments-only canonical is still blank", async () => {
+    // A canonical holding only the comment data block (no body) is the same total-wipe shape.
+    const store = new MemoryDocumentStore("the whole plan body");
+    const channel = new MemoryControlChannel();
+    const canonicalText = "<!--inplan\n[]\n-->\n";
+    const applied = await applyGatedEdit(store, channel, ev({ changed: true }), { current: "the whole plan body", canonicalText, quarantine: true, gate: null });
+    expect(applied.proposed).toBe(true);
+    expect(await store.loadDoc()).toBe("the whole plan body"); // NOT reverted
+  });
+
   it("confirmed deletions: writes acceptedText to file + canonical, clears proposed, logs DocumentEdited", async () => {
     const store = new MemoryDocumentStore("with comment");
     const channel = new MemoryControlChannel();

--- a/packages/cli/test/open.test.ts
+++ b/packages/cli/test/open.test.ts
@@ -7,7 +7,7 @@
 // ensureDoc.test.ts; here we exercise the real `open` command end-to-end.)
 
 import { spawn, spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -35,14 +35,29 @@ afterEach(() => {
   rmSync(home, { recursive: true, force: true });
 });
 
-async function waitForFile(path: string, timeoutMs: number): Promise<boolean> {
+async function waitFor(cond: () => boolean, timeoutMs: number): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    if (existsSync(path)) return true;
+    if (cond()) return true;
     await new Promise((r) => setTimeout(r, 20));
   }
-  return existsSync(path);
+  return cond();
 }
+
+const waitForFile = (path: string, timeoutMs: number): Promise<boolean> => waitFor(() => existsSync(path), timeoutMs);
+
+/** The named sidecar file under this run's single control dir (`$INPLAN_SIDECAR_DIR/<key>/<name>`), else null. */
+function sidecarPath(name: string): string | null {
+  const root = join(home, "sidecars");
+  if (!existsSync(root)) return null;
+  for (const key of readdirSync(root)) {
+    const candidate = join(root, key, name);
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+const waitForSidecar = (name: string, timeoutMs: number): Promise<boolean> => waitFor(() => sidecarPath(name) !== null, timeoutMs);
 
 describe("inplan open", () => {
   it("creates an empty doc for a fresh path (open-then-fill), not 'file not found'", async () => {
@@ -69,6 +84,46 @@ describe("inplan open", () => {
     expect(r.stderr).toMatch(/file not found/i);
     expect(existsSync(file)).toBe(false); // wait never creates the file
   });
+
+  it("SIGTERM before the first human action never clobbers the file to the empty canonical (#95)", async () => {
+    // The live incident: `open` on a fresh path seeded an EMPTY canonical; the agent filled the
+    // file; a relaunched waiter parked the fill as a review proposal and reverted the working
+    // file to the empty canonical; SIGTERM landed before any human action — the doc was 0 bytes
+    // on disk, recoverable only from the proposed sidecar. The original bytes must survive.
+    const file = join(home, "clobber.plan.md");
+    const plan = `# The plan\n\n${"A paragraph of real content that must survive.\n".repeat(40)}`;
+
+    // 1. `open` a fresh path: creates the empty doc, seeds the empty canonical, blocks in waitCycle.
+    const first = spawn(process.execPath, [CLI, "open", file], { env });
+    try {
+      expect(await waitForSidecar("canonical.md", 10_000)).toBe(true);
+      expect(readFileSync(sidecarPath("canonical.md")!, "utf8")).toBe(""); // the incident's shape: canonical is authoritative-empty
+
+      // 2. The agent fills the doc in place (open-then-fill) while the session is up.
+      writeFileSync(file, plan);
+    } finally {
+      first.kill("SIGTERM"); // the incident's first waiter death
+    }
+
+    // 3. A relaunched waiter processes the turn: default Review mode parks the fill as a proposal.
+    //    `agent_revision_proposed` in the log means the park — and any revert — has already run.
+    const second = spawn(process.execPath, [CLI, "open", file], { env });
+    try {
+      expect(
+        await waitFor(() => {
+          const log = sidecarPath("log.jsonl");
+          return log !== null && readFileSync(log, "utf8").includes("agent_revision_proposed");
+        }, 10_000),
+      ).toBe(true);
+    } finally {
+      second.kill("SIGTERM"); // before any human action — the incident's second waiter death
+    }
+    await waitFor(() => second.exitCode !== null || second.signalCode !== null, 5000);
+
+    // 4. The park is real (the proposal sidecar holds the text) AND the working file kept its bytes.
+    expect(readFileSync(sidecarPath("proposed.md")!, "utf8")).toBe(plan);
+    expect(readFileSync(file, "utf8")).toBe(plan); // never materialized emptier content than it read
+  }, 30_000);
 
   it("deprecates `open --remote` and runs it as `wait --remote`", () => {
     // A cloud doc has no local editor to launch — the only thing `open` adds locally — so

--- a/packages/cli/test/open.test.ts
+++ b/packages/cli/test/open.test.ts
@@ -104,21 +104,27 @@ describe("inplan open", () => {
     } finally {
       first.kill("SIGTERM"); // the incident's first waiter death
     }
+    // JOIN the first process before relaunching: both runs key the SAME sidecar dir (waitlock,
+    // log.jsonl), so overlapping teardown would make the lifecycle timing-dependent — and a park
+    // the dying first run manages to squeeze in must be counted as PRE-EXISTING, not mistaken
+    // for the second run's.
+    expect(await waitFor(() => first.exitCode !== null || first.signalCode !== null, 5000)).toBe(true);
+    const parkCount = (): number => {
+      const log = sidecarPath("log.jsonl");
+      return log === null ? 0 : (readFileSync(log, "utf8").match(/agent_revision_proposed/g) ?? []).length;
+    };
+    const parksBefore = parkCount();
 
     // 3. A relaunched waiter processes the turn: default Review mode parks the fill as a proposal.
-    //    `agent_revision_proposed` in the log means the park — and any revert — has already run.
+    //    A NEW `agent_revision_proposed` (count increase) means the park — and any revert — has
+    //    already run in the second process; a leftover first-run event can never satisfy this.
     const second = spawn(process.execPath, [CLI, "open", file], { env });
     try {
-      expect(
-        await waitFor(() => {
-          const log = sidecarPath("log.jsonl");
-          return log !== null && readFileSync(log, "utf8").includes("agent_revision_proposed");
-        }, 10_000),
-      ).toBe(true);
+      expect(await waitFor(() => parkCount() > parksBefore, 10_000)).toBe(true);
     } finally {
       second.kill("SIGTERM"); // before any human action — the incident's second waiter death
     }
-    await waitFor(() => second.exitCode !== null || second.signalCode !== null, 5000);
+    expect(await waitFor(() => second.exitCode !== null || second.signalCode !== null, 5000)).toBe(true);
 
     // 4. The park is real (the proposal sidecar holds the text) AND the working file kept its bytes.
     expect(readFileSync(sidecarPath("proposed.md")!, "utf8")).toBe(plan);

--- a/packages/core/src/fsBackend.ts
+++ b/packages/core/src/fsBackend.ts
@@ -210,8 +210,13 @@ export class FsDocumentStore implements DocumentStore {
    * (main process) and a CLI can share one sidecar, and interleaved mutations would lose a
    * lifecycle update. mkdir is the atomic primitive; a stale lock (a crashed holder) is broken
    * after 2s. Mutations here are a few file ops — well under the staleness window.
+   *
+   * Async: contention waits are AWAITED sleeps, never a synchronous spin — the desktop editor
+   * calls this on Electron's main thread, where a sync busy-wait under a held lock froze the
+   * whole UI for up to the 2s deadline. The semantics are unchanged (owner token, ~2s deadline,
+   * atomic take-by-rename release, quarantine behavior); only the wait yields the event loop.
    */
-  private withRowsLock<T>(run: () => T): T {
+  private async withRowsLock<T>(run: () => T): Promise<T> {
     const lockDir = `${this.proposalsPath()}.lock`;
     const ownerPath = join(lockDir, "owner");
     const token = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -237,8 +242,7 @@ export class FsDocumentStore implements DocumentStore {
           continue;
         }
         if (Date.now() > deadline) throw new Error(`proposal rows lock is held: ${lockDir}`);
-        const buf = new SharedArrayBuffer(4);
-        Atomics.wait(new Int32Array(buf), 0, 0, 25); // sync sleep without spinning a core
+        await new Promise((resolve) => setTimeout(resolve, 25)); // backoff without blocking the event loop
       }
     }
     try {
@@ -332,7 +336,7 @@ export class FsDocumentStore implements DocumentStore {
   }
 
   async withdrawProposal(id: string): Promise<void> {
-    this.withRowsLock(() => {
+    await this.withRowsLock(() => {
       const rows = this.readRowsAdoptingLegacy();
       const r = rows.find((x) => x.id === id);
       if (r && r.state === "pending") {

--- a/packages/core/test/fsBackend.test.ts
+++ b/packages/core/test/fsBackend.test.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -121,6 +121,30 @@ describe("FsDocumentStore", () => {
     await store.withdrawProposal(adopted!.id); // the full lifecycle applies to it now
     expect(await store.myPendingProposal()).toBeNull();
     expect(existsSync(paths.proposedPath)).toBe(false); // the derived file follows the lifecycle
+  });
+
+  it("a held rows lock never blocks the event loop — timers keep firing during a contended lookup", async () => {
+    // The desktop editor runs these lookups on Electron's main thread: under contention the old
+    // acquisition loop slept synchronously, freezing the whole process (no timers, no IPC, no
+    // paint) for up to the 2s deadline. Hold the lock as "another process", schedule its release
+    // on a timer, and require the event loop to have kept running while the lookup waited — the
+    // release itself can only happen if timers fire mid-contention.
+    const store = new FsDocumentStore(paths);
+    const lockDir = `${paths.proposedPath}.rows.json.lock`;
+    mkdirSync(lockDir, { recursive: true });
+    writeFileSync(join(lockDir, "owner"), "another-process");
+    let ticks = 0;
+    const tick = setInterval(() => {
+      ticks++;
+    }, 10);
+    const release = setTimeout(() => rmSync(lockDir, { recursive: true, force: true }), 150);
+    try {
+      expect(await store.myPendingProposal()).toBeNull(); // acquires once the timer-driven release runs
+    } finally {
+      clearInterval(tick);
+      clearTimeout(release);
+    }
+    expect(ticks).toBeGreaterThanOrEqual(5); // the event loop stayed live while the lock was held
   });
 
   it("caps autosave backups at the retention limit", async () => {


### PR DESCRIPTION
Fixes #95.

`inplan open` on a fresh path seeds an EMPTY canonical sidecar. When a brand-new doc's first content arrives from the agent, the Review-mode quarantine parked it as a proposal and then reverted the working file to that empty canonical — so killing the session (SIGTERM) before the first human action left the doc at 0 bytes on disk, recoverable only from the `proposed.md` sidecar. Exactly the incident in #95: empty-canonical + non-empty-proposed is the highest-risk shape, and the write-back was a total wipe.

The fix guards the quarantine revert in `applyGatedEdit` (`packages/cli/src/applyEdit.ts`): when the canonical **body** is blank and the working body is not, the revert is skipped. Review semantics are intact — the proposal is still parked and logged, and the human's accept still writes canonical. The working file just keeps the only copy of the text, under the same recovery contract as the existing failed-revert path: the next turn re-parks the identical text as a no-op. An open/wait never writes the working file emptier than what it read; only a real human decision may.

Tests:
- Two units pin the guard: a blank canonical, and a comments-only canonical whose body is blank (the guard judges the parsed body, not the raw text).
- An end-to-end regression in `open.test.ts` replays the incident with the real CLI: `open` a fresh path, assert the seeded canonical is empty, fill the file while the session is up, SIGTERM the waiter, relaunch `open`, wait for the park (`agent_revision_proposed` in the control log — by then the revert, if any, has run), SIGTERM again before any human action, then assert the proposal sidecar holds the text **and** the working file kept its original bytes.
- Proven against the bug: with the guard reverted, exactly these three tests fail (the e2e shows the file wiped to empty); with it restored, the full suite passes (1267 tests, coverage 95.56%).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved working-file content when quarantined proposals have blank or comments-only canonical content.
  * Prevented relaunching an open document from overwriting edits made before review.
  * Ensured pending proposals remain safely stored for later review.
  * Improved document loading when pending proposal data is temporarily unavailable.
  * Prevented file-lock contention from blocking other application activity.
  * Avoided duplicate or invalid proposal decisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->