### PR TITLE
Deflake the renderer review suites: sequence on observables, not on luck

### DIFF
--- a/packages/renderer/test/App.review.matrix.test.tsx
+++ b/packages/renderer/test/App.review.matrix.test.tsx
@@ -56,11 +56,17 @@ describe("App review decision matrix (memory-backed)", () => {
   async function renderAndPropose(revision = REVISED) {
     const { App } = await import("../src/App");
     render(<App />);
-    await waitFor(() => expect(document.body.textContent).toContain("Alpha line."));
+    await waitFor(() => expect(document.body.textContent).toContain("Alpha line."), { timeout: 5000 });
+    // AWAIT the proposal inside act. Fire-and-forget let setProposal land outside act (the
+    // propose chain hops the microtask queue through hashing), so the review bar could be
+    // observed after its first commit but BEFORE the effect that initializes the per-hunk
+    // accept state had flushed — a click in that window is a no-op on the empty state or is
+    // overwritten by the init (the reject/edit silently reverts to all-accepted). Awaiting
+    // inside act makes act drain that render AND its effects before the helper returns.
     await act(async () => {
-      agent.proposeRevision(revision);
+      await agent.proposeRevision(revision);
     });
-    await waitFor(() => expect(document.body.textContent).toContain("Agent proposed changes"));
+    await waitFor(() => expect(document.body.textContent).toContain("Agent proposed changes"), { timeout: 5000 });
   }
 
   it("a parked proposal shows the diff with N hunks (one switch per hunk)", async () => {
@@ -89,15 +95,16 @@ describe("App review decision matrix (memory-backed)", () => {
     expect(tri().getAttribute("aria-checked")).toBe("true");
     expect(document.querySelector(".ap-tri--accept")).toBeTruthy();
 
-    // Cycle once: accept → reject. aria-checked becomes false.
+    // Cycle once: accept → reject. aria-checked becomes false. Wait for each cycle's
+    // state before clicking again — the next click's meaning depends on it.
     await act(async () => fireEvent.click(tri()));
-    expect(tri().getAttribute("aria-checked")).toBe("false");
+    await waitFor(() => expect(tri().getAttribute("aria-checked")).toBe("false"), { timeout: 5000 });
     expect(document.querySelector(".ap-tri--reject")).toBeTruthy();
     expect(document.body.textContent).not.toContain("will be accepted");
 
     // Cycle again: reject → accept.
     await act(async () => fireEvent.click(tri()));
-    expect(tri().getAttribute("aria-checked")).toBe("true");
+    await waitFor(() => expect(tri().getAttribute("aria-checked")).toBe("true"), { timeout: 5000 });
     expect(document.querySelector(".ap-tri--accept")).toBeTruthy();
   });
 
@@ -109,8 +116,9 @@ describe("App review decision matrix (memory-backed)", () => {
     expect(hunk1Before.checked).toBe(true);
     expect(hunk2Before.checked).toBe(true);
 
-    // Reject ONLY change 1.
+    // Reject ONLY change 1 — and wait for the reject to observably commit.
     await act(async () => fireEvent.click(hunk1Before));
+    await waitFor(() => expect((screen.getAllByRole("switch", { name: /accept change 1/ })[0] as HTMLInputElement).checked).toBe(false), { timeout: 5000 });
 
     const hunk1 = screen.getAllByRole("switch", { name: /accept change 1/ })[0] as HTMLInputElement;
     const hunk2 = screen.getAllByRole("switch", { name: /accept change 2/ })[0] as HTMLInputElement;
@@ -125,7 +133,7 @@ describe("App review decision matrix (memory-backed)", () => {
 
     // One click on the mixed tri resolves the whole set back to accept.
     await act(async () => fireEvent.click(tri()));
-    expect(document.querySelector(".ap-tri--accept")).toBeTruthy();
+    await waitFor(() => expect(document.querySelector(".ap-tri--accept")).toBeTruthy(), { timeout: 5000 });
     expect((screen.getAllByRole("switch", { name: /accept change 1/ })[0] as HTMLInputElement).checked).toBe(true);
   });
 
@@ -136,32 +144,34 @@ describe("App review decision matrix (memory-backed)", () => {
       fireEvent.click(screen.getByRole("button", { name: /^Apply$/ }));
     });
 
-    await waitFor(() => expect(document.body.textContent).not.toContain("Agent proposed changes"));
+    await waitFor(() => expect(document.body.textContent).not.toContain("Agent proposed changes"), { timeout: 5000 });
     // Both accepted hunks landed in the applied (preview) body.
     expect(document.body.textContent).toContain("Alpha CHANGED.");
     expect(document.body.textContent).toContain("Beta CHANGED.");
     expect(document.body.textContent).not.toContain("Alpha line.");
     expect(document.body.textContent).not.toContain("Beta line.");
-    // Decision made → proposal discarded.
-    expect(await (window as unknown as Win).api.getProposal()).toBeNull();
+    // Decision made → proposal discarded — the settle is a chained promise
+    // (clearProposal → decideProposal), so poll rather than read once.
+    await waitFor(async () => expect(await (window as unknown as Win).api.getProposal()).toBeNull(), { timeout: 5000 });
   });
 
   it("Reject-all then Apply discards the proposal and leaves the body unchanged", async () => {
     await renderAndPropose();
-    // accept → reject (one click rejects every hunk).
+    // accept → reject (one click rejects every hunk). Don't Apply until the reject
+    // observably committed — Apply reads the toggle state.
     await act(async () => fireEvent.click(tri()));
-    expect(document.querySelector(".ap-tri--reject")).toBeTruthy();
+    await waitFor(() => expect(document.querySelector(".ap-tri--reject")).toBeTruthy(), { timeout: 5000 });
 
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: /^Apply$/ }));
     });
 
-    await waitFor(() => expect(document.body.textContent).not.toContain("Agent proposed changes"));
+    await waitFor(() => expect(document.body.textContent).not.toContain("Agent proposed changes"), { timeout: 5000 });
     // Original body intact; nothing from the proposal survived.
     expect(document.body.textContent).toContain("Alpha line.");
     expect(document.body.textContent).toContain("Beta line.");
     expect(document.body.textContent).not.toContain("CHANGED");
-    expect(await (window as unknown as Win).api.getProposal()).toBeNull();
+    await waitFor(async () => expect(await (window as unknown as Win).api.getProposal()).toBeNull(), { timeout: 5000 });
   });
 
   it("the pencil edits a hunk's proposed text and Apply uses the EDITED text", async () => {
@@ -180,11 +190,14 @@ describe("App review decision matrix (memory-backed)", () => {
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: /save edit/i }));
     });
+    // Don't Apply until the saved edit is observably part of the review (the diff
+    // preview renders the edited proposed text) — Apply reads the edits state.
+    await waitFor(() => expect(document.body.textContent).toContain("Alpha EDITED."), { timeout: 5000 });
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: /^Apply$/ }));
     });
 
-    await waitFor(() => expect(document.body.textContent).not.toContain("Agent proposed changes"));
+    await waitFor(() => expect(document.body.textContent).not.toContain("Agent proposed changes"), { timeout: 5000 });
     // The human's edit wins over the agent's proposal for hunk 1; hunk 2 still applies.
     expect(document.body.textContent).toContain("Alpha EDITED.");
     expect(document.body.textContent).not.toContain("Alpha CHANGED.");
@@ -203,13 +216,16 @@ describe("App review decision matrix (memory-backed)", () => {
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: /save edit/i }));
     });
-    // Now reject change 1 entirely.
+    await waitFor(() => expect(document.body.textContent).toContain("Alpha EDITED."), { timeout: 5000 });
+    // Now reject change 1 entirely — and wait for the reject to observably commit
+    // before Apply reads the toggle state.
     await act(async () => fireEvent.click(screen.getAllByRole("switch", { name: /accept change 1/ })[0]!));
+    await waitFor(() => expect((screen.getAllByRole("switch", { name: /accept change 1/ })[0] as HTMLInputElement).checked).toBe(false), { timeout: 5000 });
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: /^Apply$/ }));
     });
 
-    await waitFor(() => expect(document.body.textContent).not.toContain("Agent proposed changes"));
+    await waitFor(() => expect(document.body.textContent).not.toContain("Agent proposed changes"), { timeout: 5000 });
     // Rejected hunk keeps the ORIGINAL line; the saved edit is discarded with the rejection.
     expect(document.body.textContent).toContain("Alpha line.");
     expect(document.body.textContent).not.toContain("Alpha EDITED.");

--- a/packages/renderer/test/App.reviewDeep.test.tsx
+++ b/packages/renderer/test/App.reviewDeep.test.tsx
@@ -43,11 +43,17 @@ afterEach(cleanup);
 async function mountAndPropose() {
   const { App } = await import("../src/App");
   render(<App />);
-  await waitFor(() => expect(document.body.textContent).toContain("Alpha line."));
+  await waitFor(() => expect(document.body.textContent).toContain("Alpha line."), { timeout: 5000 });
+  // AWAIT the proposal inside act. Fire-and-forget let setProposal land outside act (the
+  // propose chain hops the microtask queue through hashing), so the review bar could be
+  // observed after its first commit but BEFORE the effect that initializes the per-hunk
+  // accept state had flushed — a click in that window is a no-op on the empty state or is
+  // overwritten by the init (the reject silently reverts to all-accepted). Awaiting inside
+  // act makes act drain that render AND its effects before the helper returns.
   await act(async () => {
-    agent.proposeRevision(REVISED);
+    await agent.proposeRevision(REVISED);
   });
-  await waitFor(() => expect(document.body.textContent).toContain("Agent proposed changes"));
+  await waitFor(() => expect(document.body.textContent).toContain("Agent proposed changes"), { timeout: 5000 });
 }
 
 describe("App deep review flow (memory-backed)", () => {
@@ -61,22 +67,29 @@ describe("App deep review flow (memory-backed)", () => {
     await act(async () => {
       tri.click();
     });
-    expect(document.querySelector(".ap-tri--reject")).toBeTruthy();
+    // Don't Apply until the reject-all observably committed — Apply reads the toggle state.
+    await waitFor(() => expect(document.querySelector(".ap-tri--reject")).toBeTruthy(), { timeout: 5000 });
     await act(async () => {
       apply.click();
     });
 
-    // Review bar is gone and the parked proposal was cleared.
-    await waitFor(() => expect(document.body.textContent).not.toContain("Agent proposed changes"));
-    expect(await api().getProposal()).toBeNull();
+    // Review bar is gone and the parked proposal was cleared. The settle and the decision
+    // log entry are chained promises behind Apply, so poll them rather than read once.
+    await waitFor(() => expect(document.body.textContent).not.toContain("Agent proposed changes"), { timeout: 5000 });
+    await waitFor(async () => expect(await api().getProposal()).toBeNull(), { timeout: 5000 });
 
     // The proposed text was NOT adopted — the original body survives.
     expect(document.body.textContent).toContain("Alpha line.");
     expect(document.body.textContent).not.toContain("Alpha CHANGED.");
 
     // Rejecting every hunk logs the rejected-all decision.
-    const log = await agent.log();
-    expect(log.some((e) => e.type === "revision_rejected_all")).toBe(true);
+    await waitFor(
+      async () => {
+        const log = await agent.log();
+        expect(log.some((e) => e.type === "revision_rejected_all")).toBe(true);
+      },
+      { timeout: 5000 },
+    );
   });
 
   it('"later" parks the review behind an "awaiting your review" banner that re-shows it', async () => {
@@ -88,7 +101,7 @@ describe("App deep review flow (memory-backed)", () => {
     });
 
     // The review bar is parked; a banner offers to re-open it.
-    await waitFor(() => expect(document.body.textContent).not.toContain("Agent proposed changes"));
+    await waitFor(() => expect(document.body.textContent).not.toContain("Agent proposed changes"), { timeout: 5000 });
     expect(document.body.textContent).toContain("awaiting your review");
     // The proposal itself is still parked (not discarded).
     expect(await api().getProposal()).not.toBeNull();
@@ -98,7 +111,7 @@ describe("App deep review flow (memory-backed)", () => {
     await act(async () => {
       reShow.click();
     });
-    await waitFor(() => expect(document.body.textContent).toContain("Agent proposed changes"));
+    await waitFor(() => expect(document.body.textContent).toContain("Agent proposed changes"), { timeout: 5000 });
     expect(document.body.textContent).not.toContain("awaiting your review");
   });
 

--- a/packages/renderer/test/App.reviewDiff.test.tsx
+++ b/packages/renderer/test/App.reviewDiff.test.tsx
@@ -47,11 +47,17 @@ describe("App review diff controls (memory-backed)", () => {
   async function renderAndPropose() {
     const { App } = await import("../src/App");
     render(<App />);
-    await waitFor(() => expect(document.body.textContent).toContain("Alpha line."));
+    await waitFor(() => expect(document.body.textContent).toContain("Alpha line."), { timeout: 5000 });
+    // AWAIT the proposal inside act. Fire-and-forget let setProposal land outside act (the
+    // propose chain hops the microtask queue through hashing), so the review bar could be
+    // observed after its first commit but BEFORE the effect that initializes the per-hunk
+    // accept state had flushed — a click in that window is a no-op on the empty state or is
+    // overwritten by the init (the reject/edit silently reverts to all-accepted). Awaiting
+    // inside act makes act drain that render AND its effects before the helper returns.
     await act(async () => {
-      agent.proposeRevision(REVISED);
+      await agent.proposeRevision(REVISED);
     });
-    await waitFor(() => expect(document.body.textContent).toContain("Agent proposed changes"));
+    await waitFor(() => expect(document.body.textContent).toContain("Agent proposed changes"), { timeout: 5000 });
   }
 
   it("'Review next' steps through the change hunks, showing the cursor position", async () => {
@@ -88,6 +94,8 @@ describe("App review diff controls (memory-backed)", () => {
     await act(async () => {
       fireEvent.click(change1[0]!);
     });
+    // Don't Apply until the reject actually committed — Apply reads the toggle state.
+    await waitFor(() => expect((screen.getAllByRole("switch", { name: /accept change 1/ })[0] as HTMLInputElement).checked).toBe(false), { timeout: 5000 });
 
     const apply = screen.getByRole("button", { name: /^Apply$/ });
     await act(async () => {
@@ -96,12 +104,13 @@ describe("App review diff controls (memory-backed)", () => {
 
     // Review bar clears; the rejected first hunk kept "Alpha line.", the accepted
     // second hunk became "Beta CHANGED."
-    await waitFor(() => expect(document.body.textContent).not.toContain("Agent proposed changes"));
+    await waitFor(() => expect(document.body.textContent).not.toContain("Agent proposed changes"), { timeout: 5000 });
     expect(document.body.textContent).toContain("Alpha line.");
     expect(document.body.textContent).toContain("Beta CHANGED.");
     expect(document.body.textContent).not.toContain("Beta line.");
-    // Proposal was discarded after a decision was made.
-    expect(await (window as unknown as Win).api.getProposal()).toBeNull();
+    // Proposal was discarded after a decision was made — the settle is a chained promise
+    // (clearProposal → decideProposal), so poll rather than read once.
+    await waitFor(async () => expect(await (window as unknown as Win).api.getProposal()).toBeNull(), { timeout: 5000 });
   });
 
   it("'Reject all' then Apply keeps the original body and discards the proposal", async () => {
@@ -111,16 +120,18 @@ describe("App review diff controls (memory-backed)", () => {
     await act(async () => {
       fireEvent.click(screen.getByRole("checkbox", { name: /accept or reject all changes/i }));
     });
+    // Don't Apply until the tri-state observably flipped to reject — Apply reads the toggle state.
+    await waitFor(() => expect(screen.getByRole("checkbox", { name: /accept or reject all changes/i }).getAttribute("aria-checked")).toBe("false"), { timeout: 5000 });
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: /^Apply$/ }));
     });
 
-    await waitFor(() => expect(document.body.textContent).not.toContain("Agent proposed changes"));
+    await waitFor(() => expect(document.body.textContent).not.toContain("Agent proposed changes"), { timeout: 5000 });
     // Nothing from the proposal survived.
     expect(document.body.textContent).toContain("Alpha line.");
     expect(document.body.textContent).toContain("Beta line.");
     expect(document.body.textContent).not.toContain("CHANGED");
-    expect(await (window as unknown as Win).api.getProposal()).toBeNull();
+    await waitFor(async () => expect(await (window as unknown as Win).api.getProposal()).toBeNull(), { timeout: 5000 });
   });
 
   it("shows a per-hunk 'will be accepted/rejected' label and a tri-state that goes mixed", async () => {
@@ -131,7 +142,7 @@ describe("App review diff controls (memory-backed)", () => {
     await act(async () => {
       fireEvent.click(screen.getAllByRole("switch", { name: /accept change 1/ })[0]!);
     });
-    expect(document.body.textContent).toContain("will be rejected");
+    await waitFor(() => expect(document.body.textContent).toContain("will be rejected"), { timeout: 5000 });
     expect(document.querySelector(".ap-tri--mixed")).toBeTruthy();
   });
 
@@ -139,18 +150,19 @@ describe("App review diff controls (memory-backed)", () => {
     await renderAndPropose();
     const tri = (): HTMLElement => screen.getByRole("checkbox", { name: /accept or reject all changes/i });
     expect(document.querySelector(".ap-tri--accept")).toBeTruthy(); // default: all accepted
-    // accept → reject (one click rejects every hunk).
+    // accept → reject (one click rejects every hunk). Each step waits for the state it
+    // produced before clicking again — the next click's meaning depends on it.
     await act(async () => fireEvent.click(tri()));
-    expect(document.querySelector(".ap-tri--reject")).toBeTruthy();
+    await waitFor(() => expect(document.querySelector(".ap-tri--reject")).toBeTruthy(), { timeout: 5000 });
     expect(document.body.textContent).not.toContain("will be accepted");
     // reject → accept.
     await act(async () => fireEvent.click(tri()));
-    expect(document.querySelector(".ap-tri--accept")).toBeTruthy();
+    await waitFor(() => expect(document.querySelector(".ap-tri--accept")).toBeTruthy(), { timeout: 5000 });
     // Make it mixed (reject a single hunk), then one click resolves the whole set to accept.
     await act(async () => fireEvent.click(screen.getAllByRole("switch", { name: /accept change 1/ })[0]!));
-    expect(document.querySelector(".ap-tri--mixed")).toBeTruthy();
+    await waitFor(() => expect(document.querySelector(".ap-tri--mixed")).toBeTruthy(), { timeout: 5000 });
     await act(async () => fireEvent.click(tri()));
-    expect(document.querySelector(".ap-tri--accept")).toBeTruthy();
+    await waitFor(() => expect(document.querySelector(".ap-tri--accept")).toBeTruthy(), { timeout: 5000 });
   });
 
   it("the pencil edits a hunk's proposed text and Apply uses the edited text", async () => {
@@ -166,10 +178,13 @@ describe("App review diff controls (memory-backed)", () => {
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: /save edit/i }));
     });
+    // Don't Apply until the saved edit is observably part of the review (the diff
+    // preview renders the edited proposed text) — Apply reads the edits state.
+    await waitFor(() => expect(document.body.textContent).toContain("Alpha EDITED."), { timeout: 5000 });
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: /^Apply$/ }));
     });
-    await waitFor(() => expect(document.body.textContent).not.toContain("Agent proposed changes"));
+    await waitFor(() => expect(document.body.textContent).not.toContain("Agent proposed changes"), { timeout: 5000 });
     expect(document.body.textContent).toContain("Alpha EDITED."); // the human's edit, not the agent's
     expect(document.body.textContent).not.toContain("Alpha CHANGED.");
   });
@@ -189,7 +204,7 @@ describe("App review diff controls (memory-backed)", () => {
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: /^Apply$/ }));
     });
-    await waitFor(() => expect(document.body.textContent).not.toContain("Agent proposed changes"));
+    await waitFor(() => expect(document.body.textContent).not.toContain("Agent proposed changes"), { timeout: 5000 });
     expect(document.body.textContent).toContain("Alpha CHANGED."); // unchanged proposal applied
     expect(document.body.textContent).not.toContain("Alpha EDITED.");
   });
@@ -205,14 +220,18 @@ describe("App review diff controls (memory-backed)", () => {
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: /save edit/i }));
     });
+    // The saved edit must be committed before ⌘Z, or there is nothing to undo yet.
+    await waitFor(() => expect(document.body.textContent).toContain("Alpha EDITED."), { timeout: 5000 });
     // Undo the edit through the review timeline (no field focused → routes to reviewUndo).
     await act(async () => {
       fireEvent.keyDown(document, { key: "z", metaKey: true });
     });
+    // And the undo must observably restore the proposal before Apply reads the edits state.
+    await waitFor(() => expect(document.body.textContent).not.toContain("Alpha EDITED."), { timeout: 5000 });
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: /^Apply$/ }));
     });
-    await waitFor(() => expect(document.body.textContent).not.toContain("Agent proposed changes"));
+    await waitFor(() => expect(document.body.textContent).not.toContain("Agent proposed changes"), { timeout: 5000 });
     expect(document.body.textContent).toContain("Alpha CHANGED."); // edit undone → original proposal
     expect(document.body.textContent).not.toContain("Alpha EDITED.");
   });
@@ -229,6 +248,8 @@ describe("App review diff controls (memory-backed)", () => {
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: /save edit/i }));
     });
+    // The saved edit must be committed before the keystrokes it must survive.
+    await waitFor(() => expect(document.body.textContent).toContain("Alpha EDITED."), { timeout: 5000 });
     // Re-open the editor and press ⌘Z / Ctrl+Z WITH the textarea focused. The guard
     // (active element inside .ap-ihunk-edit-ta) must let CodeMirror/native undo own it and
     // skip review-undo — so the saved edit is left intact.
@@ -249,7 +270,7 @@ describe("App review diff controls (memory-backed)", () => {
     await act(async () => {
       fireEvent.click(screen.getByRole("button", { name: /^Apply$/ }));
     });
-    await waitFor(() => expect(document.body.textContent).not.toContain("Agent proposed changes"));
+    await waitFor(() => expect(document.body.textContent).not.toContain("Agent proposed changes"), { timeout: 5000 });
     expect(document.body.textContent).toContain("Alpha EDITED."); // bypass held → edit survived
     expect(document.body.textContent).not.toContain("Alpha CHANGED.");
   });
@@ -263,7 +284,7 @@ describe("App review diff controls (memory-backed)", () => {
     });
 
     // The review bar is gone; a parked banner with a "Review" button appears.
-    await waitFor(() => expect(document.body.textContent).not.toContain("Agent proposed changes"));
+    await waitFor(() => expect(document.body.textContent).not.toContain("Agent proposed changes"), { timeout: 5000 });
     expect(document.body.textContent).toContain("The agent proposed changes awaiting your review.");
     const reviewBtn = screen.getByRole("button", { name: /^Review$/ });
 
@@ -271,7 +292,7 @@ describe("App review diff controls (memory-backed)", () => {
     await act(async () => {
       fireEvent.click(reviewBtn);
     });
-    await waitFor(() => expect(document.body.textContent).toContain("Agent proposed changes"));
+    await waitFor(() => expect(document.body.textContent).toContain("Agent proposed changes"), { timeout: 5000 });
     expect(document.body.textContent).not.toContain("awaiting your review.");
     // The proposal is still parked (not yet decided).
     expect((await (window as unknown as Win).api.getProposal())?.content).toBe(REVISED);


### PR DESCRIPTION
## Why

Under CI load (and occasionally in local parallel runs) the renderer review suites — `App.reviewDiff.test.tsx`, `App.review.matrix.test.tsx`, `App.reviewDeep.test.tsx` — failed intermittently, a different test each time, always green in isolation and on rerun. Observed shapes: a reject-all Apply that recorded as accepted-all, a per-hunk toggle that read back unchanged, and a pencil hunk-edit whose Apply used the agent's original text.

## Root cause

The helpers fired `agent.proposeRevision()` without awaiting it, so `setProposal` landed **outside `act`** (the propose chain hops the microtask queue through hashing). The review bar's first commit is then observable before the effect that initializes the per-hunk accept state (`App.tsx`: `setAccepted(new Array(changeCount).fill(true)); setEdits({})`) has flushed. The window is invisible in the DOM — `accepted[idx] ?? true` renders the switches as accepted either way — but a click inside it either no-ops on the still-empty array (per-hunk toggle) or is overwritten when the init effect lands (tri-state reject, saved pencil edit), silently reverting the review to all-accepted. That reproduces all three observed failures exactly; verified by temporarily delaying the init effect, which made the unfixed tests fail in precisely these shapes.

## Fix (tests only)

- **Await the propose inside `act`** in all three helpers, so `act` drains the proposal render *and* its effects before any interaction. This closes the race deterministically.
- **Gate every Apply on the observable precondition it depends on** (tri-state `aria-checked` flipped, hunk switch off, edited text visible in the diff preview) via `waitFor`, instead of clicking straight through — if state were ever stale again the test now fails at the precondition with a clear message rather than asserting a bogus apply.
- **Poll the genuinely async post-Apply settles**: `getProposal()` → null and the decision log entry sit behind the `clearProposal → decideProposal` / `logAction → append` continuations that Apply fires without awaiting; read them with `waitFor` rather than once.
- **Explicit 5s budgets** on the settle-dependent waits instead of `waitFor`'s 1s default, which a loaded runner can exceed.

No production code changes. One observation for the record: the init-after-first-commit window is real in the product too, but it lasts one effect flush (~ms after the bar first renders), is unreachable by a human click, and is masked from the DOM by the `?? true` fallback — so it is left as-is rather than restructured.

## Verification

- The three files run 10x sequentially: 22/22 tests green every run.
- Full renderer suite run 3x: 84 files / 606 tests green every run.
- `npm run typecheck` clean across all workspaces; pre-commit gate (full suite + coverage ≥95%) passed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

