### PR TITLE
Initialize the review state synchronously with the proposal

### DIFF
--- a/packages/renderer/src/App.tsx
+++ b/packages/renderer/src/App.tsx
@@ -180,6 +180,39 @@ interface Proposal {
   base?: string;
 }
 
+/**
+ * Everything the reviewer can change about a proposal — the per-hunk accept flags, the per-hunk
+ * edits to the PROPOSED (added) text (keyed by change-block index, so a change can be refined
+ * before it's applied), which hunk's inline editor is open, and the "Review next" cursor — tagged
+ * with the proposal it belongs to.
+ *
+ * The tag is what keeps the review's initialization SYNCHRONOUS with the proposal: state carrying
+ * any other key is stale and reads as the pristine default (every hunk accepted, no edits, no open
+ * editor, no cursor) in the very render that first shows the review, so the bar is never on screen
+ * with stale flags behind it. Initializing from an effect instead left a one-flush window in which
+ * the bar was live but `accepted` was still the previous — on a first proposal, empty — array: a
+ * click landing in it either no-oped mapping over that array or was overwritten when the effect
+ * flushed, silently reverting a reject or a saved hunk edit to all-accepted.
+ *
+ * The tag is the proposal's IDENTITY, not its id: re-showing the same proposal object (parked with
+ * "later", or a metadata-only re-notification — both deliberately preserve the object) keeps the
+ * reviewer's in-progress state, exactly as the effect's `[changeCount, proposal]` deps did.
+ */
+interface ReviewState {
+  key: Proposal | null;
+  accepted: boolean[];
+  edits: Record<number, string[]>;
+  editingHunk: number | null;
+  /** Index of the hunk "Review next" last stepped to, or -1 before the first step. */
+  cursor: number;
+}
+
+/** The part of a review the undo/redo timeline steps through (the doc isn't mutated until Apply). */
+type ReviewSnapshot = Pick<ReviewState, "accepted" | "edits">;
+
+/** Before any proposal — also the shape a stale review reads as, via `pristineReview`. */
+const NO_REVIEW: ReviewState = { key: null, accepted: [], edits: {}, editingHunk: null, cursor: -1 };
+
 type FindMatch = { scope: "body"; from: number; to: number } | { scope: "comment"; id: string; from: number; to: number };
 
 /** Props the onboarding wrapper (AppRoot) threads into the editor. All optional —
@@ -1596,11 +1629,26 @@ export function App(props: EditorProps = {}): JSX.Element {
   // same review and the preview alone is a complete review surface in 1-pane mode.
   const reviewSegs = useMemo(() => (proposal ? lineSegments(proposal.baseBody, proposal.next.body) : []), [proposal]);
   const changeCount = useMemo(() => reviewSegs.filter(isChange).length, [reviewSegs]);
-  const [accepted, setAccepted] = useState<boolean[]>([]);
-  // Per-hunk edits to the PROPOSED (added) text, keyed by change-block index — the human can refine
-  // a change before applying it. `editedSegs` overlays them onto the diff so both panes + Apply use
-  // the edited text. Empty by default (the agent's proposal verbatim).
-  const [edits, setEdits] = useState<Record<number, string[]>>({});
+  // The reviewer's state (see ReviewState) is READ THROUGH its proposal tag rather than reset by an
+  // effect: `pristineReview` is what a proposal starts as, and it is what every read sees until an
+  // interaction stores a deviation against that same proposal. So the first commit that renders the
+  // review bar already carries the right flags — there is no window in which a click no-ops on a
+  // stale array or gets overwritten by a late initialization.
+  const [reviewState, setReviewState] = useState<ReviewState>(NO_REVIEW);
+  const pristineReview = useMemo<ReviewState>(
+    () => ({ ...NO_REVIEW, key: proposal, accepted: new Array(changeCount).fill(true) }),
+    [proposal, changeCount],
+  );
+  const { accepted, edits, editingHunk, cursor: reviewCursor } = reviewState.key === proposal ? reviewState : pristineReview;
+  /** Store part of the review. Re-bases onto `pristineReview` when what's stored belongs to an
+   *  older proposal, so the first interaction on a new review can't inherit the previous one's. */
+  const patchReview = useCallback(
+    (patch: Partial<Omit<ReviewState, "key">>) =>
+      setReviewState((cur) => ({ ...(cur.key === proposal ? cur : pristineReview), ...patch, key: proposal })),
+    [proposal, pristineReview],
+  );
+  // `editedSegs` overlays the per-hunk edits onto the diff so both panes + Apply use the edited
+  // text. Empty by default (the agent's proposal verbatim).
   const editedSegs = useMemo(() => {
     let ci = -1;
     return reviewSegs.map((s) => {
@@ -1611,49 +1659,51 @@ export function App(props: EditorProps = {}): JSX.Element {
   }, [reviewSegs, edits]);
   // Review is its own little undo/redo timeline (the doc isn't mutated until Apply): toggling a
   // switch, Accept/Reject all, and editing a hunk all snapshot {accepted, edits} so ⌘Z/⌘⇧Z step
-  // through them while the review is open.
-  const reviewHist = useRef<{ accepted: boolean[]; edits: Record<number, string[]> }[]>([]);
-  const reviewFuture = useRef<{ accepted: boolean[]; edits: Record<number, string[]> }[]>([]);
-  const [editingHunk, setEditingHunk] = useState<number | null>(null);
+  // through them while the review is open. The stacks carry the same proposal tag as the state and
+  // are cleared on first use after a new proposal — clearing them from an effect would leave a
+  // window of its own, one in which ⌘Z could step back into the PREVIOUS review's snapshots.
+  const reviewHist = useRef<{ key: Proposal | null; past: ReviewSnapshot[]; future: ReviewSnapshot[] }>({ key: null, past: [], future: [] });
+  const reviewTimeline = useCallback(() => {
+    const h = reviewHist.current;
+    if (h.key !== proposal) {
+      h.key = proposal;
+      h.past = [];
+      h.future = [];
+    }
+    return h;
+  }, [proposal]);
   const [editDraft, setEditDraft] = useState("");
-  useEffect(() => {
-    setAccepted(new Array(changeCount).fill(true));
-    setEdits({});
-    reviewHist.current = [];
-    reviewFuture.current = [];
-    setEditingHunk(null);
-  }, [changeCount, proposal]);
-  // Commit a review change through the undo timeline.
+  // Commit a review change through the undo timeline. `nextEditingHunk` defaults to leaving the
+  // inline editor as it stands (toggling a switch doesn't close it); saving an edit passes null to
+  // close it in the same commit as the edit it saves.
   const commitReview = useCallback(
-    (nextAccepted: boolean[], nextEdits: Record<number, string[]>) => {
-      reviewHist.current.push({ accepted, edits });
-      if (reviewHist.current.length > 200) reviewHist.current.shift();
-      reviewFuture.current = [];
-      setAccepted(nextAccepted);
-      setEdits(nextEdits);
+    (nextAccepted: boolean[], nextEdits: Record<number, string[]>, nextEditingHunk: number | null = editingHunk) => {
+      const h = reviewTimeline();
+      h.past.push({ accepted, edits });
+      if (h.past.length > 200) h.past.shift();
+      h.future = [];
+      patchReview({ accepted: nextAccepted, edits: nextEdits, editingHunk: nextEditingHunk });
     },
-    [accepted, edits],
+    [accepted, edits, editingHunk, patchReview, reviewTimeline],
   );
   const toggleHunk = useCallback((idx: number, val: boolean) => commitReview(accepted.map((v, k) => (k === idx ? val : v)), edits), [commitReview, accepted, edits]);
   const setAllAccepted = useCallback((val: boolean) => commitReview(new Array(changeCount).fill(val), edits), [commitReview, changeCount, edits]);
   const reviewUndo = useCallback(() => {
-    const prev = reviewHist.current.pop();
+    const h = reviewTimeline();
+    const prev = h.past.pop();
     if (!prev) return;
-    reviewFuture.current.push({ accepted, edits });
-    setEditingHunk(null);
-    setAccepted(prev.accepted);
-    setEdits(prev.edits);
+    h.future.push({ accepted, edits });
+    patchReview({ ...prev, editingHunk: null });
     setStatus(t("msg.undid"));
-  }, [accepted, edits]);
+  }, [accepted, edits, patchReview, reviewTimeline]);
   const reviewRedo = useCallback(() => {
-    const next = reviewFuture.current.pop();
+    const h = reviewTimeline();
+    const next = h.future.pop();
     if (!next) return;
-    reviewHist.current.push({ accepted, edits });
-    setEditingHunk(null);
-    setAccepted(next.accepted);
-    setEdits(next.edits);
+    h.past.push({ accepted, edits });
+    patchReview({ ...next, editingHunk: null });
     setStatus(t("msg.redid"));
-  }, [accepted, edits]);
+  }, [accepted, edits, patchReview, reviewTimeline]);
   reviewUndoRef.current = reviewUndo;
   reviewRedoRef.current = reviewRedo;
   // Open the inline editor for a hunk (seed it with that hunk's current proposed text).
@@ -1661,26 +1711,25 @@ export function App(props: EditorProps = {}): JSX.Element {
     (idx: number) => {
       const blocks = editedSegs.filter(isChange);
       setEditDraft((blocks[idx]?.added ?? []).join("\n"));
-      setEditingHunk(idx);
+      patchReview({ editingHunk: idx });
     },
-    [editedSegs],
+    [editedSegs, patchReview],
   );
   const saveEditHunk = useCallback(() => {
     if (editingHunk == null) return;
-    commitReview(accepted, { ...edits, [editingHunk]: editDraft.split("\n") });
-    setEditingHunk(null);
+    commitReview(accepted, { ...edits, [editingHunk]: editDraft.split("\n") }, null);
   }, [editingHunk, editDraft, commitReview, accepted, edits]);
-  const cancelEditHunk = useCallback(() => setEditingHunk(null), []);
+  const cancelEditHunk = useCallback(() => patchReview({ editingHunk: null }), [patchReview]);
   const applyReview = useCallback(() => applyProposal(editedSegs, accepted), [applyProposal, editedSegs, accepted]);
 
   // "Review next": step through change hunks, scrolling each into view (in both
-  // the preview and, when shown, the source diff) and highlighting it.
-  const [reviewCursor, setReviewCursor] = useState(-1);
-  useEffect(() => setReviewCursor(-1), [proposal]);
+  // the preview and, when shown, the source diff) and highlighting it. The cursor rides in the
+  // review state, so a new proposal starts it back at -1 in the same render that shows the review
+  // (an effect-driven reset could still be overwriting a step taken in that first commit).
   const reviewNext = useCallback(() => {
     if (!changeCount) return;
     const n = (reviewCursor + 1) % changeCount;
-    setReviewCursor(n);
+    patchReview({ cursor: n });
     // Surface the source diff too (2-pane shows one side) so the SAME change is
     // visible in both panes, then center the hunk in each.
     if (panes === 2 && rightTab !== "source") setRightTab("source");
@@ -1692,7 +1741,7 @@ export function App(props: EditorProps = {}): JSX.Element {
       previewRef.current?.querySelector(`[data-hunk="${n}"]`)?.scrollIntoView({ block: "start", behavior: "smooth" });
       document.querySelector(`.ap-diffsource [data-hunk="${n}"]`)?.scrollIntoView({ block: "start", behavior: "smooth" });
     });
-  }, [changeCount, reviewCursor, panes, rightTab]);
+  }, [changeCount, reviewCursor, patchReview, panes, rightTab]);
 
   const threads = useMemo(() => buildThreads(doc.comments), [doc.comments]);
   const ordered = useMemo<OrderedThread[]>(() => {

--- a/packages/renderer/test/App.reviewInitSync.test.tsx
+++ b/packages/renderer/test/App.reviewInitSync.test.tsx
@@ -1,0 +1,217 @@
+// @vitest-environment happy-dom
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Regression: the review's per-hunk state must be initialized SYNCHRONOUSLY with the proposal —
+// there must be NO commit in which the review bar is on screen while `accepted`/`edits` still hold
+// the previous (on a first proposal, empty) values.
+//
+// The state used to be initialized from an effect keyed on the proposal, which left exactly such a
+// window: the bar's first commit was observable before the effect flushed. It was invisible in the
+// DOM (the per-hunk switches render `accepted[idx] ?? true`, so they LOOK accepted either way), but
+// an interaction landing in it was lost two different ways — a per-hunk toggle mapped over the
+// stale array and no-oped, and anything that did commit (tri-state reject-all, a saved hunk edit)
+// was overwritten when the initialization flushed, silently reverting the review to all-accepted.
+//
+// Driving that window needs commit-phase granularity, finer than `act`: the StatusBar is stubbed
+// with a probe that runs a LAYOUT effect on every App commit, and layout effects run strictly
+// before any passive effect of the same commit. The probe fires a real click on the real control
+// the moment the review bar first exists in the DOM — i.e. inside the window — and the test then
+// asserts the interaction both took effect and survived the rest of the commit.
+//
+// SourceEditor (CodeMirror) is stubbed because it needs layout APIs happy-dom only stubs.
+
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { forwardRef, useImperativeHandle, useLayoutEffect } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createMemoryApi, type MemoryAgent } from "../src/memoryApi";
+
+/** Set by a test to run in the commit phase of every App render; cleared when it has fired. */
+const probe = vi.hoisted(() => ({ onCommit: null as null | (() => void) }));
+
+vi.mock("../src/SourceEditor", () => ({
+  SourceEditor: forwardRef(function SourceEditorStub(_props: unknown, ref: React.Ref<unknown>) {
+    useImperativeHandle(ref, () => ({ scrollToLine() {}, selectRange() {} }));
+    return null;
+  }),
+}));
+
+// The status bar is App's last child and re-renders with it, so its layout effect is a hook into
+// the commit phase of every App render — after the whole tree's DOM is in place, before the passive
+// effects (which is where the review state used to be initialized) of that same commit.
+vi.mock("../src/StatusBar", () => ({
+  StatusBar: function StatusBarProbe() {
+    useLayoutEffect(() => {
+      probe.onCommit?.();
+    });
+    return null;
+  },
+}));
+
+const DOC = "# Plan\n\nAlpha line.\n\nBeta line.\n\n<!--inplan v1\n[]\n-->\n";
+// Two distinct body edits => two change hunks.
+const REVISED = "# Plan\n\nAlpha CHANGED.\n\nBeta CHANGED.\n\n<!--inplan v1\n[]\n-->\n";
+const REVISED2 = "# Plan\n\nAlpha SECOND.\n\nBeta SECOND.\n\n<!--inplan v1\n[]\n-->\n";
+
+let agent: MemoryAgent;
+
+type Win = { api: { getProposal(): Promise<{ id?: string; content: string } | null> } };
+
+function mount(content: string) {
+  document.body.innerHTML = '<div id="root"></div>';
+  const session = createMemoryApi({ content });
+  (window as unknown as { api: unknown }).api = session.api;
+  agent = session.agent;
+}
+
+afterEach(() => {
+  probe.onCommit = null;
+  cleanup();
+});
+
+const hunkSwitches = () => document.querySelectorAll<HTMLInputElement>('input[aria-label="accept change 1"]');
+const tri = () => document.querySelector<HTMLButtonElement>("button.ap-tri:not([disabled])");
+const hunk1 = () => screen.getAllByRole("switch", { name: /accept change 1/ })[0] as HTMLInputElement;
+
+/**
+ * Arm the probe to act ONCE, in the commit phase of the first render that shows the review bar.
+ * `ready` guards on the control the action needs actually being in the DOM. Returns a getter for
+ * whether it fired, so a test can prove it really drove the window rather than passing vacuously.
+ */
+function armOnFirstReviewCommit(ready: () => boolean, action: () => void): () => boolean {
+  let fired = false;
+  probe.onCommit = () => {
+    if (fired || !document.querySelector(".ap-review-bar") || !ready()) return;
+    fired = true;
+    action();
+  };
+  return () => fired;
+}
+
+describe("review state initializes synchronously with the proposal", () => {
+  beforeEach(() => mount(DOC));
+
+  async function renderApp() {
+    const { App } = await import("../src/App");
+    render(<App />);
+    await waitFor(() => expect(document.body.textContent).toContain("Alpha line."), { timeout: 5000 });
+  }
+
+  it("a per-hunk reject clicked in the review's FIRST commit takes effect and survives", async () => {
+    await renderApp();
+
+    // Reject hunk 1 from inside the window. Before the fix this mapped over the still-empty
+    // `accepted` (a no-op) and was then overwritten by the initialization — the hunk came back
+    // accepted and Apply took the agent's text for it.
+    const fired = armOnFirstReviewCommit(
+      () => hunkSwitches().length > 0,
+      () => hunkSwitches()[0]!.click(),
+    );
+    await act(async () => {
+      await agent.proposeRevision(REVISED);
+    });
+    expect(fired()).toBe(true); // the window was really driven
+
+    // Took effect, and nothing overwrote it once the commit finished. Read once rather than poll:
+    // `act` above drained the commit AND its effects, so this IS the settled state — a value that
+    // only arrived later would mean something landed after the commit, which is the bug itself.
+    expect(hunk1().checked).toBe(false);
+    expect(document.querySelector(".ap-tri--mixed")).toBeTruthy(); // one of two hunks rejected
+
+    // And it is the state Apply uses: hunk 1 rejected, hunk 2 accepted.
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^Apply$/ }));
+    });
+    await waitFor(() => expect(document.body.textContent).not.toContain("Agent proposed changes"), { timeout: 5000 });
+    expect(document.body.textContent).toContain("Alpha line.");
+    expect(document.body.textContent).toContain("Beta CHANGED.");
+    expect(document.body.textContent).not.toContain("Alpha CHANGED.");
+    await waitFor(async () => expect(await (window as unknown as Win).api.getProposal()).toBeNull(), { timeout: 5000 });
+  });
+
+  it("a tri-state reject-all clicked in the review's FIRST commit is not overwritten", async () => {
+    await renderApp();
+
+    // Reject-all from inside the window. This one did commit (`fill(false)` needs no prior state)
+    // and was then reverted to all-accepted by the initialization — the reviewer's rejection
+    // became a full accept.
+    const fired = armOnFirstReviewCommit(
+      () => tri() !== null,
+      () => tri()!.click(),
+    );
+    await act(async () => {
+      await agent.proposeRevision(REVISED);
+    });
+    expect(fired()).toBe(true);
+
+    expect(document.querySelector(".ap-tri--reject")).toBeTruthy(); // settled after act — see above
+    expect(document.body.textContent).not.toContain("will be accepted");
+
+    // Apply keeps the original body — nothing from the proposal survives.
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^Apply$/ }));
+    });
+    await waitFor(() => expect(document.body.textContent).not.toContain("Agent proposed changes"), { timeout: 5000 });
+    expect(document.body.textContent).toContain("Alpha line.");
+    expect(document.body.textContent).toContain("Beta line.");
+    expect(document.body.textContent).not.toContain("CHANGED");
+  });
+
+  it("'Review next' pressed in the review's FIRST commit keeps its cursor", async () => {
+    await renderApp();
+
+    const fired = armOnFirstReviewCommit(
+      () => screen.queryAllByRole("button", { name: /^Review next/ }).length > 0,
+      () => screen.getAllByRole("button", { name: /^Review next/ })[0]!.click(),
+    );
+    await act(async () => {
+      await agent.proposeRevision(REVISED);
+    });
+    expect(fired()).toBe(true);
+
+    // The cursor reset used to run from its own effect, so a step taken in the window was undone.
+    expect(screen.getByRole("button", { name: /Review next \(1\/2\)/ })).toBeTruthy();
+  });
+
+  it("a NEW proposal starts pristine: no inherited rejects, and ⌘Z can't reach the old review", async () => {
+    await renderApp();
+    await act(async () => {
+      await agent.proposeRevision(REVISED);
+    });
+    await waitFor(() => expect(document.body.textContent).toContain("Agent proposed changes"), { timeout: 5000 });
+
+    // Reject a hunk in the FIRST review, then park it and let a second proposal replace it.
+    await act(async () => {
+      fireEvent.click(hunk1());
+    });
+    await waitFor(() => expect(hunk1().checked).toBe(false), { timeout: 5000 });
+    await act(async () => {
+      await agent.proposeRevision(REVISED2);
+    });
+    await waitFor(() => expect(document.body.textContent).toContain("Alpha SECOND."), { timeout: 5000 });
+
+    // The second review is all-accepted from its first commit — the first review's reject is gone.
+    expect(hunk1().checked).toBe(true);
+    expect(document.querySelector(".ap-tri--accept")).toBeTruthy();
+
+    // ⌘Z has nothing to undo here: the timeline belongs to the proposal, so it cannot step back
+    // into the previous review's snapshots (which would resurrect that reject).
+    await act(async () => {
+      fireEvent.keyDown(document, { key: "z", metaKey: true });
+    });
+    expect(hunk1().checked).toBe(true);
+
+    // Undo/redo still work WITHIN this review.
+    await act(async () => {
+      fireEvent.click(hunk1());
+    });
+    await waitFor(() => expect(hunk1().checked).toBe(false), { timeout: 5000 });
+    await act(async () => {
+      fireEvent.keyDown(document, { key: "z", metaKey: true });
+    });
+    await waitFor(() => expect(hunk1().checked).toBe(true), { timeout: 5000 });
+    await act(async () => {
+      fireEvent.keyDown(document, { key: "z", metaKey: true, shiftKey: true });
+    });
+    await waitFor(() => expect(hunk1().checked).toBe(false), { timeout: 5000 });
+  });
+});


### PR DESCRIPTION
## Why

#103 deflaked the renderer review suites and recorded the product-side finding it had ruled out of scope: the review bar's first commit is observable **before** the effect that initializes the per-hunk accept state has flushed. In that window the bar is live while `accepted` still holds the previous — on a first proposal, empty — array.

The DOM masks it, because the per-hunk switches render `accepted[idx] ?? true` and so look accepted either way. An interaction landing in the window is lost two different ways:

- a **per-hunk toggle** maps over the stale array (`[].map(...)` → `[]`) and no-ops;
- anything that *does* commit — a **tri-state reject-all**, a **saved pencil edit**, a **"Review next" step** — is overwritten when the initialization flushes, silently reverting the review to all-accepted.

#103 called the window unreachable by a human click, which is true of the ~one-flush case it was looking at. It is not a property of the design: the window's length is however long that commit's passive effects take to flush, so anything that delays them (a loaded main thread, a long commit elsewhere in the tree, React yielding) widens it. The state should simply never be observable in a wrong shape.

## What changed

Derive rather than sync. The reviewer's state — per-hunk accept flags, per-hunk edits, which hunk's inline editor is open, and the "Review next" cursor — now lives in one object **tagged with the proposal it belongs to**. A tag that isn't the current proposal reads as the pristine default (every hunk accepted, no edits, no open editor, no cursor) in the very render that first shows the review, and only deviations from that default are ever stored. So the first commit already carries the right flags: there is no window to click into, and the two effects that used to do the initializing are gone.

The undo/redo stacks get the same treatment — they carry the proposal tag and are cleared on first use after a new proposal, rather than from an effect that could leave ⌘Z stepping back into the *previous* review's snapshots.

Two properties are deliberately preserved:

- **No new flicker.** The first commit renders exactly what it rendered before (all-accepted); only the state behind it is now real rather than about to be replaced.
- **Identity, not id, is the tag.** Re-showing the same proposal object — parked with "later", or a metadata-only re-notification, both of which deliberately preserve the object — keeps the reviewer's work in progress, exactly as the effects' `[changeCount, proposal]` deps did.

## Tests

`App.reviewInitSync.test.tsx` drives the closed window at a granularity finer than `act()`: a `StatusBar` stub runs a **layout** effect on every App commit — strictly before any passive effect of that same commit — and clicks the real control the moment the review bar first exists in the DOM. Each case asserts the probe actually fired, so it cannot pass vacuously, and then reads the settled state **once** rather than polling: a value that only arrives later is the bug.

Four cases: a per-hunk reject, a tri-state reject-all, and a "Review next" step all taken inside the review's first commit (each also carried through Apply, so the assertion is about the state Apply uses, not just the DOM); plus one pinning that a new proposal still starts pristine, that ⌘Z cannot reach the previous review, and that undo/redo still work within a review.

## Verification

- Reverting the fix and keeping the test fails all three window cases, with the failure each shape predicts: the reject reads back accepted (`expected true to be false`), the tri-state loses its rejection (`.ap-tri--reject` absent), the cursor resets (no `Review next (1/2)`). The fourth case passes either way — it pins behavior the fix had to keep.
- The existing review suites are **unmodified** and green: `App.review`, `App.review.matrix`, `App.reviewDeep`, `App.reviewDiff`, `App.reviewDemotion` — 24 tests, run 5x with the new file (28/28 every run).
- Full renderer suite 3x: 87 files / 630 tests green every run.
- `npm run typecheck` clean across all workspaces; pre-commit gate (full suite + coverage ≥95%) passed — 1297 tests, 95.45% lines.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

