### PR TITLE
release: 0.2.0 — proposals get first-class identity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5335,7 +5335,7 @@
     },
     "packages/cli": {
       "name": "@inplan/cli",
-      "version": "0.1.31",
+      "version": "0.2.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@hocuspocus/provider": "^2.15.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inplan/cli",
-  "version": "0.1.31",
+  "version": "0.2.0",
   "private": true,
   "description": "inplan CLI: open / wait / signal orchestration over the document core.",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
Version bump for publishing. **Minor, not patch:** upgrading is required against row-backed hosts — a proposal is now a first-class row with identity and a terminal-immutable state, and a host running the row-backed store rejects the legacy park path, so an old CLI's park fails loudly with an upgrade message until it updates.

Since 0.1.31:

- **Proposals get first-class identity** (#98): client-minted ids, the base stored alongside the content so a 3-way review never depends on a checkpoint, terminal-immutable states, and re-parking that is idempotent across a lost response.
- **The landing signal is a lookup, not an inference** (#99): `wait --remote` audits a park by proposal id. The event-window machinery — window anchoring, clock-skew bounds, the awaiting-outcome grace — is deleted; the wait output's `proposal` field carries the id in both `pending_review` and `park_failed`.
- **The review is a queue** (#100): the editor reviews a document's pending proposals oldest-first with a count, a proposal written against an older document is reviewed as a 3-way merge onto the current text, decisions settle the exact row atomically, and the decision events name the proposal they decided.
- **`open` can no longer wipe a working file** by reverting it to a blank canonical (#102, fixes #95); the fs proposal-rows lock no longer blocks the event loop under contention.
- **The renderer review suites are deflaked** (#103).

After merge, publishing is a tagged GitHub Release (`v0.2.0`) — the release workflow publishes via npm OIDC trusted publishing with provenance.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

