### PR TITLE
preview: a multi-line block keeps its lines, its columns, and its comment anchor — fenced or not

### DIFF
--- a/packages/renderer/src/App.tsx
+++ b/packages/renderer/src/App.tsx
@@ -2266,14 +2266,20 @@ export function App(props: EditorProps = {}): JSX.Element {
             onPaste={onPreviewPasteImage}
             onClick={(e) => {
               const target = e.target as HTMLElement;
+              // A comment anchor is resolved by its data-cmt attribute, not by tag: a PARAGRAPH
+              // anchor is a real markdown link (an <a>), but a FENCED one can't be — fence
+              // content is literal text, so markdown.ts marks the spanned code with a <span
+              // data-cmt> instead. Both must be click-to-focus, and looking for the attribute
+              // covers both (it's also how the rail and the overlap check already find them).
+              const anchor = target.closest("[data-cmt]");
+              if (anchor) {
+                e.preventDefault();
+                focusComment(anchor.getAttribute("data-cmt")!, true); // clicked in the preview — don't re-scroll the preview
+                return;
+              }
               const a = target.closest("a");
               if (a) {
                 e.preventDefault();
-                const cmt = a.getAttribute("data-cmt");
-                if (cmt) {
-                  focusComment(cmt, true); // clicked in the preview — don't re-scroll the preview
-                  return;
-                }
                 const href = a.getAttribute("href") ?? "";
                 if (isInternalDocLink(href)) {
                   navigateGuarded(() => void hostApi().openDoc(resolveDocPath(docPathRef.current, href)));

--- a/packages/renderer/src/markdown.ts
+++ b/packages/renderer/src/markdown.ts
@@ -27,6 +27,15 @@ const renderHtmlToken = (tokens: Parameters<MarkdownIt["renderer"]["renderToken"
 md.renderer.rules.html_block = (tokens, idx) => renderHtmlToken(tokens, idx);
 md.renderer.rules.html_inline = (tokens, idx) => renderHtmlToken(tokens, idx);
 
+// The preview preserves a paragraph's newlines (`white-space: pre-wrap` on `.ap-rendered p`, so a
+// hand-aligned block keeps its lines and columns). markdown-it's default hardbreak rule emits
+// `<br>\n` — that trailing newline is cosmetic source formatting, invisible under HTML's default
+// whitespace collapsing but a SECOND, real line break once newlines are preserved, which would
+// turn every markdown hard break into a blank line. Emit the `<br>` alone. hardbreak is the only
+// rule that puts a newline INSIDE a paragraph; markdown-it's renderer adds its other newlines
+// around block-level tokens only, which the paragraph-scoped style rule doesn't touch.
+md.renderer.rules.hardbreak = () => "<br>";
+
 // Tag comment-anchor links (`#cmt-...`) so the preview can highlight them and
 // wire up click-to-focus behavior. When `showAnchor(id)` is false (e.g. a resolved
 // comment while "show resolved" is off), the anchor is rendered as PLAIN TEXT —

--- a/packages/renderer/src/markdown.ts
+++ b/packages/renderer/src/markdown.ts
@@ -122,12 +122,75 @@ for (const name of BLOCK_RULES) {
     return orig ? orig(tokens, idx, options, env, self) : self.renderToken(tokens, idx, options);
   };
 }
-// Fenced/indented code render as full HTML strings; inject data-line on the <pre>.
+// A comment anchor written INSIDE a code block. CommonMark treats a fence's (or an indented
+// block's) content as LITERAL TEXT, so `[label](#cmt-id)` there is not a link at all: markdown-it
+// hands the renderer the raw characters and the default rule escapes them straight into the
+// <code>. That left the reader looking at anchor SYNTAX as if it were part of the code, while the
+// comment had nothing to point at — no element carrying data-cmt, so the thread was neither
+// clickable in the preview nor reachable from the rail. Nothing stops an author from getting
+// there, either: the source-side gate (docOps' spanCommentBlocker) matches the selection against
+// the body TEXT and is fence-unaware, so commenting on fenced code writes exactly this document.
+//
+// So recognize the wrapper in the code's own content: drop the syntax, keep the code text, and
+// mark the spanned characters. The pattern is deliberately the same one docOps writes and
+// unwraps (its ANCHOR_RE), so what the preview recognizes is exactly what the editor produces.
+// An inline code SPAN (`code_inline`) is untouched — that remains the way to show anchor syntax
+// literally, and a fence still shows `[x](#not-cmt)` and friends verbatim.
+const CODE_ANCHOR_RE = /\[([^\]]*)\]\(#(cmt-[0-9a-z]+)\)/gi;
+// The same pattern without /g, for a presence check — `.test` on a global regex advances its
+// lastIndex between calls. Derived from `.source` so the two can never drift apart.
+const HAS_CODE_ANCHOR = new RegExp(CODE_ANCHOR_RE.source, "i");
+
+/**
+ * A code block's body as HTML: the author's text escaped, with each comment-anchor wrapper
+ * replaced by its label inside a `<span data-cmt class="ap-anchor">` — a <span> and not an <a>
+ * because a link inside <code> would inherit link styling and read as prose, and because every
+ * consumer (the preview's click handler, the rail's scroll/flash) resolves its target by
+ * `[data-cmt]`. When the anchor is hidden (a resolved comment while "show resolved" is off) the
+ * label is emitted bare, matching what the link_open rule does for a paragraph anchor.
+ *
+ * Escaping is not weakened anywhere: EVERY character of the author's content, label included,
+ * goes through `escapeHtml`, and the only markup added is the span — whose id is constrained to
+ * `[0-9a-z]` by the pattern that produced it, so it needs no quoting of its own.
+ */
+function codeBodyWithAnchors(content: string, showAnchor?: (id: string) => boolean): string {
+  let out = "";
+  let last = 0;
+  for (const m of content.matchAll(CODE_ANCHOR_RE)) {
+    out += md.utils.escapeHtml(content.slice(last, m.index));
+    const id = m[2]!.toLowerCase();
+    const label = md.utils.escapeHtml(m[1]!);
+    out += showAnchor && !showAnchor(id) ? label : `<span data-cmt="${id}" class="ap-anchor">${label}</span>`;
+    last = m.index + m[0].length;
+  }
+  return out + md.utils.escapeHtml(content.slice(last));
+}
+
+// Fenced/indented code render as full HTML strings; inject data-line on the <pre>, and render
+// any comment anchor the content carries (see CODE_ANCHOR_RE).
 for (const name of ["fence", "code_block"]) {
   const orig = md.renderer.rules[name];
   md.renderer.rules[name] = (tokens, idx, options, env, self) => {
-    const html = orig ? orig(tokens, idx, options, env, self) : self.renderToken(tokens, idx, options);
+    const render = (): string => (orig ? orig(tokens, idx, options, env, self) : self.renderToken(tokens, idx, options));
     const tok = tokens[idx]!;
+    let html: string;
+    // An ordinary code block — overwhelmingly the common case — goes down the untouched default
+    // path, so this stays a branch rather than a rewrite of how code renders.
+    if (HAS_CODE_ANCHOR.test(tok.content)) {
+      // Ask the DEFAULT rule for this block's shell (`<pre><code class="language-…">`, built
+      // from the info string and the token's attrs) by rendering it with no content, then put
+      // our own body inside it. Nothing about the wrapper is reimplemented, and nothing but
+      // escapeHtml output and our own span reaches the page. markdown-it's fence rule builds
+      // those attrs "without modifying original token", so rendering twice can't duplicate them.
+      const raw = tok.content;
+      tok.content = "";
+      const shell = render();
+      tok.content = raw;
+      const at = shell.lastIndexOf("</code>");
+      html = at < 0 ? render() : shell.slice(0, at) + codeBodyWithAnchors(raw, (env as LinkEnv).showAnchor) + shell.slice(at);
+    } else {
+      html = render();
+    }
     return tok.map ? html.replace(/^<pre/, `<pre data-line="${tok.map[0]}"`) : html;
   };
 }

--- a/packages/renderer/src/styles.css
+++ b/packages/renderer/src/styles.css
@@ -233,6 +233,16 @@ body {
 @media (prefers-reduced-motion: reduce) { .ap-sidepanel, .ap-sidepanel.ap-sidepanel--closing { animation: none; } }
 .ap-preview { flex: 1; min-width: 0; overflow: auto; padding: 28px 36px; border-right: 1px solid var(--line); background: var(--bg); }
 .ap-rendered { max-width: 760px; }
+/* Show a paragraph the way its author typed it. Markdown keeps the author's newlines inside a
+   paragraph and markdown-it emits them inside the <p>, but HTML's default whitespace processing
+   collapses each newline — and each run of alignment spaces — to a single space, so a directory
+   tree or any hand-aligned block pasted into a plan arrived as one run-on line with its columns
+   gone. `pre-wrap` honors both, and still wraps a long line at the pane width (unlike `pre`).
+   Deliberately scoped to paragraph content: markdown-it also emits cosmetic newlines BETWEEN
+   block tags (inside <li>, <blockquote>, <ul>, around a loose list item's <p>), and preserving
+   those would open a blank line before every nested list. Tradeoff: prose whose source is
+   hand-wrapped now shows those line breaks in the preview, matching the source pane. */
+.ap-rendered p { white-space: pre-wrap; }
 .ap-rendered img { max-width: 100%; height: auto; } /* a pasted/picked image is embedded at its native pixel size otherwise */
 .ap-rendered:focus { outline: none; } /* tabIndex={-1}: click-focusable (to receive a native paste event) but not Tab-reachable, so there's no keyboard focus ring to suppress here */
 .ap-rendered h1, .ap-rendered h2, .ap-rendered h3 { font-family: var(--serif); font-weight: 500; letter-spacing: -0.01em; line-height: 1.15; }

--- a/packages/renderer/test/App.multilineAnchor.test.tsx
+++ b/packages/renderer/test/App.multilineAnchor.test.tsx
@@ -2,13 +2,20 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //
 // End-to-end guard for a span comment whose anchored text spans SEVERAL source lines — the case
-// from the multi-line-preview bug: an author cannot escape a hand-aligned block into a code fence
-// without losing the comment, because an anchor's link text is inline, so the block has to stay a
-// paragraph. Mounts the real <App/> over a doc whose only comment anchors a three-line directory
-// tree, and checks the anchor is still ONE element covering all three lines, still tagged
-// data-cmt/.ap-anchor, and still click-to-focus. (Whether those three lines are drawn as three
-// lines is the stylesheet's job — asserted in previewMultiline.test.ts, since happy-dom does no
-// layout and cannot report the rendered line count.)
+// from the multi-line-preview bug. Mounts the real <App/> over a doc whose only comment anchors a
+// three-line directory tree, and checks the anchor is still ONE element covering all three lines,
+// still tagged data-cmt/.ap-anchor, and still click-to-focus.
+//
+// Covered in both of the places the reported document put that block: as a PARAGRAPH, and inside
+// a ``` FENCE. The fence is the harder half, because fence content is literal text to CommonMark:
+// the anchor is not a markdown link there, so the renderer marks the spanned characters with a
+// `<span data-cmt>` of its own instead of an `<a>`. Everything downstream — the preview's click
+// handler, the rail's scroll/flash — resolves its target by `[data-cmt]`, so both shapes work; a
+// handler that had gone looking for an `<a>` specifically would break on the fenced one.
+//
+// (Whether those three lines are DRAWN as three lines is the stylesheet's job — asserted in
+// previewMultiline.test.ts, since happy-dom does no layout and cannot report a rendered line
+// count.)
 
 import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { forwardRef, useImperativeHandle } from "react";
@@ -28,56 +35,101 @@ const TREE_LINES = [
   "└── /login           — 인증",
 ];
 
-const DOC_WITH_MULTILINE_COMMENT =
-  `# Plan\n\nRoutes:\n\n[${TREE_LINES.join("\n")}](#cmt-cwnj04)\n\n<!--inplan v1\n` +
+const ANCHORED_TREE = `[${TREE_LINES.join("\n")}](#cmt-cwnj04)`;
+const COMMENT_BLOCK =
+  "<!--inplan v1\n" +
   '[ { "id": "cmt-cwnj04", "author": "alice", "date": "2026-05-30T10:00:00", "resolved": false, "text": "Is /login still needed?" } ]\n' +
   "-->\n";
 
+const DOC_WITH_MULTILINE_COMMENT = `# Plan\n\nRoutes:\n\n${ANCHORED_TREE}\n\n${COMMENT_BLOCK}`;
+/** The same document with the tree fenced — the second half of the reported case. */
+const DOC_WITH_FENCED_COMMENT = `# Plan\n\nRoutes:\n\n\`\`\`\n${ANCHORED_TREE}\n\`\`\`\n\n${COMMENT_BLOCK}`;
+
 beforeEach(() => {
   document.body.innerHTML = '<div id="root"></div>';
-  const session = createMemoryApi({ content: DOC_WITH_MULTILINE_COMMENT });
-  (window as unknown as { api: unknown }).api = session.api;
 });
 afterEach(cleanup);
 
-async function mountApp() {
+/** Mount the real editor over `content`, settled once the comment's text is on screen. */
+async function mountApp(content: string) {
+  const session = createMemoryApi({ content });
+  (window as unknown as { api: unknown }).api = session.api;
   const { App } = await import("../src/App");
   render(<App />);
   await waitFor(() => expect(document.body.textContent).toContain("Is /login still needed?"));
 }
 
-describe("a span comment anchoring a multi-line block", () => {
-  it("renders as a single tagged anchor covering every line of the block", async () => {
-    await mountApp();
-    const anchors = document.querySelectorAll<HTMLElement>(".ap-rendered [data-cmt]");
-    expect(anchors).toHaveLength(1);
-    const anchor = anchors[0]!;
-    expect(anchor.tagName).toBe("A");
-    expect(anchor.getAttribute("data-cmt")).toBe("cmt-cwnj04");
-    expect(anchor.classList.contains("ap-anchor")).toBe(true);
-    // One anchor, all three lines — not just the first line linked and the rest left loose.
-    for (const line of TREE_LINES) expect(anchor.textContent).toContain(line);
-  });
-
-  it("is still click-to-focus: clicking it focuses and flashes the whole anchored block", async () => {
-    await mountApp();
-    const anchor = document.querySelector('[data-cmt="cmt-cwnj04"]') as HTMLElement;
-    expect(anchor.classList.contains("ap-flash-anchor")).toBe(false);
-    await act(async () => {
-      fireEvent.click(anchor);
+// Both halves must satisfy the same reader-facing contract, so they run the same checks. Only
+// the element the renderer can legitimately use differs: a paragraph anchor IS a markdown link
+// (<a>), a fenced one cannot be (<span>).
+for (const [label, content, tag] of [
+  ["as a paragraph", DOC_WITH_MULTILINE_COMMENT, "A"],
+  ["inside a code fence", DOC_WITH_FENCED_COMMENT, "SPAN"],
+] as const) {
+  describe(`a span comment anchoring a multi-line block ${label}`, () => {
+    it("renders as a single tagged anchor covering every line of the block", async () => {
+      await mountApp(content);
+      const anchors = document.querySelectorAll<HTMLElement>(".ap-rendered [data-cmt]");
+      expect(anchors).toHaveLength(1);
+      const anchor = anchors[0]!;
+      expect(anchor.tagName).toBe(tag);
+      expect(anchor.getAttribute("data-cmt")).toBe("cmt-cwnj04");
+      expect(anchor.classList.contains("ap-anchor")).toBe(true);
+      // One anchor, all three lines — not just the first line linked and the rest left loose.
+      for (const line of TREE_LINES) expect(anchor.textContent).toContain(line);
     });
-    // App's preview onClick resolves the event target with closest("a") and focuses data-cmt —
-    // structure-based, so it works from any line of the multi-line anchor.
-    expect(anchor.classList.contains("ap-flash-anchor")).toBe(true);
+
+    it("is still click-to-focus: clicking it focuses and flashes the whole anchored block", async () => {
+      await mountApp(content);
+      const anchor = document.querySelector('[data-cmt="cmt-cwnj04"]') as HTMLElement;
+      expect(anchor.classList.contains("ap-flash-anchor")).toBe(false);
+      await act(async () => {
+        fireEvent.click(anchor);
+      });
+      // App's preview onClick resolves the event target by [data-cmt] — element-agnostic, so it
+      // works from any line of the multi-line anchor and for either shape of marker.
+      expect(anchor.classList.contains("ap-flash-anchor")).toBe(true);
+    });
+
+    it("keeps the block's lines intact in the preview markup, so the anchor and the text agree", async () => {
+      await mountApp(content);
+      const anchor = document.querySelector('[data-cmt="cmt-cwnj04"]') as HTMLElement;
+      // The newlines must survive into the DOM text — the stylesheet can only preserve what's there.
+      expect(anchor.textContent!.split("\n")).toHaveLength(3);
+      // …and so must the runs of alignment spaces the author typed to line the columns up.
+      const dashColumns = anchor.textContent!.split("\n").map((l) => l.indexOf("—"));
+      expect(new Set(dashColumns).size).toBe(1);
+    });
+
+    it("shows the reader the block, never the anchor's markdown syntax", async () => {
+      await mountApp(content);
+      const rendered = document.querySelector(".ap-rendered") as HTMLElement;
+      expect(rendered.textContent).not.toContain("](#cmt-cwnj04)");
+      expect(rendered.textContent).not.toContain("#cmt-cwnj04");
+    });
+  });
+}
+
+describe("a fenced comment anchor", () => {
+  it("keeps the fence a code block, with its source line for cross-pane sync", async () => {
+    await mountApp(DOC_WITH_FENCED_COMMENT);
+    const marker = document.querySelector('[data-cmt="cmt-cwnj04"]') as HTMLElement;
+    const pre = marker.closest("pre");
+    expect(pre).not.toBeNull();
+    expect(marker.closest("code")).not.toBeNull();
+    // The fence's <pre> still carries the data-line the click handler syncs the source pane to.
+    expect(pre!.getAttribute("data-line")).toBe("4");
   });
 
-  it("keeps the block's lines intact in the preview markup, so the anchor and the text agree", async () => {
-    await mountApp();
-    const anchor = document.querySelector('[data-cmt="cmt-cwnj04"]') as HTMLElement;
-    // The newlines must survive into the DOM text — the stylesheet can only preserve what's there.
-    expect(anchor.textContent!.split("\n")).toHaveLength(3);
-    // …and so must the runs of alignment spaces the author typed to line the columns up.
-    const dashColumns = anchor.textContent!.split("\n").map((l) => l.indexOf("—"));
-    expect(new Set(dashColumns).size).toBe(1);
+  it("is reachable from the comments rail, which flashes the marker in the preview", async () => {
+    await mountApp(DOC_WITH_FENCED_COMMENT);
+    const card = document.querySelector('[data-cmt-card="cmt-cwnj04"]') as HTMLElement;
+    const marker = document.querySelector('[data-cmt="cmt-cwnj04"]') as HTMLElement;
+    await act(async () => {
+      fireEvent.click(card);
+    });
+    // focusComment() looks the preview target up by [data-cmt] and flashes it — the whole point
+    // of marking the fenced span, since before this there was no element to find.
+    expect(marker.classList.contains("ap-flash-anchor")).toBe(true);
   });
 });

--- a/packages/renderer/test/App.multilineAnchor.test.tsx
+++ b/packages/renderer/test/App.multilineAnchor.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment happy-dom
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// End-to-end guard for a span comment whose anchored text spans SEVERAL source lines — the case
+// from the multi-line-preview bug: an author cannot escape a hand-aligned block into a code fence
+// without losing the comment, because an anchor's link text is inline, so the block has to stay a
+// paragraph. Mounts the real <App/> over a doc whose only comment anchors a three-line directory
+// tree, and checks the anchor is still ONE element covering all three lines, still tagged
+// data-cmt/.ap-anchor, and still click-to-focus. (Whether those three lines are drawn as three
+// lines is the stylesheet's job — asserted in previewMultiline.test.ts, since happy-dom does no
+// layout and cannot report the rendered line count.)
+
+import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { forwardRef, useImperativeHandle } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createMemoryApi } from "../src/memoryApi";
+
+vi.mock("../src/SourceEditor", () => ({
+  SourceEditor: forwardRef(function SourceEditorStub(_props: unknown, ref: React.Ref<unknown>) {
+    useImperativeHandle(ref, () => ({ scrollToLine() {}, selectRange() {} }));
+    return null;
+  }),
+}));
+
+const TREE_LINES = [
+  "├── /dashboard       — 분석 대시보드 (로그인 필요)",
+  "├── /collections     — 컬렉션 관리 (웹 버전)",
+  "└── /login           — 인증",
+];
+
+const DOC_WITH_MULTILINE_COMMENT =
+  `# Plan\n\nRoutes:\n\n[${TREE_LINES.join("\n")}](#cmt-cwnj04)\n\n<!--inplan v1\n` +
+  '[ { "id": "cmt-cwnj04", "author": "alice", "date": "2026-05-30T10:00:00", "resolved": false, "text": "Is /login still needed?" } ]\n' +
+  "-->\n";
+
+beforeEach(() => {
+  document.body.innerHTML = '<div id="root"></div>';
+  const session = createMemoryApi({ content: DOC_WITH_MULTILINE_COMMENT });
+  (window as unknown as { api: unknown }).api = session.api;
+});
+afterEach(cleanup);
+
+async function mountApp() {
+  const { App } = await import("../src/App");
+  render(<App />);
+  await waitFor(() => expect(document.body.textContent).toContain("Is /login still needed?"));
+}
+
+describe("a span comment anchoring a multi-line block", () => {
+  it("renders as a single tagged anchor covering every line of the block", async () => {
+    await mountApp();
+    const anchors = document.querySelectorAll<HTMLElement>(".ap-rendered [data-cmt]");
+    expect(anchors).toHaveLength(1);
+    const anchor = anchors[0]!;
+    expect(anchor.tagName).toBe("A");
+    expect(anchor.getAttribute("data-cmt")).toBe("cmt-cwnj04");
+    expect(anchor.classList.contains("ap-anchor")).toBe(true);
+    // One anchor, all three lines — not just the first line linked and the rest left loose.
+    for (const line of TREE_LINES) expect(anchor.textContent).toContain(line);
+  });
+
+  it("is still click-to-focus: clicking it focuses and flashes the whole anchored block", async () => {
+    await mountApp();
+    const anchor = document.querySelector('[data-cmt="cmt-cwnj04"]') as HTMLElement;
+    expect(anchor.classList.contains("ap-flash-anchor")).toBe(false);
+    await act(async () => {
+      fireEvent.click(anchor);
+    });
+    // App's preview onClick resolves the event target with closest("a") and focuses data-cmt —
+    // structure-based, so it works from any line of the multi-line anchor.
+    expect(anchor.classList.contains("ap-flash-anchor")).toBe(true);
+  });
+
+  it("keeps the block's lines intact in the preview markup, so the anchor and the text agree", async () => {
+    await mountApp();
+    const anchor = document.querySelector('[data-cmt="cmt-cwnj04"]') as HTMLElement;
+    // The newlines must survive into the DOM text — the stylesheet can only preserve what's there.
+    expect(anchor.textContent!.split("\n")).toHaveLength(3);
+    // …and so must the runs of alignment spaces the author typed to line the columns up.
+    const dashColumns = anchor.textContent!.split("\n").map((l) => l.indexOf("—"));
+    expect(new Set(dashColumns).size).toBe(1);
+  });
+});

--- a/packages/renderer/test/previewMultiline.test.ts
+++ b/packages/renderer/test/previewMultiline.test.ts
@@ -1,21 +1,31 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //
 // A multi-line block typed into a plan document must READ in the preview the way it reads in
-// the source pane: same number of lines, same columns. Markdown's paragraph rule keeps the
-// author's newlines in the token stream, and markdown-it duly emits them inside the <p> — but
-// HTML's default whitespace processing collapses a newline, and every run of alignment spaces,
-// down to a single space. A directory tree pasted into a plan therefore arrived as one run-on
-// line with its columns gone.
+// the source pane: same number of lines, same columns, and no markdown plumbing on show. The
+// reported document broke that in TWO places, and both are covered here.
 //
-// These tests assert the property a READER cares about (how many lines, and do the columns line
-// up), not the shape of the markup: they take the rendered HTML and put it through the same
-// whitespace processing the browser will, using the `white-space` value the stylesheet actually
-// declares for the preview's paragraph content. So they fail both when the renderer drops the
-// newlines and when the stylesheet doesn't honor them.
+// 1. AS A PARAGRAPH. Markdown's paragraph rule keeps the author's newlines in the token stream,
+//    and markdown-it duly emits them inside the <p> — but HTML's default whitespace processing
+//    collapses a newline, and every run of alignment spaces, down to a single space. A directory
+//    tree pasted into a plan therefore arrived as one run-on line with its columns gone.
+//
+// 2. INSIDE A FENCE. The same tree also appears inside a ``` fence, carrying the same comment
+//    anchor. CommonMark treats fence content as literal text, so `[label](#cmt-id)` written
+//    there is not a link at all: markdown-it hands the renderer the raw characters and the
+//    default fence renderer escapes them into the <code>. The reader saw the anchor SYNTAX as
+//    if it were part of the code, and the comment had nothing to point at — no <a>/<span>
+//    carrying data-cmt, so it was neither clickable in the preview nor reachable from the rail.
+//
+// These tests assert the property a READER cares about (how many lines, do the columns line up,
+// is any markdown plumbing visible), not the shape of the markup: they take the rendered HTML
+// and put it through the same whitespace processing the browser will, using the `white-space`
+// the stylesheet actually declares for that kind of content. So they fail both when the
+// renderer drops the newlines and when the stylesheet doesn't honor them.
 
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import { addSpanComment, spanCommentBlocker } from "../src/docOps";
 import { renderMarkdown } from "../src/markdown";
 
 const css = readFileSync(fileURLToPath(new URL("../src/styles.css", import.meta.url)), "utf8");
@@ -33,15 +43,18 @@ function previewParagraphWhiteSpace(): string {
   return ws;
 }
 
+/** The entities markdown-it's `escapeHtml` produces, and the characters they stand for. */
+const ENTITIES: Record<string, string> = { "&lt;": "<", "&gt;": ">", "&quot;": '"', "&amp;": "&" };
+
+/** The character data a reader sees for a run of markup: tags dropped, entities decoded. */
+function decodeText(markup: string): string {
+  return markup.replace(/<[^>]+>/g, "").replace(/&(?:lt|gt|quot|amp);/g, (e) => ENTITIES[e]!);
+}
+
 /** The text of the first rendered <p>, with <br> turned into the line break it draws. */
 function paragraphText(html: string): string {
   const inner = /<p\b[^>]*>([\s\S]*?)<\/p>/.exec(html)?.[1] ?? "";
-  return inner
-    .replace(/<br\s*\/?>/g, "\n")
-    .replace(/<[^>]+>/g, "")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&amp;/g, "&");
+  return decodeText(inner.replace(/<br\s*\/?>/g, "\n"));
 }
 
 /**
@@ -95,8 +108,8 @@ describe("preview keeps a multi-line block's lines and columns", () => {
   }
 
   it("keeps the anchor a single clickable/highlightable link around the whole block", () => {
-    // The reason the author cannot escape into a code fence: an anchor's link text is inline,
-    // so the multi-line block has to stay a paragraph. The anchor must survive intact.
+    // A paragraph anchor is a real markdown link, so markdown-it renders it as one <a> — it must
+    // survive the whitespace handling intact, wrapping every line of the block.
     const html = renderMarkdown(ANCHORED_TREE);
     const opens = [...html.matchAll(/<a\b[^>]*>/g)];
     expect(opens.length).toBe(1);
@@ -134,5 +147,172 @@ describe("preview keeps a multi-line block's lines and columns", () => {
     for (const sel of selectors) {
       expect(sel).not.toMatch(/\.ap-rendered\s+(li|ul|ol|blockquote|table)\b/);
     }
+  });
+});
+
+// --- half two: the same block inside a fence ----------------------------------
+
+/** The markup inside the n-th rendered `<pre><code>`. */
+function codeMarkup(html: string, n = 0): string {
+  const blocks = [...html.matchAll(/<pre\b[^>]*>\s*<code\b[^>]*>([\s\S]*?)<\/code>\s*<\/pre>/g)];
+  return blocks[n]?.[1] ?? "";
+}
+
+/** The `white-space` the stylesheet applies to the preview's code blocks. Nothing is declared
+ *  for `.ap-rendered pre`, which is the point: a `<pre>` keeps the UA default `pre`, so a code
+ *  block already draws every newline and every run of alignment spaces as typed. If a rule ever
+ *  overrides that to something collapsing, the reader assertions below stop holding — so read
+ *  the value out of the stylesheet rather than assuming it. */
+function previewCodeWhiteSpace(): string {
+  const re = /(?:^|\})([^{}]*\.ap-rendered[^{}]*\b(?:pre|code)\b[^{}]*)\{([^}]*)\}/gm;
+  let ws = "pre"; // the UA default for <pre>
+  for (const m of css.matchAll(re)) {
+    const decl = /white-space:\s*([a-z-]+)/.exec(m[2]!);
+    if (decl) ws = decl[1]!;
+  }
+  return ws;
+}
+
+/** The lines a reader sees inside the n-th rendered code block. */
+function codeLines(html: string, n = 0): string[] {
+  const text = decodeText(codeMarkup(html, n)).replace(/\n$/, ""); // fences end with a newline
+  const ws = previewCodeWhiteSpace();
+  if (ws === "pre" || ws === "pre-wrap") return text.split("\n");
+  if (ws === "pre-line") return text.split("\n").map((l) => l.replace(/[^\S\n]+/g, " "));
+  return [text.replace(/\s+/g, " ")];
+}
+
+/** Every element in the rendered HTML that carries a comment anchor's id. */
+function anchorTags(html: string): string[] {
+  return [...html.matchAll(/<(?:a|span)\b[^>]*\bdata-cmt=[^>]*>/g)].map((m) => m[0]);
+}
+
+/** The user's exact reported case: the three-line tree, anchored, inside a fence. */
+const FENCED_ANCHORED_TREE = "```\n" + ANCHORED_TREE + "\n```\n";
+
+describe("a comment anchor written inside a code fence", () => {
+  it("renders as a real anchor the reader can click, not as visible anchor syntax", () => {
+    const html = renderMarkdown(FENCED_ANCHORED_TREE);
+    // What the reader sees is the code — no brackets, no (#cmt-…) tail.
+    const lines = codeLines(html);
+    expect(lines).toEqual([
+      "├── /dashboard       — 분석 대시보드 (로그인 필요)",
+      "├── /collections     — 컬렉션 관리 (웹 버전)",
+      "└── /login           — 인증",
+    ]);
+    expect(codeMarkup(html)).not.toContain("#cmt-cwnj04)");
+    expect(decodeText(codeMarkup(html))).not.toContain("](");
+    // …and the columns still line up, as they do in the fence's source.
+    expect(lines.map((l) => l.indexOf("—"))).toEqual([21, 21, 21]);
+    // The comment has exactly one element to point at, tagged the way the rail and the
+    // click/highlight path look it up.
+    const tags = anchorTags(html);
+    expect(tags.length).toBe(1);
+    expect(tags[0]).toContain('data-cmt="cmt-cwnj04"');
+    expect(tags[0]).toContain('class="ap-anchor"');
+    // …and it covers all three lines, not just the first.
+    const inner = /<span\b[^>]*\bdata-cmt="cmt-cwnj04"[^>]*>([\s\S]*?)<\/span>/.exec(html)?.[1] ?? "";
+    expect(inner.split("\n")).toHaveLength(3);
+  });
+
+  it("keeps the code block a code block: no <a>, and the <pre> still carries its source line", () => {
+    const html = renderMarkdown(FENCED_ANCHORED_TREE);
+    // A link inside <code> would inherit link styling and read as prose; the marker is a <span>.
+    expect(html).not.toContain("<a ");
+    expect(html).toMatch(/^<pre data-line="0"><code>/);
+  });
+
+  it("carries an anchor in an indented (four-space) code block too", () => {
+    const html = renderMarkdown("    [tabs vs spaces](#cmt-ab12cd)\n");
+    expect(codeLines(html)).toEqual(["tabs vs spaces"]);
+    expect(anchorTags(html)).toHaveLength(1);
+  });
+
+  it("renders every anchor in a fence that carries several", () => {
+    const html = renderMarkdown("```\n[first](#cmt-aaa111)\nmiddle\n[second](#cmt-bbb222)\n```\n");
+    expect(codeLines(html)).toEqual(["first", "middle", "second"]);
+    const tags = anchorTags(html);
+    expect(tags).toHaveLength(2);
+    expect(tags[0]).toContain('data-cmt="cmt-aaa111"');
+    expect(tags[1]).toContain('data-cmt="cmt-bbb222"');
+  });
+
+  it("normalizes the id's case, the way a paragraph anchor does", () => {
+    // link_open lowercases a `#CMT-…` href before tagging it, so the rail's lookup by the
+    // comment's own (lowercase) id finds it. The fenced marker must agree, or a hand-typed
+    // uppercase anchor would render a marker nothing can find.
+    const html = renderMarkdown("```\n[case](#CMT-AAA111)\n```\n");
+    expect(anchorTags(html)[0]).toContain('data-cmt="cmt-aaa111"');
+    expect(codeLines(html)).toEqual(["case"]);
+  });
+
+  it("marks only the anchored part of a fence, leaving the rest plain code", () => {
+    const html = renderMarkdown("```\nkeep me\n[watch this](#cmt-aaa111)\nkeep me too\n```\n");
+    expect(codeLines(html)).toEqual(["keep me", "watch this", "keep me too"]);
+    // The span must not swallow the surrounding lines.
+    const inner = /<span\b[^>]*\bdata-cmt="cmt-aaa111"[^>]*>([\s\S]*?)<\/span>/.exec(html)?.[1] ?? "";
+    expect(inner).toBe("watch this");
+  });
+
+  it("keeps the fence's language class, so highlighting/styling by language is unaffected", () => {
+    const html = renderMarkdown("```ts\nconst [a](#cmt-aaa111) = 1;\n```\n");
+    expect(html).toContain('<code class="language-ts">');
+    expect(codeLines(html)).toEqual(["const a = 1;"]);
+    expect(anchorTags(html)).toHaveLength(1);
+  });
+
+  it("leaves a link that only LOOKS like an anchor completely literal", () => {
+    // Only `#cmt-<id>` is a comment anchor. Anything else in a fence is code, shown verbatim.
+    const html = renderMarkdown("```\n[x](#not-cmt)\n[y](https://example.com)\n[z](#cmt)\n```\n");
+    expect(codeLines(html)).toEqual(["[x](#not-cmt)", "[y](https://example.com)", "[z](#cmt)"]);
+    expect(anchorTags(html)).toHaveLength(0);
+  });
+
+  it("still escapes the code it renders — an anchor is no way in for raw HTML", () => {
+    // The renderer escapes raw HTML everywhere else on purpose (see markdown.ts's html_block /
+    // html_inline rules); handling the anchor ourselves must not open a hole, inside the
+    // anchor's label or outside it.
+    const html = renderMarkdown('```\n<script>alert(1)</script> & "q"\n[<img onerror=x>](#cmt-aaa111)\n```\n');
+    expect(html).not.toContain("<script>");
+    expect(html).not.toContain("<img");
+    expect(html).toContain("&lt;script&gt;");
+    expect(html).toContain("&lt;img onerror=x&gt;");
+    expect(html).toContain("&amp;");
+    // The reader still sees exactly the characters typed.
+    expect(codeLines(html)).toEqual(['<script>alert(1)</script> & "q"', "<img onerror=x>"]);
+  });
+
+  it("renders a hidden (resolved) fenced anchor as plain code, with no marker and no syntax", () => {
+    const html = renderMarkdown(FENCED_ANCHORED_TREE, () => false);
+    expect(anchorTags(html)).toHaveLength(0);
+    expect(codeMarkup(html)).not.toContain("#cmt-cwnj04");
+    expect(codeLines(html)).toHaveLength(3);
+  });
+
+  it("is the anchor the editor itself writes there — commenting on fenced code round-trips", () => {
+    // This is how the reported document came to exist. spanCommentBlocker matches the selection
+    // against the body TEXT and is fence-unaware, so it does not refuse a selection inside a
+    // fence; addSpanComment then wraps those lines in place. That is now a supported thing to
+    // do rather than a way to break a document, and this pins the two ends together: whatever
+    // the editor writes, the preview renders as a working anchor over unchanged code.
+    const body = "```\n" + PLAIN_TREE + "\n```\n";
+    const span = { startLine: 0, endLine: 4 };
+    expect(spanCommentBlocker(body, PLAIN_TREE, span)).toBeNull();
+    const res = addSpanComment({ body, comments: [] }, PLAIN_TREE, { text: "still needed?", author: "alice" }, span);
+    expect(res).not.toBeNull();
+    // The fence itself is untouched — the anchor went inside it, not around it.
+    expect(res!.doc.body.startsWith("```\n[")).toBe(true);
+    const html = renderMarkdown(res!.doc.body);
+    expect(codeLines(html)).toEqual(PLAIN_TREE.split("\n"));
+    const tags = anchorTags(html);
+    expect(tags).toHaveLength(1);
+    expect(tags[0]).toContain(`data-cmt="${res!.id}"`);
+  });
+
+  it("leaves an ordinary fence byte-for-byte as markdown-it renders it", () => {
+    // The anchor handling is a branch, not a rewrite: a fence with no anchor must go down the
+    // untouched default path.
+    const src = "```py\ndef f(x):\n    return x < 1 & x > 0\n```\n";
+    expect(renderMarkdown(src)).toBe('<pre data-line="0"><code class="language-py">def f(x):\n    return x &lt; 1 &amp; x &gt; 0\n</code></pre>\n');
   });
 });

--- a/packages/renderer/test/previewMultiline.test.ts
+++ b/packages/renderer/test/previewMultiline.test.ts
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// A multi-line block typed into a plan document must READ in the preview the way it reads in
+// the source pane: same number of lines, same columns. Markdown's paragraph rule keeps the
+// author's newlines in the token stream, and markdown-it duly emits them inside the <p> — but
+// HTML's default whitespace processing collapses a newline, and every run of alignment spaces,
+// down to a single space. A directory tree pasted into a plan therefore arrived as one run-on
+// line with its columns gone.
+//
+// These tests assert the property a READER cares about (how many lines, and do the columns line
+// up), not the shape of the markup: they take the rendered HTML and put it through the same
+// whitespace processing the browser will, using the `white-space` value the stylesheet actually
+// declares for the preview's paragraph content. So they fail both when the renderer drops the
+// newlines and when the stylesheet doesn't honor them.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { renderMarkdown } from "../src/markdown";
+
+const css = readFileSync(fileURLToPath(new URL("../src/styles.css", import.meta.url)), "utf8");
+
+/** The `white-space` the stylesheet applies to a paragraph of rendered preview content. */
+function previewParagraphWhiteSpace(): string {
+  // Any rule whose selector list targets a <p> inside .ap-rendered (the preview's content root,
+  // shared by the inline-diff view) and sets white-space.
+  const re = /(?:^|\})([^{}]*\.ap-rendered[^{}]*\bp\b[^{}]*)\{([^}]*)\}/gm;
+  let ws = "normal";
+  for (const m of css.matchAll(re)) {
+    const decl = /white-space:\s*([a-z-]+)/.exec(m[2]!);
+    if (decl) ws = decl[1]!;
+  }
+  return ws;
+}
+
+/** The text of the first rendered <p>, with <br> turned into the line break it draws. */
+function paragraphText(html: string): string {
+  const inner = /<p\b[^>]*>([\s\S]*?)<\/p>/.exec(html)?.[1] ?? "";
+  return inner
+    .replace(/<br\s*\/?>/g, "\n")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&");
+}
+
+/**
+ * The lines a reader actually sees for a rendered paragraph — the browser's whitespace
+ * processing for the stylesheet's declared `white-space`, applied to the paragraph's text.
+ * `pre`/`pre-wrap` preserve newlines AND space runs; `pre-line` preserves only the newlines;
+ * anything else collapses every whitespace run, newlines included, into one space.
+ */
+function visibleLines(html: string): string[] {
+  const text = paragraphText(html);
+  const ws = previewParagraphWhiteSpace();
+  if (ws === "pre" || ws === "pre-wrap") return text.split("\n");
+  if (ws === "pre-line") return text.split("\n").map((l) => l.replace(/[^\S\n]+/g, " "));
+  return [text.replace(/\s+/g, " ")];
+}
+
+/** The three-line directory tree from the bug report, as one span-comment anchor's link text. */
+const ANCHORED_TREE =
+  "[├── /dashboard       — 분석 대시보드 (로그인 필요)\n" +
+  "├── /collections     — 컬렉션 관리 (웹 버전)\n" +
+  "└── /login           — 인증](#cmt-cwnj04)";
+
+/** The same block with no anchor — the tree renders through the same paragraph path. */
+const PLAIN_TREE =
+  "├── /dashboard       — 분석 대시보드 (로그인 필요)\n" +
+  "├── /collections     — 컬렉션 관리 (웹 버전)\n" +
+  "└── /login           — 인증";
+
+describe("preview keeps a multi-line block's lines and columns", () => {
+  for (const [label, src] of [
+    ["carrying a span-comment anchor", ANCHORED_TREE],
+    ["as plain text", PLAIN_TREE],
+  ] as const) {
+    describe(`a three-line directory tree ${label}`, () => {
+      const lines = visibleLines(renderMarkdown(src));
+
+      it("reads as three separate lines, not one run-on line", () => {
+        expect(lines.length).toBe(3);
+        expect(lines[0]).toMatch(/^├── \/dashboard\b/);
+        expect(lines[1]).toMatch(/^├── \/collections\b/);
+        expect(lines[2]).toMatch(/^└── \/login\b/);
+      });
+
+      it("keeps the runs of alignment spaces, so the columns still line up", () => {
+        // The author padded each line so every "—" sits in the same column. That is the whole
+        // point of the block; collapsing the space runs destroys it even if the lines survive.
+        const dashColumns = lines.map((l) => l.indexOf("—"));
+        expect(dashColumns).toEqual([21, 21, 21]);
+      });
+    });
+  }
+
+  it("keeps the anchor a single clickable/highlightable link around the whole block", () => {
+    // The reason the author cannot escape into a code fence: an anchor's link text is inline,
+    // so the multi-line block has to stay a paragraph. The anchor must survive intact.
+    const html = renderMarkdown(ANCHORED_TREE);
+    const opens = [...html.matchAll(/<a\b[^>]*>/g)];
+    expect(opens.length).toBe(1);
+    expect(opens[0]![0]).toContain('data-cmt="cmt-cwnj04"');
+    expect(opens[0]![0]).toContain('class="ap-anchor"');
+    // …and it wraps all three lines, rather than only the first.
+    const linkText = /<a\b[^>]*>([\s\S]*?)<\/a>/.exec(html)?.[1] ?? "";
+    expect(linkText.split("\n").length).toBe(3);
+  });
+
+  it("still renders a hidden (resolved) anchor's multi-line label as plain text", () => {
+    const html = renderMarkdown(ANCHORED_TREE, () => false);
+    expect(html).not.toContain("<a");
+    expect(visibleLines(html).length).toBe(3);
+  });
+
+  it("does not double a markdown hard break into a blank line", () => {
+    // markdown-it's default hardbreak rule emits "<br>\n" — the trailing newline is cosmetic
+    // source formatting, invisible under normal whitespace processing but a SECOND line break
+    // once the paragraph preserves newlines. Three hard-broken lines must stay three lines.
+    const html = renderMarkdown("alpha  \nbeta  \ngamma\n");
+    expect(html).toContain("<br>");
+    expect(visibleLines(html)).toEqual(["alpha", "beta", "gamma"]);
+  });
+
+  it("leaves markdown's own block-level newlines out of the preserved scope", () => {
+    // The stylesheet must scope the preservation to paragraph content. markdown-it puts
+    // cosmetic newlines between BLOCK tags (inside <li>, <blockquote>, <ul>, …); preserving
+    // those would open a blank line before every nested list and in every loose list item.
+    const ws = previewParagraphWhiteSpace();
+    expect(ws).toBe("pre-wrap");
+    const scoped = /(?:^|\})([^{}]*)\{[^}]*white-space:\s*pre-wrap[^}]*\}/gm;
+    const selectors = [...css.matchAll(scoped)].map((m) => m[1]!.trim()).filter((s) => s.includes(".ap-rendered"));
+    expect(selectors.length).toBeGreaterThan(0);
+    for (const sel of selectors) {
+      expect(sel).not.toMatch(/\.ap-rendered\s+(li|ul|ol|blockquote|table)\b/);
+    }
+  });
+});


### PR DESCRIPTION
## The bug

A multi-line block typed into a plan document rendered wrongly in the preview. The reported case was a directory tree carrying a span-comment anchor, and the document put that block in **two** places — as a paragraph, and again inside a fenced code block. Each broke differently, and this PR fixes both.

```
[├── /dashboard       — 분석 대시보드 (로그인 필요)
├── /collections     — 컬렉션 관리 (웹 버전)
└── /login           — 인증](#cmt-cwnj04)
```

- **As a paragraph** it came out as one run-on line, losing both its line breaks and its column alignment.
- **Inside a ``` fence** the lines and columns survived (a `<pre>` keeps them), but the *anchor* did not: the reader was shown the raw characters `[` … `](#cmt-cwnj04)` as if they were part of the code, and the comment had nothing to point at — neither clickable in the preview nor reachable from the comments rail.

---

# Half one — the paragraph

## The mechanism

The anchor is not the cause — a plain three-line block renders identically. Markdown's paragraph rule keeps the author's newlines, and markdown-it duly emits them inside the `<p>`:

```html
<p data-line="0" data-end-line="2"><a href="#cmt-cwnj04" data-cmt="cmt-cwnj04" class="ap-anchor">├── /dashboard       — …
├── /collections     — …
└── /login           — …</a></p>
```

Those are real newlines. HTML's default whitespace processing then collapses each of them, and each run of alignment spaces, down to a single space. Nothing was losing the line breaks; the preview simply wasn't honoring them.

## The fix

`white-space: pre-wrap` on `.ap-rendered p`. It preserves both the newlines already in the markup and the runs of alignment spaces, with no change to how markdown is parsed, and unlike `pre` it still wraps a long line at the pane width. `.ap-rendered` is the preview's content root and is also the root of the inline-diff view, so multi-line diff hunks benefit the same way.

The alternative, markdown-it's `breaks: true`, was rejected on evidence: it turns a newline into a `<br>` but leaves the collapsed alignment spaces untouched, so it fixes only half of what was reported, and it diverges from CommonMark for every document in the process.

Scoping the rule to paragraph content is deliberate rather than incidental. Dumping the renderer output for a kitchen-sink document shows markdown-it also emits cosmetic newlines *between block tags* — and every one of them sits outside a `<p>`:

```
">parent\n<"                          a tight <li> before a nested <ul>
">nested child\n<"                    likewise, one level deeper
">tight with\na continuation line<"   a tight <li>'s own continuation
```

Putting `pre-wrap` on `li` would therefore have opened a blank line before every nested list. Across that same document, all ten `<p>` elements came back clean: no leading whitespace, no trailing whitespace, no blank lines.

### One companion change

markdown-it's default hardbreak rule emits `"<br>\n"`. That trailing newline is cosmetic source formatting — invisible while whitespace collapses, but a *second*, real line break once newlines are preserved. Without this, every markdown hard break would have become a blank line: `alpha  \nbeta  \ngamma` rendered as `['alpha', '', 'beta', '', 'gamma']`. The rule now emits the `<br>` alone.

hardbreak is the only rule that puts a newline *inside* a paragraph. markdown-it's `renderToken` adds its other newlines only when `token.block` is set, i.e. around block-level tokens, which the paragraph-scoped style rule doesn't touch.

## The tradeoff

**Prose whose source is hand-wrapped will now show those line breaks in the preview instead of reflowing.** This is a visible behavior change for existing documents. It is the deliberate cost of the fix: the preview now agrees with the source pane about where the lines are.

A known remaining limitation, left alone on purpose rather than widening the scope: a hand-aligned block inside a **tight** list item is still collapsed, because a tight item's text is not wrapped in a `<p>`. Adding a blank line between items makes the list loose, which wraps each item in a `<p>` and restores the alignment.

---

# Half two — the fence

## The mechanism

CommonMark treats a fence's content as **literal text**, so `[label](#cmt-id)` written inside one is not a markdown link at all. markdown-it hands the renderer the raw characters and the default `fence` rule escapes them straight into the `<code>`:

```html
<pre data-line="0"><code>[├── /dashboard       — 분석 대시보드 (로그인 필요)
├── /collections     — 컬렉션 관리 (웹 버전)
└── /login           — 인증](#cmt-cwnj04)
</code></pre>
```

No `<a>`, no `<span>`, nothing carrying `data-cmt`. So the comment was **unreachable in both directions**: clicking the block in the preview did nothing (the click handler found no anchor), and focusing the thread from the rail found no element to scroll to or flash. Meanwhile the reader was looking at anchor plumbing presented as code.

### Does the editor allow this? Yes — it writes it itself

Checked directly, because the answer decides the fix. The refusal path (`commentBlockReason` → `spanCommentBlocker`, surfacing `topbar.cantRendered` / `cantSpanBlocks` / `cantOverlap`) is **fence-unaware**: `spanCommentBlocker` locates the selection by matching it against the body *text*, and a fence's content is present in the body verbatim, so the match succeeds and it returns `null` — anchorable. `addSpanComment` then wraps those lines in place:

```
blocker = null
```
```
```
[const a = *p;
const b = *q;](#cmt-68xur4)
```
```

There is no inconsistency to reconcile and no gate that was bypassed. Selecting fenced code and commenting on it is a supported gesture that produced a broken document.

## The fix: render the anchor (option a), not refuse it (option b)

Refusing fenced anchors and cleaning up afterwards was rejected. It would have taken away something users are already doing deliberately — and worse, "making already-written docs readable" under that option means stripping the syntax and showing the label as plain code, which leaves the rail holding a comment the reader has no way to locate. Half one's own write-up assumed a fence *couldn't* carry a comment; that assumption is what this half removes.

So the `fence`/`code_block` rule now recognizes the wrapper in the code's own content, drops the syntax, keeps the code text, and marks the spanned characters:

```html
<pre data-line="4"><code><span data-cmt="cmt-cwnj04" class="ap-anchor">├── /dashboard       — 분석 대시보드 (로그인 필요)
├── /collections     — 컬렉션 관리 (웹 버전)
└── /login           — 인증</span>
</code></pre>
```

The pattern is deliberately the same one `docOps` writes and unwraps (its `ANCHOR_RE`), so what the preview recognizes is exactly what the editor produces — pinned by a round-trip test that runs `spanCommentBlocker` → `addSpanComment` → `renderMarkdown` and asserts the result reads as clean code under one working anchor.

### Escaping is not weakened

This was the precondition for choosing (a) at all, given that the rest of the renderer escapes raw HTML on purpose (see the `html_block`/`html_inline` rules and their comment).

- **Every** character of the author's content, the anchor's label included, still goes through `md.utils.escapeHtml`. The only markup added is the `<span>`, whose id the pattern constrains to `[0-9a-z]`, so it needs no quoting of its own.
- The `<pre><code class="language-…">` wrapper is **not reimplemented**. It comes from the default rule, rendered over empty content, with the escaped body spliced in — so the info string, the token's attrs, and anything markdown-it does there keep working. (markdown-it's fence rule builds those attrs "without modifying original token", so rendering twice cannot duplicate them.)
- A fence with no anchor takes the untouched default path, asserted byte-for-byte.

Test: `` ```\n<script>alert(1)</script> & "q"\n[<img onerror=x>](#cmt-aaa111)\n``` `` yields no `<script>` and no `<img>` in the output, `&lt;script&gt;` / `&lt;img onerror=x&gt;` / `&amp;` present, and the reader sees exactly the characters typed.

### A `<span>`, and therefore a second change

A `<a>` inside `<code>` would inherit link styling and read as prose, so the marker is a `<span>` — which broke the preview's click handler, since it resolved its target with `closest("a")`. It now resolves by `closest("[data-cmt]")`, the attribute the comments rail's scroll/flash (`querySelector('[data-cmt="…"]')`) and the selection-overlap check (`querySelectorAll("[data-cmt]")`) **already** look for. Ordinary link navigation (internal doc links, `https:`) falls through to the `closest("a")` branch unchanged. `.ap-rendered .ap-anchor` was already element-agnostic, so no CSS change was needed.

### The tradeoff

**A fence can no longer display `[label](#cmt-<id>)` as literal sample text.** This is the same ambiguity a paragraph anchor has always had — the syntax is recognized wherever it appears, whether or not a comment with that id exists. An inline code span (`` `[x](#cmt-1)` ``) is untouched and remains the way to show anchor syntax literally, and only `#cmt-<id>` is claimed: `[x](#not-cmt)`, `[z](#cmt)`, and ordinary links stay verbatim in a fence.

---

## Proof

The tests assert what a **reader** sees rather than the shape of the markup. `visibleLines()` / `codeLines()` put the rendered HTML through the same whitespace processing a browser would, driven by the `white-space` value read out of `styles.css` — distinguishing `pre-wrap`/`pre` (newlines and space runs preserved) from `pre-line` (newlines only, so a half-fix fails) from `normal`. For code blocks the value read back is the UA default `pre`, because nothing is declared for `.ap-rendered pre`; reading it rather than assuming it means a future rule that collapses code whitespace fails these tests instead of silently passing. Columns are checked the way the author perceives them: the `—` must land in the same column on all three lines.

Both halves were written first and failed first.

**Half one** — 7 of 8 assertions failed against the unfixed tree, with the anchor test passing, matching the diagnosis that the anchor was never at fault. Reverting each part independently, then restoring:

- Removing `.ap-rendered p { white-space: pre-wrap; }` → 7 failed / 1 passed, including `expected [ 15 ] to deeply equal [ 21, 21, 21 ]` (one line, columns gone).
- Removing the hardbreak override → 1 failed, `expected [ 'alpha', '', 'beta', '', 'gamma' ] to deeply equal [ 'alpha', 'beta', 'gamma' ]`.

**Half two** — 7 of 18 in `previewMultiline.test.ts` and 6 of 10 in `App.multilineAnchor.test.tsx` failed against the unfixed tree; the fenced case that already passed was the one asserting an ordinary fence is unchanged. Reverting each part independently, then restoring:

- Removing the `fence`/`code_block` anchor rendering → **14 failed**, including `expected '[├── /dashboard …](#cmt-cwnj04)' not to contain '#cmt-cwnj04'` and, in the mounted app, no `[data-cmt]` element to click at all.
- Removing the click-path widening (back to `closest("a")`) → **1 failed**, and precisely the right one: `a span comment anchoring a multi-line block inside a code fence > is still click-to-focus`, with the paragraph case still green.

Beyond the reported case, the fenced half covers: multiple anchors in one fence; an anchor spanning only part of a fence (the span must not swallow the neighbouring lines); a fence with a language tag (`<code class="language-ts">` preserved); an indented four-space code block; a hidden (resolved) anchor, which renders as plain code with no marker *and* no syntax, matching what `link_open` does for a paragraph; id case normalization (`#CMT-AAA111` → `data-cmt="cmt-aaa111"`, as the rail's lookup requires); and the anchor-looking-but-not-anchor strings above.

The comment anchor is verified end-to-end in `App.multilineAnchor.test.tsx`, which mounts the real `<App/>` over a document whose only comment anchors the three-line tree — **once as a paragraph and once fenced**, running the same reader-facing checks against both: exactly one `[data-cmt]` element, tagged `data-cmt="cmt-cwnj04"` and `.ap-anchor`, an `<a>` in the paragraph and a `<span>` in the fence, whose text carries all three lines with the columns aligned and shows no anchor syntax; clicking it adds `ap-flash-anchor`. The fenced one additionally checks it is still inside a `<pre>`/`<code>` carrying its `data-line` for cross-pane sync, and that clicking its **rail card** flashes it in the preview — the direction that had nothing to find before.

Full suite: 1327 passed / 2 skipped across 155 files; coverage 95.47% (gate ≥95%); `typecheck` clean across all workspaces. No changes to the `markdown`, `inlineMarkup`, `docOps`, or `App` review suites were needed.
