### PR TITLE
login: validate the handoff credential, and try the browser before falling back

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -28,7 +28,7 @@ import {
 } from "@inplan/core/node";
 import { agentAuthorFor } from "./agentAuthor";
 import { gitProvenance } from "./provenance";
-import { authedSession, authPath, clearAuth, currentUser, liveRemoteBackend, loadAuth, remoteBackend, saveAuth, verifyCachedAccessToken, type AuthFile, type SessionFailure } from "./cliAuth";
+import { authedSession, authPath, clearAuth, currentUser, liveRemoteBackend, loadAuth, remoteBackend, saveAuth, verifyCachedAccessToken, type AuthFile } from "./cliAuth";
 import { BrowserDidNotOpenError, LoginSessionExpiredError, clearPendingLogin, createLoginSession, loadPendingLogin, openInBrowser, pollLoginSession, rendezvousLogin, type PendingLogin } from "./cliLogin";
 import { resolveIdentity, setManualProfile, writeLocalProfile } from "./cliProfile";
 import { checkForUpdate, selfUpdate, UPDATE_PKG, warnIfOutdated } from "./update";
@@ -778,7 +778,14 @@ async function doLogin(args: string[]): Promise<void> {
         // Watch the launch, don't just fire it: the opener's own error/exit code is a definite "no
         // browser here", so the poll below can bail on that instead of inferring it from silence.
         const launch = new AbortController();
-        openInBrowser(minted.url, () => launch.abort());
+        // Abort the wait only on a CERTAIN failure — no opener process at all. An opener that ran and
+        // exited non-zero is a hint, not a verdict (some sandboxed configs return non-zero having
+        // launched anyway), and because the opener exits in milliseconds while the ack takes seconds
+        // it would always win that race: acting on it would turn a working browser into an immediate
+        // "did not open". Let the ack window arbitrate that case instead — that is what it is for.
+        openInBrowser(minted.url, (kind) => {
+          if (kind === "no-opener") launch.abort();
+        });
         const auth = await pollLoginSession(minted, {
           openAckMs: OPEN_ACK_MS,
           launchSignal: launch.signal,
@@ -919,13 +926,16 @@ export async function primeSessionOrFail(retryDelayMs = 750): Promise<void> {
   // Route 2 — no usable access token, so spend the rotation. A skew wider than any token's lifetime
   // makes reuseCached decline the cache, so the refresh actually runs.
   const FORCE_REFRESH_SKEW_S = 10 * 365 * 24 * 3600;
-  const forceRefresh = async (): Promise<"ok" | SessionFailure> => {
+  // The cause rides in the RESULT rather than a closure variable the compiler cannot see written:
+  // narrowing would otherwise pin it to its initial value and reject the comparisons below.
+  const forceRefresh = async (): Promise<"ok" | "inconclusive" | "rejected-spent" | "rejected-other"> => {
     const before = loadAuth()?.refreshToken;
-    let reason: SessionFailure = "inconclusive";
-    const session = await authedSession(FORCE_REFRESH_SKEW_S, (r) => {
-      reason = r;
+    let refusal: "inconclusive" | "rejected-spent" | "rejected-other" = "inconclusive";
+    const session = await authedSession(FORCE_REFRESH_SKEW_S, (reason, cause) => {
+      refusal =
+        reason === "inconclusive" ? "inconclusive" : cause === "refresh-token-spent" ? "rejected-spent" : "rejected-other";
     });
-    if (!session) return reason;
+    if (!session) return refusal;
     // A session is NOT proof the refresh happened. When authedSession cannot get the refresh lock it
     // falls back to any not-yet-expired cached token (skew 0) — deliberately, so a long `wait`
     // survives lock churn — and that fallback would let a handoff with a spent refresh token report
@@ -935,7 +945,14 @@ export async function primeSessionOrFail(retryDelayMs = 750): Promise<void> {
   };
   const refreshed = await withOneRetry(forceRefresh);
   if (refreshed === "ok") return;
-  if (refreshed === "rejected") refused("its refresh token had already been spent, so it could never have been used.");
+  // Name the spent-token case ONLY when GoTrue actually named it. `rejected` covers 400/401/403,
+  // which also includes a bad anon key or a revoked user — printing "its refresh token had already
+  // been spent" for those is a confident falsehood, the same mistake one level down as reporting a
+  // network blip as a refusal.
+  if (refreshed === "rejected-spent") refused("its refresh token had already been spent, so it could never have been used.");
+  if (refreshed === "rejected-other") {
+    refused("the server refused it — the token may be invalid or revoked, or this deployment's anon key may no longer match.");
+  }
   unproven();
 }
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -851,11 +851,17 @@ function canAttemptBrowserLaunch(): boolean {
  * so subsequent commands take the fast path and never touch the single-use token.
  */
 async function primeSessionOrFail(): Promise<void> {
+  // Force the REFRESH path, don't just ask for "a session". When the handoff carries an unexpired
+  // access token, authedSession's fast path would hand one back without ever redeeming the refresh
+  // token — so a spent refresh token would sail through login and only surface an hour later, when
+  // a long `wait` tries to renew and dies. A skew wider than any token's lifetime makes reuseCached
+  // decline the cached token, so the refresh runs here, once, and its rotation is persisted.
+  const FORCE_REFRESH_SKEW_S = 10 * 365 * 24 * 3600;
   // One retry: authedSession also returns null when it loses the refresh lock to a concurrent
   // process (a live `wait`), which is contention, not a bad credential.
-  if (await authedSession()) return;
+  if (await authedSession(FORCE_REFRESH_SKEW_S)) return;
   await new Promise((r) => setTimeout(r, 750));
-  if (await authedSession()) return;
+  if (await authedSession(FORCE_REFRESH_SKEW_S)) return;
   clearAuth();
   process.stderr.write(
     "inplan login: signed in, but the server rejected the credential the browser handed over —\n" +

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -29,7 +29,7 @@ import {
 import { agentAuthorFor } from "./agentAuthor";
 import { gitProvenance } from "./provenance";
 import { authedSession, authPath, clearAuth, currentUser, liveRemoteBackend, loadAuth, remoteBackend, saveAuth, type AuthFile } from "./cliAuth";
-import { LoginSessionExpiredError, clearPendingLogin, createLoginSession, loadPendingLogin, pollLoginSession, rendezvousLogin, type PendingLogin } from "./cliLogin";
+import { BrowserDidNotOpenError, LoginSessionExpiredError, clearPendingLogin, createLoginSession, loadPendingLogin, openInBrowser, pollLoginSession, rendezvousLogin, type PendingLogin } from "./cliLogin";
 import { resolveIdentity, setManualProfile, writeLocalProfile } from "./cliProfile";
 import { checkForUpdate, selfUpdate, UPDATE_PKG, warnIfOutdated } from "./update";
 import { runningEditorPid } from "./editorProcess";
@@ -754,6 +754,7 @@ async function doLogin(args: string[]): Promise<void> {
         process.stderr.write(`inplan: waiting for the pending browser sign-in to finish…\n  ${pending.url}\n`);
         const auth = await pollLoginSession(pending, { onNudge: printLoginNudge });
         saveAuth(auth);
+        await primeSessionOrFail();
         await persistCloudIdentity();
         output({ status: "logged_in", url: auth.url, ...(auth.email ? { email: auth.email } : {}) });
         return;
@@ -763,6 +764,38 @@ async function doLogin(args: string[]): Promise<void> {
           process.exit(1);
         }
         /* expired → fall through to a fresh pending session */
+      }
+    }
+    // Try the browser FIRST when this environment plausibly has an opener. Detection of a coding
+    // agent decides where to fall BACK to, not whether to attempt a launch at all: plenty of agent
+    // shells (this one included) can open a browser, and doing so saves the human two round-trips
+    // of copy-pasting a URL. The page's `opened` ack is what makes the attempt verifiable, so a
+    // failed launch costs only OPEN_ACK_MS before the printed-URL path takes over.
+    if (canAttemptBrowserLaunch()) {
+      let minted: PendingLogin | undefined;
+      try {
+        minted = await createLoginSession();
+        openInBrowser(minted.url);
+        const auth = await pollLoginSession(minted, { openAckMs: OPEN_ACK_MS, onNudge: printLoginNudge });
+        saveAuth(auth);
+        await primeSessionOrFail();
+        await persistCloudIdentity();
+        output({ status: "logged_in", url: auth.url, ...(auth.email ? { email: auth.email } : {}) });
+        return;
+      } catch (e) {
+        // No ack: hand the SAME session to the human via the printed-URL flow.
+        if (e instanceof BrowserDidNotOpenError) {
+          await pendingLoginExit(minted);
+          process.exit(1);
+        }
+        // Anything else (expired link, unreadable handoff, a rejected credential from
+        // primeSessionOrFail's exit) is a real failure — don't silently retry a different way.
+        if (e instanceof LoginSessionExpiredError) {
+          await pendingLoginExit();
+          process.exit(1);
+        }
+        process.stderr.write(`inplan login: ${e instanceof Error ? e.message : String(e)}\n`);
+        process.exit(1);
       }
     }
     await pendingLoginExit();
@@ -785,12 +818,52 @@ async function doLogin(args: string[]): Promise<void> {
         })
       : await defaultRendezvousLogin();
     saveAuth(auth);
+    await primeSessionOrFail();
     await persistCloudIdentity();
     output({ status: "logged_in", url: auth.url, ...(auth.email ? { email: auth.email } : {}) });
   } catch (e) {
     process.stderr.write(`inplan login: ${e instanceof Error ? e.message : String(e)}\n`);
     process.exit(1);
   }
+}
+
+/** How long to wait for the page's `opened` ack before deciding the browser never launched.
+ *  Short on purpose: it is pure latency on the path where there is no browser, and the printed-URL
+ *  fallback is right behind it. */
+const OPEN_ACK_MS = 6_000;
+
+/** May we *attempt* to launch a browser? Distinct from {@link canInteractiveLogin}, which asks
+ *  whether we may BLOCK on one: an attempt is cheap and self-verifying (the page acks `opened`),
+ *  so it is worth trying wherever an opener could plausibly exist. CI has no display, and
+ *  INPLAN_NO_BROWSER is an explicit "never". */
+function canAttemptBrowserLaunch(): boolean {
+  return !process.env.CI && !process.env.INPLAN_NO_BROWSER;
+}
+
+/**
+ * Validate the credential we just stored, by taking its FIRST refresh now.
+ *
+ * The handoff carries a refresh token but no access token, so every later command must refresh —
+ * and Supabase refresh tokens are single-use. If the token arrives already spent, the old flow
+ * still printed `logged_in` (the only thing that would have noticed was `persistCloudIdentity`,
+ * whose `catch {}` swallows it) and the failure surfaced later as a baffling "not logged in" on an
+ * unrelated command. Spend the rotation here instead: on success it also caches the access token,
+ * so subsequent commands take the fast path and never touch the single-use token.
+ */
+async function primeSessionOrFail(): Promise<void> {
+  // One retry: authedSession also returns null when it loses the refresh lock to a concurrent
+  // process (a live `wait`), which is contention, not a bad credential.
+  if (await authedSession()) return;
+  await new Promise((r) => setTimeout(r, 750));
+  if (await authedSession()) return;
+  clearAuth();
+  process.stderr.write(
+    "inplan login: signed in, but the server rejected the credential the browser handed over —\n" +
+      "  its refresh token had already been spent, so it could never have been used.\n" +
+      "  Sign in again. If this repeats, the browser session is rotating the token before the CLI\n" +
+      "  can claim it, and the sign-in page needs to hand over an unused token (or an access token).\n",
+  );
+  process.exit(1);
 }
 
 /** Best-effort: write the signed-in cloud account's name/email to the local profile. */
@@ -948,11 +1021,14 @@ export function scrubAgentEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
  * simply the command that just ran, because ensureLoggedIn resumes the pending sidecar. The JSON
  * line carries the same fields for parsers, and the distinct exit code lets wrappers branch.
  */
-async function pendingLoginExit(): Promise<void> {
+async function pendingLoginExit(existing?: PendingLogin): Promise<void> {
   let url: string;
   let expiresInSec: number;
   try {
-    const pending = await createLoginSession();
+    // Reuse a session the caller already minted (the try-the-browser-first path below) instead of
+    // minting a second one: the human is about to be handed THIS url, and the resume must claim
+    // the same rendezvous row.
+    const pending = existing ?? (await createLoginSession());
     url = pending.url;
     expiresInSec = Math.max(0, Math.floor((pending.expiresAt - Date.now()) / 1000));
   } catch (e) {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -28,7 +28,7 @@ import {
 } from "@inplan/core/node";
 import { agentAuthorFor } from "./agentAuthor";
 import { gitProvenance } from "./provenance";
-import { authedSession, authPath, clearAuth, currentUser, liveRemoteBackend, loadAuth, remoteBackend, saveAuth, type AuthFile, type SessionFailure } from "./cliAuth";
+import { authedSession, authPath, clearAuth, currentUser, liveRemoteBackend, loadAuth, remoteBackend, saveAuth, verifyCachedAccessToken, type AuthFile, type SessionFailure } from "./cliAuth";
 import { BrowserDidNotOpenError, LoginSessionExpiredError, clearPendingLogin, createLoginSession, loadPendingLogin, openInBrowser, pollLoginSession, rendezvousLogin, type PendingLogin } from "./cliLogin";
 import { resolveIdentity, setManualProfile, writeLocalProfile } from "./cliProfile";
 import { checkForUpdate, selfUpdate, UPDATE_PKG, warnIfOutdated } from "./update";
@@ -777,13 +777,11 @@ async function doLogin(args: string[]): Promise<void> {
         minted = await createLoginSession();
         // Watch the launch, don't just fire it: the opener's own error/exit code is a definite "no
         // browser here", so the poll below can bail on that instead of inferring it from silence.
-        let launchFailed = false;
-        openInBrowser(minted.url, () => {
-          launchFailed = true;
-        });
+        const launch = new AbortController();
+        openInBrowser(minted.url, () => launch.abort());
         const auth = await pollLoginSession(minted, {
           openAckMs: OPEN_ACK_MS,
-          launchFailed: () => launchFailed,
+          launchSignal: launch.signal,
           onNudge: printLoginNudge,
         });
         saveAuth(auth);
@@ -855,62 +853,90 @@ function canAttemptBrowserLaunch(): boolean {
 }
 
 /**
- * Validate the credential we just stored, by taking its FIRST refresh now.
+ * Validate the credential we just stored, before `login` claims it worked.
  *
- * The handoff carries a refresh token but no access token, so every later command must refresh —
- * and Supabase refresh tokens are single-use. If the token arrives already spent, the old flow
- * still printed `logged_in` (the only thing that would have noticed was `persistCloudIdentity`,
- * whose `catch {}` swallows it) and the failure surfaced later as a baffling "not logged in" on an
- * unrelated command. Spend the rotation here instead: on success it also caches the access token,
- * so subsequent commands take the fast path and never touch the single-use token.
+ * The old flow printed `logged_in` for a credential nobody had checked: the handoff carried a
+ * refresh token, Supabase refresh tokens are single-use, and if the sign-in page's own client had
+ * already rotated the session the token arrived spent. The only code that would have noticed was
+ * `persistCloudIdentity`, whose `catch {}` swallows exactly that — so the failure resurfaced later
+ * as a baffling "not logged in" on an unrelated command.
+ *
+ * Two routes, and which one runs matters:
+ *
+ *  1. The handoff sealed a live ACCESS token ⇒ validate NON-DESTRUCTIVELY. One authenticated
+ *     round-trip proves the session works, and the single-use refresh token stays unspent. This is
+ *     the whole point of the page sealing that token: forcing a refresh here would re-run the very
+ *     race the sealed token exists to avoid, and would make the page's half buy nothing.
+ *
+ *  2. No usable access token (an older page, or one already near expiry) ⇒ force the refresh, which
+ *     is then the only proof available. A spent token must fail HERE, with the browser still open
+ *     and an actionable message, rather than an hour later mid-`wait` with nothing to recover with.
+ *
+ * Be clear about the limit of route 1: it proves the session authenticates NOW. It deliberately
+ * does NOT prove the refresh token is still live, because the only way to test that is to spend it.
+ * So a long `wait` can still meet a dead refresh token when the access token expires. That residual
+ * is inherent to handing the CLI a COPY of the browser's session; the durable fix is for the CLI to
+ * get a session of its OWN, minted server-side at the rendezvous /complete step. Tracked as
+ * follow-up — deliberately not built here.
  */
 export async function primeSessionOrFail(retryDelayMs = 750): Promise<void> {
-  // Force the REFRESH path, don't just ask for "a session". When the handoff carries an unexpired
-  // access token, authedSession's fast path would hand one back without ever redeeming the refresh
-  // token — so a spent refresh token would sail through login and only surface an hour later, when
-  // a long `wait` tries to renew and dies. A skew wider than any token's lifetime makes reuseCached
-  // decline the cached token, so the refresh runs here, once, and its rotation is persisted.
-  const FORCE_REFRESH_SKEW_S = 10 * 365 * 24 * 3600;
-  // WHY the reason matters: authedSession collapses every failure to null — a spent token, a
-  // dropped connection, a 5xx, and losing the refresh lock to a live `wait` all look identical.
-  // Deleting the credential is only defensible for the first; on the others we would destroy a
-  // working session AND tell the user something false about why.
-  const attempt = async (): Promise<"ok" | SessionFailure> => {
-    let reason: SessionFailure = "inconclusive";
-    const session = await authedSession(FORCE_REFRESH_SKEW_S, (r) => {
-      reason = r;
-    });
-    return session ? "ok" : reason;
-  };
-  let outcome = await attempt();
-  if (outcome === "ok") return;
-  // Retry ONLY when the first attempt was inconclusive (lock contention from a concurrent `wait`,
-  // a transport blip). Re-presenting a token the server has already refused buys nothing, and
-  // GoTrue treats a second use of a spent token as reuse — which can revoke the whole family.
-  if (outcome !== "rejected") {
-    await new Promise((r) => setTimeout(r, retryDelayMs));
-    outcome = await attempt();
-    if (outcome === "ok") return;
-  }
-  if (outcome === "rejected") {
+  // A verdict is only worth acting on when we know which kind it is. authedSession collapses every
+  // failure to null — a spent token, a dropped connection, a 5xx, a 429, losing the refresh lock to
+  // a live `wait` — and deleting the user's credential is defensible for exactly one of those.
+  const refused = (what: string): never => {
     clearAuth();
     process.stderr.write(
-      "inplan login: signed in, but the server rejected the credential the browser handed over —\n" +
-        "  its refresh token had already been spent, so it could never have been used.\n" +
+      `inplan login: signed in, but the server rejected the credential the browser handed over — ${what}\n` +
         "  Sign in again. If this repeats, the browser session is rotating the token before the CLI\n" +
         "  can claim it, and the sign-in page needs to hand over an unused token (or an access token).\n",
     );
     process.exit(1);
-  }
-  // Inconclusive: KEEP the credential — it may well be fine, and a network blip must not force the
-  // whole browser handoff again. Still exit non-zero: this command's whole point is to stop
-  // claiming a success it has not verified.
-  process.stderr.write(
-    "inplan login: signed in, but the credential could not be verified — the check did not get a\n" +
-      "  answer from the server (network, an outage, or another `inplan` holding the refresh lock).\n" +
-      "  The credential is KEPT, not discarded: run the command again, or `inplan whoami` to check.\n",
-  );
-  process.exit(1);
+  };
+  // KEEP the credential: it may well be fine, and a blip must not cost the whole browser handoff.
+  // Still exit non-zero — not claiming an unverified success is this command's entire purpose.
+  const unproven = (): never => {
+    process.stderr.write(
+      "inplan login: signed in, but the credential could not be verified — the check did not get an\n" +
+        "  answer from the server (network, an outage, or another `inplan` holding the refresh lock).\n" +
+        "  The credential is KEPT, not discarded: run the command again, or `inplan whoami` to check.\n",
+    );
+    process.exit(1);
+  };
+  /** Run `check` once, and once more after a pause if it was merely unanswered. */
+  const withOneRetry = async <T extends string>(check: () => Promise<T | "inconclusive">): Promise<T | "inconclusive"> => {
+    const first = await check();
+    if (first !== "inconclusive") return first;
+    await new Promise((r) => setTimeout(r, retryDelayMs));
+    return check();
+  };
+
+  // Route 1 — the cheap, non-destructive proof.
+  const cached = await withOneRetry(verifyCachedAccessToken);
+  if (cached === "ok") return;
+  if (cached === "rejected") refused("its access token was not accepted.");
+  if (cached === "inconclusive") unproven();
+
+  // Route 2 — no usable access token, so spend the rotation. A skew wider than any token's lifetime
+  // makes reuseCached decline the cache, so the refresh actually runs.
+  const FORCE_REFRESH_SKEW_S = 10 * 365 * 24 * 3600;
+  const forceRefresh = async (): Promise<"ok" | SessionFailure> => {
+    const before = loadAuth()?.refreshToken;
+    let reason: SessionFailure = "inconclusive";
+    const session = await authedSession(FORCE_REFRESH_SKEW_S, (r) => {
+      reason = r;
+    });
+    if (!session) return reason;
+    // A session is NOT proof the refresh happened. When authedSession cannot get the refresh lock it
+    // falls back to any not-yet-expired cached token (skew 0) — deliberately, so a long `wait`
+    // survives lock churn — and that fallback would let a handoff with a spent refresh token report
+    // `logged_in` having redeemed nothing. The ROTATION is the proof: only a live refresh token
+    // yields a new one, and cliAuth persists it before returning.
+    return loadAuth()?.refreshToken !== before ? "ok" : "inconclusive";
+  };
+  const refreshed = await withOneRetry(forceRefresh);
+  if (refreshed === "ok") return;
+  if (refreshed === "rejected") refused("its refresh token had already been spent, so it could never have been used.");
+  unproven();
 }
 
 /** Best-effort: write the signed-in cloud account's name/email to the local profile. */

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -28,7 +28,7 @@ import {
 } from "@inplan/core/node";
 import { agentAuthorFor } from "./agentAuthor";
 import { gitProvenance } from "./provenance";
-import { authedSession, authPath, clearAuth, currentUser, liveRemoteBackend, loadAuth, remoteBackend, saveAuth, type AuthFile } from "./cliAuth";
+import { authedSession, authPath, clearAuth, currentUser, liveRemoteBackend, loadAuth, remoteBackend, saveAuth, type AuthFile, type SessionFailure } from "./cliAuth";
 import { BrowserDidNotOpenError, LoginSessionExpiredError, clearPendingLogin, createLoginSession, loadPendingLogin, openInBrowser, pollLoginSession, rendezvousLogin, type PendingLogin } from "./cliLogin";
 import { resolveIdentity, setManualProfile, writeLocalProfile } from "./cliProfile";
 import { checkForUpdate, selfUpdate, UPDATE_PKG, warnIfOutdated } from "./update";
@@ -769,14 +769,23 @@ async function doLogin(args: string[]): Promise<void> {
     // Try the browser FIRST when this environment plausibly has an opener. Detection of a coding
     // agent decides where to fall BACK to, not whether to attempt a launch at all: plenty of agent
     // shells (this one included) can open a browser, and doing so saves the human two round-trips
-    // of copy-pasting a URL. The page's `opened` ack is what makes the attempt verifiable, so a
-    // failed launch costs only OPEN_ACK_MS before the printed-URL path takes over.
+    // of copy-pasting a URL. Two signals make the attempt verifiable: the opener reporting its own
+    // failure (definite, caught in one poll) and the page's `opened` ack (the backstop, OPEN_ACK_MS).
     if (canAttemptBrowserLaunch()) {
       let minted: PendingLogin | undefined;
       try {
         minted = await createLoginSession();
-        openInBrowser(minted.url);
-        const auth = await pollLoginSession(minted, { openAckMs: OPEN_ACK_MS, onNudge: printLoginNudge });
+        // Watch the launch, don't just fire it: the opener's own error/exit code is a definite "no
+        // browser here", so the poll below can bail on that instead of inferring it from silence.
+        let launchFailed = false;
+        openInBrowser(minted.url, () => {
+          launchFailed = true;
+        });
+        const auth = await pollLoginSession(minted, {
+          openAckMs: OPEN_ACK_MS,
+          launchFailed: () => launchFailed,
+          onNudge: printLoginNudge,
+        });
         saveAuth(auth);
         await primeSessionOrFail();
         await persistCloudIdentity();
@@ -828,9 +837,14 @@ async function doLogin(args: string[]): Promise<void> {
 }
 
 /** How long to wait for the page's `opened` ack before deciding the browser never launched.
- *  Short on purpose: it is pure latency on the path where there is no browser, and the printed-URL
- *  fallback is right behind it. */
-const OPEN_ACK_MS = 6_000;
+ *
+ *  Generous on purpose, and it used to be 6s — about three polls. A cold Chrome/Safari start plus
+ *  the page's own load routinely exceeds that, so the short window's most likely victim was a
+ *  machine where the browser DID open: it would report failure on the success path, which is the
+ *  very class of misleading status this command exists to stop doing. The window is only a backstop
+ *  now — `openInBrowser` reports a failed launch directly (missing opener, non-zero exit), which is
+ *  the case that actually needed to be fast, and it is caught in one poll rather than by timeout. */
+const OPEN_ACK_MS = 20_000;
 
 /** May we *attempt* to launch a browser? Distinct from {@link canInteractiveLogin}, which asks
  *  whether we may BLOCK on one: an attempt is cheap and self-verifying (the page acks `opened`),
@@ -850,24 +864,51 @@ function canAttemptBrowserLaunch(): boolean {
  * unrelated command. Spend the rotation here instead: on success it also caches the access token,
  * so subsequent commands take the fast path and never touch the single-use token.
  */
-async function primeSessionOrFail(): Promise<void> {
+export async function primeSessionOrFail(retryDelayMs = 750): Promise<void> {
   // Force the REFRESH path, don't just ask for "a session". When the handoff carries an unexpired
   // access token, authedSession's fast path would hand one back without ever redeeming the refresh
   // token — so a spent refresh token would sail through login and only surface an hour later, when
   // a long `wait` tries to renew and dies. A skew wider than any token's lifetime makes reuseCached
   // decline the cached token, so the refresh runs here, once, and its rotation is persisted.
   const FORCE_REFRESH_SKEW_S = 10 * 365 * 24 * 3600;
-  // One retry: authedSession also returns null when it loses the refresh lock to a concurrent
-  // process (a live `wait`), which is contention, not a bad credential.
-  if (await authedSession(FORCE_REFRESH_SKEW_S)) return;
-  await new Promise((r) => setTimeout(r, 750));
-  if (await authedSession(FORCE_REFRESH_SKEW_S)) return;
-  clearAuth();
+  // WHY the reason matters: authedSession collapses every failure to null — a spent token, a
+  // dropped connection, a 5xx, and losing the refresh lock to a live `wait` all look identical.
+  // Deleting the credential is only defensible for the first; on the others we would destroy a
+  // working session AND tell the user something false about why.
+  const attempt = async (): Promise<"ok" | SessionFailure> => {
+    let reason: SessionFailure = "inconclusive";
+    const session = await authedSession(FORCE_REFRESH_SKEW_S, (r) => {
+      reason = r;
+    });
+    return session ? "ok" : reason;
+  };
+  let outcome = await attempt();
+  if (outcome === "ok") return;
+  // Retry ONLY when the first attempt was inconclusive (lock contention from a concurrent `wait`,
+  // a transport blip). Re-presenting a token the server has already refused buys nothing, and
+  // GoTrue treats a second use of a spent token as reuse — which can revoke the whole family.
+  if (outcome !== "rejected") {
+    await new Promise((r) => setTimeout(r, retryDelayMs));
+    outcome = await attempt();
+    if (outcome === "ok") return;
+  }
+  if (outcome === "rejected") {
+    clearAuth();
+    process.stderr.write(
+      "inplan login: signed in, but the server rejected the credential the browser handed over —\n" +
+        "  its refresh token had already been spent, so it could never have been used.\n" +
+        "  Sign in again. If this repeats, the browser session is rotating the token before the CLI\n" +
+        "  can claim it, and the sign-in page needs to hand over an unused token (or an access token).\n",
+    );
+    process.exit(1);
+  }
+  // Inconclusive: KEEP the credential — it may well be fine, and a network blip must not force the
+  // whole browser handoff again. Still exit non-zero: this command's whole point is to stop
+  // claiming a success it has not verified.
   process.stderr.write(
-    "inplan login: signed in, but the server rejected the credential the browser handed over —\n" +
-      "  its refresh token had already been spent, so it could never have been used.\n" +
-      "  Sign in again. If this repeats, the browser session is rotating the token before the CLI\n" +
-      "  can claim it, and the sign-in page needs to hand over an unused token (or an access token).\n",
+    "inplan login: signed in, but the credential could not be verified — the check did not get a\n" +
+      "  answer from the server (network, an outage, or another `inplan` holding the refresh lock).\n" +
+      "  The credential is KEPT, not discarded: run the command again, or `inplan whoami` to check.\n",
   );
   process.exit(1);
 }

--- a/packages/cli/src/cliAuth.ts
+++ b/packages/cli/src/cliAuth.ts
@@ -243,9 +243,40 @@ async function reuseCached(auth: AuthFile, skewS = ACCESS_SKEW_S): Promise<Authe
  *  a wide margin there would only rotate the single-use token more often than necessary. */
 export const LIVE_REFRESH_SKEW_S = 10 * 60;
 
-export async function authedSession(skewS = ACCESS_SKEW_S): Promise<AuthedSession | null> {
+/**
+ * Why {@link authedSession} returned null. It collapses every failure to `null` because almost all
+ * of its callers only need "can I act as this user right now?" — but ONE caller (login's credential
+ * priming) has to decide whether to DELETE the stored credential, and that decision is only sound
+ * for a failure known to be terminal.
+ *
+ * - `rejected` — the server looked at the refresh token and refused it (spent / invalid). No retry
+ *   revives it, so the credential is genuinely dead.
+ * - `inconclusive` — we never got a verdict: a dropped connection, a 5xx, lock contention, or a
+ *   refresh response we declined to trust. Says nothing about the credential, only that we could
+ *   not ask. Discarding a credential on this evidence throws away a working session.
+ */
+export type SessionFailure = "rejected" | "inconclusive";
+
+/** GoTrue statuses that are a verdict on the *credential* rather than on the request's luck.
+ *  400 is what `refresh_token_already_used` / `invalid_grant` arrive as; 401/403 are the same class
+ *  of "this token is not acceptable". Deliberately NOT 408/429 (retry later) and not 5xx (the
+ *  server never looked), and not supabase-js's status-0 transport errors. */
+const REJECTING_STATUSES = new Set([400, 401, 403]);
+
+/** Classify a failed `refreshSession` so a caller can tell "your credential is dead" from
+ *  "I couldn't reach the server". Anything unrecognised is inconclusive — the safe direction,
+ *  since the only action gated on `rejected` is deleting the user's credential. */
+function refreshFailureKind(error: unknown): SessionFailure {
+  const status = (error as { status?: unknown } | null | undefined)?.status;
+  return typeof status === "number" && REJECTING_STATUSES.has(status) ? "rejected" : "inconclusive";
+}
+
+export async function authedSession(skewS = ACCESS_SKEW_S, onFailure?: (reason: SessionFailure) => void): Promise<AuthedSession | null> {
   const cached = loadAuth();
-  if (!cached) return null;
+  if (!cached) {
+    onFailure?.("inconclusive"); // no credentials at all: nothing was rejected, there was nothing to ask with
+    return null;
+  }
 
   // Fast path — reuse a still-valid access token: no refresh, no rotation, no lock. This is what
   // makes concurrent `inplan` processes safe (they never touch the single-use refresh token).
@@ -257,17 +288,26 @@ export async function authedSession(skewS = ACCESS_SKEW_S): Promise<AuthedSessio
   // path. Load again inside the lock in case a concurrent process just refreshed.
   const locked = await withAuthLock<AuthedSession | null>(async ({ stillMine }) => {
     const auth = loadAuth();
-    if (!auth) return null;
+    if (!auth) {
+      onFailure?.("inconclusive");
+      return null;
+    }
     const fresh = await reuseCached(auth, skewS); // a peer may have refreshed while we waited for the lock
     if (fresh) return fresh;
 
     // Fence the single-use rotation: if we were paused past staleMs and reclaimed, bail rather than
     // refresh alongside the new owner (that double-rotate revokes the token → logs the session out).
     // The caller re-checks the cache on non-acquisition, so returning null here is safely retryable.
-    if (!stillMine()) return null;
+    if (!stillMine()) {
+      onFailure?.("inconclusive"); // lost the lock — we never asked the server anything
+      return null;
+    }
     const db = newClient(auth);
     const { data, error } = await db.auth.refreshSession({ refresh_token: auth.refreshToken });
-    if (error || !data.session) return null;
+    if (error || !data.session) {
+      onFailure?.(error ? refreshFailureKind(error) : "inconclusive");
+      return null;
+    }
 
     // A refresh response with no rotated token is anomalous, and the old fallback (`|| auth.refreshToken`)
     // hid it in the most damaging way: rotation had almost certainly happened server-side, so we'd
@@ -276,6 +316,7 @@ export async function authedSession(skewS = ACCESS_SKEW_S): Promise<AuthedSessio
     // so a server that genuinely doesn't rotate stays usable on the next attempt.
     if (!data.session.refresh_token) {
       process.stderr.write("inplan: refresh returned no new refresh token; keeping the stored one and retrying rather than persisting a possibly-spent token\n");
+      onFailure?.("inconclusive"); // we chose not to trust the response — the credential itself was never refused
       return null;
     }
 
@@ -298,7 +339,9 @@ export async function authedSession(skewS = ACCESS_SKEW_S): Promise<AuthedSessio
   // transient contention returns a usable session rather than a spurious null. Only a genuinely
   // expired/absent session yields null here — the one case where callers SHOULD say "run inplan
   // login". This keeps a long `wait` from aborting (and misreporting "logged out") on lock churn.
-  return reuseCached(loadAuth() ?? cached, 0);
+  const contended = await reuseCached(loadAuth() ?? cached, 0);
+  if (!contended) onFailure?.("inconclusive"); // never acquired the lock ⇒ no verdict on the credential
+  return contended;
 }
 
 /** The signed-in user (id + email + display name), or null when not logged in / session invalid. */

--- a/packages/cli/src/cliAuth.ts
+++ b/packages/cli/src/cliAuth.ts
@@ -263,16 +263,38 @@ export type SessionFailure = "rejected" | "inconclusive";
  *  server never looked), and not supabase-js's status-0 transport errors. */
 const REJECTING_STATUSES = new Set([400, 401, 403]);
 
+/**
+ * WHICH refusal, when the server was specific enough to say — so a caller can explain itself
+ * without asserting more than it knows. `rejected` spans 400/401/403, which covers a spent refresh
+ * token but equally a bad anon key or a revoked user; only `refresh-token-spent` licenses the
+ * "already spent" wording.
+ */
+export type RejectionCause = "refresh-token-spent" | "unspecified";
+
+/** Does this error say, in GoTrue's own words, that the refresh token was already used? Checks the
+ *  structured code AND the message, because `error_code` is a newer addition and older deployments
+ *  only carry "Invalid Refresh Token: Already Used". */
+function isSpentRefreshToken(error: unknown): boolean {
+  const e = (error ?? {}) as { code?: unknown; message?: unknown };
+  if (e.code === "refresh_token_already_used") return true;
+  return typeof e.message === "string" && /already used/i.test(e.message);
+}
+
 /** Classify a failed auth call — a refresh OR an access-token identity check — so a caller can tell
  *  "your credential is dead" from "I couldn't reach the server". Anything unrecognised is
  *  inconclusive: the safe direction, since the only action gated on `rejected` is deleting the
  *  user's credential. */
-function authFailureKind(error: unknown): SessionFailure {
+function authFailureKind(error: unknown): { reason: SessionFailure; cause: RejectionCause } {
   const status = (error as { status?: unknown } | null | undefined)?.status;
-  return typeof status === "number" && REJECTING_STATUSES.has(status) ? "rejected" : "inconclusive";
+  const rejected = typeof status === "number" && REJECTING_STATUSES.has(status);
+  if (!rejected) return { reason: "inconclusive", cause: "unspecified" };
+  return { reason: "rejected", cause: isSpentRefreshToken(error) ? "refresh-token-spent" : "unspecified" };
 }
 
-export async function authedSession(skewS = ACCESS_SKEW_S, onFailure?: (reason: SessionFailure) => void): Promise<AuthedSession | null> {
+export async function authedSession(
+  skewS = ACCESS_SKEW_S,
+  onFailure?: (reason: SessionFailure, cause?: RejectionCause) => void,
+): Promise<AuthedSession | null> {
   const cached = loadAuth();
   if (!cached) {
     onFailure?.("inconclusive"); // no credentials at all: nothing was rejected, there was nothing to ask with
@@ -306,7 +328,8 @@ export async function authedSession(skewS = ACCESS_SKEW_S, onFailure?: (reason: 
     const db = newClient(auth);
     const { data, error } = await db.auth.refreshSession({ refresh_token: auth.refreshToken });
     if (error || !data.session) {
-      onFailure?.(error ? authFailureKind(error) : "inconclusive");
+      const graded = error ? authFailureKind(error) : { reason: "inconclusive" as const, cause: "unspecified" as const };
+      onFailure?.(graded.reason, graded.cause);
       return null;
     }
 
@@ -381,7 +404,7 @@ export async function verifyCachedAccessToken(): Promise<CachedSessionCheck> {
   if (!bound) return "absent";
   const { data, error } = await bound.db.auth.getUser(auth.accessToken);
   if (!error && data?.user) return "ok";
-  return error ? authFailureKind(error) : "inconclusive";
+  return error ? authFailureKind(error).reason : "inconclusive";
 }
 
 /** The signed-in user (id + email + display name), or null when not logged in / session invalid. */

--- a/packages/cli/src/cliAuth.ts
+++ b/packages/cli/src/cliAuth.ts
@@ -263,10 +263,11 @@ export type SessionFailure = "rejected" | "inconclusive";
  *  server never looked), and not supabase-js's status-0 transport errors. */
 const REJECTING_STATUSES = new Set([400, 401, 403]);
 
-/** Classify a failed `refreshSession` so a caller can tell "your credential is dead" from
- *  "I couldn't reach the server". Anything unrecognised is inconclusive — the safe direction,
- *  since the only action gated on `rejected` is deleting the user's credential. */
-function refreshFailureKind(error: unknown): SessionFailure {
+/** Classify a failed auth call — a refresh OR an access-token identity check — so a caller can tell
+ *  "your credential is dead" from "I couldn't reach the server". Anything unrecognised is
+ *  inconclusive: the safe direction, since the only action gated on `rejected` is deleting the
+ *  user's credential. */
+function authFailureKind(error: unknown): SessionFailure {
   const status = (error as { status?: unknown } | null | undefined)?.status;
   return typeof status === "number" && REJECTING_STATUSES.has(status) ? "rejected" : "inconclusive";
 }
@@ -305,7 +306,7 @@ export async function authedSession(skewS = ACCESS_SKEW_S, onFailure?: (reason: 
     const db = newClient(auth);
     const { data, error } = await db.auth.refreshSession({ refresh_token: auth.refreshToken });
     if (error || !data.session) {
-      onFailure?.(error ? refreshFailureKind(error) : "inconclusive");
+      onFailure?.(error ? authFailureKind(error) : "inconclusive");
       return null;
     }
 
@@ -342,6 +343,45 @@ export async function authedSession(skewS = ACCESS_SKEW_S, onFailure?: (reason: 
   const contended = await reuseCached(loadAuth() ?? cached, 0);
   if (!contended) onFailure?.("inconclusive"); // never acquired the lock ⇒ no verdict on the credential
   return contended;
+}
+
+/**
+ * The outcome of checking a cached access token against the server.
+ * `absent` means there was no token worth checking — not a failure, just nothing to check with.
+ */
+export type CachedSessionCheck = "ok" | "absent" | SessionFailure;
+
+/**
+ * Prove the stored session works RIGHT NOW without spending the single-use refresh token.
+ *
+ * The sign-in page seals its live access token precisely so the CLI has a credential nobody
+ * rotates; redeeming the refresh token to check it would re-run the race that token exists to
+ * avoid. So bind the cached token the way every ordinary command does and make ONE authenticated
+ * round-trip: `getUser` sends the JWT to GoTrue, which either accepts it or does not. `setSession`
+ * alone would prove nothing — it is a local decode, no network involved.
+ *
+ * What this can and cannot prove, precisely:
+ *  - it proves the session authenticates now, so `login` is not reporting an unusable credential;
+ *  - it does NOT prove the refresh token is still live, because the only way to test that is to
+ *    spend it. A long `wait` can therefore still meet a dead refresh token at expiry. That residual
+ *    is inherent to handing the CLI a COPY of the browser's session, and the durable fix is for the
+ *    CLI to receive a session of its own (minted server-side at the rendezvous /complete step)
+ *    rather than a copy — tracked as follow-up, deliberately not built here.
+ *
+ * Returns `absent` when there is no cached token the normal fast path would use, which is the
+ * signal for the caller to fall back to proving the credential the expensive way.
+ */
+export async function verifyCachedAccessToken(): Promise<CachedSessionCheck> {
+  const auth = loadAuth();
+  if (!auth) return "absent";
+  // The SAME bar the ordinary fast path applies (ACCESS_SKEW_S): a token with less headroom than
+  // that would be declined by the very next command and refreshed anyway, so validating it here
+  // would prove something about a credential nobody is going to use.
+  const bound = await reuseCached(auth);
+  if (!bound) return "absent";
+  const { data, error } = await bound.db.auth.getUser(auth.accessToken);
+  if (!error && data?.user) return "ok";
+  return error ? authFailureKind(error) : "inconclusive";
 }
 
 /** The signed-in user (id + email + display name), or null when not logged in / session invalid. */

--- a/packages/cli/src/cliLogin.ts
+++ b/packages/cli/src/cliLogin.ts
@@ -49,9 +49,9 @@ export function loginApiBase(): string {
 
 export interface RendezvousDeps {
   fetchImpl?: typeof fetch;
-  /** Launch the system browser at `url`, reporting a failed launch through the callback.
-   *  Overridable in tests. Default: OS opener ({@link openInBrowser}). */
-  open?: (url: string, onLaunchFailure?: () => void) => void;
+  /** Launch the system browser at `url`, reporting a failed launch (and how certain it is) through
+   *  the callback. Overridable in tests. Default: OS opener ({@link openInBrowser}). */
+  open?: (url: string, onLaunchFailure?: (kind: LaunchFailure) => void) => void;
   now?: () => number;
   sleep?: (ms: number) => Promise<void>;
 }
@@ -72,9 +72,11 @@ export interface RendezvousLoginOptions extends RendezvousDeps {
    *  cannot distinguish "no browser" from "a browser that is still starting", so keep it generous
    *  and let `launchFailed` catch the common case. Unset (the default) waits the full `timeoutMs`. */
   openAckMs?: number;
-  /** Fires when the browser launch has been observed to FAIL (the opener was missing, or exited
-   *  non-zero). A definite answer rather than a timeout's guess, so it ends the wait immediately
-   *  with {@link BrowserDidNotOpenError} instead of sitting out `openAckMs`.
+  /** Fires when the browser launch has been observed to fail CERTAINLY — i.e. there is no opener
+   *  process at all. A definite answer rather than a timeout's guess, so it ends the wait
+   *  immediately with {@link BrowserDidNotOpenError} instead of sitting out `openAckMs`. Callers
+   *  must not wire a merely-suspicious signal (an opener exiting non-zero) in here: that would
+   *  trade a slow fallback for a wrong one.
    *
    *  A SIGNAL, not a predicate, because the opener reports asynchronously: the report can land
    *  while a stalled poll request is in flight, and a predicate could only be re-read after that
@@ -348,7 +350,16 @@ export async function pollLoginSession(pending: PendingLogin, opts: RendezvousLo
         // Cut the request short on a launch failure too, not just on the budget: the opener reports
         // asynchronously, so without this a report landing mid-request would sit behind a stalled
         // connection for the whole budget before the loop could act on it.
-        signal: launchAwareSignal(pollRequestBudgetMs(now(), deadline, sawOpened ? undefined : openAckDeadline), opts.launchSignal),
+        // BOTH extra bounds fall away once the page has acked. The ack window has done its job — and
+        // an AbortSignal stays aborted forever, so a launch signal that has already fired would make
+        // AbortSignal.any born-aborted for every remaining request: each one dies before it leaves,
+        // `launchDead()` rightly declines to throw (the page acked), so the loop sleeps and retries
+        // into the same instant abort until the foreground deadline. A login that was about to
+        // complete would end as "login timed out" instead.
+        signal: launchAwareSignal(
+          pollRequestBudgetMs(now(), deadline, sawOpened ? undefined : openAckDeadline),
+          sawOpened ? undefined : opts.launchSignal,
+        ),
       });
     } catch {
       // Was that abort the launcher telling us there is no browser? Then it is the answer, not a
@@ -404,39 +415,48 @@ export async function rendezvousLogin(opts: RendezvousLoginOptions = {}): Promis
   return pollLoginSession(pending, opts);
 }
 
+/** How a browser launch failed, and — the part that matters — how sure we are.
+ *  - `no-opener`: there is no opener process at all (spawn threw, or ENOENT arrived as an 'error'
+ *    event). CERTAIN: nothing was launched, so nothing is coming.
+ *  - `opener-declined`: the opener ran and exited non-zero. A GOOD signal, NOT a certain one — some
+ *    sandboxed/desktop configurations return non-zero having launched the browser anyway. */
+export type LaunchFailure = "no-opener" | "opener-declined";
+
 /**
  * Best-effort: open `url` in the OS browser. Errors never propagate — the URL is also printed so
  * the user can open it by hand (and the 30 s no-`opened` nudge re-prompts).
  *
  * `onLaunchFailure` turns the launch from fire-and-forget into something OBSERVABLE. The opener
- * tells us plainly when it could not do its job: a missing `xdg-open` on a headless box (the main
- * real "no browser" case) arrives as an async 'error' event, and macOS `open` / `xdg-open` exit
- * NON-ZERO when they cannot handle the URL. Discarding those signals is what forced the caller to
- * infer a failed launch from the *absence* of the page's ack — which can only ever be a timeout,
- * and therefore can only ever call a slow browser a broken one. Fires at most once.
+ * tells us plainly when it could not do its job, and discarding that is what forced the caller to
+ * infer a failed launch from the *absence* of the page's ack — which can only ever be a timeout, and
+ * so can only ever call a slow browser a broken one. It reports WHICH kind of failure because the
+ * two deserve different treatment: see {@link LaunchFailure}. Fires at most once.
  */
-export function openInBrowser(url: string, onLaunchFailure?: () => void): void {
+export function openInBrowser(url: string, onLaunchFailure?: (kind: LaunchFailure) => void): void {
   const cmd = process.platform === "darwin" ? "open" : process.platform === "win32" ? "cmd" : "xdg-open";
   const args = process.platform === "win32" ? ["/c", "start", "", url] : [url];
   let reported = false;
-  const failed = (): void => {
+  const failed = (kind: LaunchFailure): void => {
     if (reported) return;
     reported = true;
-    onLaunchFailure?.();
+    onLaunchFailure?.(kind);
   };
   try {
     const child = spawn(cmd, args, { detached: true, stdio: "ignore" });
     // A missing opener (headless/CI) surfaces as an async 'error' event, not a sync throw — handle
     // it so it can't become an unhandled error and crash before the printed-URL fallback.
-    child.on("error", failed);
-    // The opener is a launcher, not the browser: it exits within milliseconds and its code says
-    // whether it handed the URL off. Non-zero ⇒ it did not, so there is no point waiting for an ack.
+    child.on("error", () => failed("no-opener"));
+    // The opener is a launcher, not the browser: it exits within milliseconds and its code is a hint
+    // about whether it handed the URL off. Only a HINT — hence `opener-declined` rather than a
+    // verdict. NB this handler depends on the parent outliving a `detached: true` + `unref()`'d
+    // child, which `unref()` normally disclaims; it holds here only because the caller goes straight
+    // into the poll loop and so stays alive well past the opener's few milliseconds.
     child.on("exit", (code) => {
-      if (code !== 0) failed();
+      if (code !== 0) failed("opener-declined");
     });
     child.unref();
   } catch {
-    failed(); // opener missing (headless/CI) — the printed URL is the fallback
+    failed("no-opener"); // opener missing (headless/CI) — the printed URL is the fallback
   }
 }
 
@@ -462,18 +482,22 @@ async function unsealHandoff(privateKeyPkcs8: string, sealed: { epk: string; iv:
     anon?: string;
     refresh?: string;
     email?: string;
-    /** OPTIONAL. A refresh token is single-use, so a handoff carrying one alone is good for exactly
-     *  one rotation — and if the page's own client rotates first, for none at all. Sealing the live
-     *  ACCESS token alongside it gives the CLI a credential nobody rotates.
+    /** OPTIONAL, and the reason this half exists. A refresh token is single-use, so a handoff
+     *  carrying one alone is good for exactly one rotation — and if the page's own client rotates
+     *  first, for none at all, which is the bug this branch chases. Sealing the live ACCESS token
+     *  alongside it hands the CLI a credential NOBODY rotates.
      *
-     *  It does NOT let login skip the first refresh: `primeSessionOrFail` spends that rotation on
-     *  purpose, because a refresh token that turns out to be spent has to fail loudly at sign-in
-     *  rather than an hour later, mid-`wait`, with no way to recover. What the pair buys is that
-     *  the priming refresh can be *declined* without failing the login — `authedSession` falls back
-     *  to any unexpired cached token when it cannot get the refresh lock (a concurrent `wait`), so
-     *  a handoff with an access token signs in through contention that would otherwise stall.
+     *  That is what lets `primeSessionOrFail` prove the credential without spending the rotation:
+     *  with this pair present it validates through the access token and leaves the refresh token
+     *  untouched, so the CLI never has to win a race against the page's own client just to sign in.
+     *  Taken only as a MATCHED pair — a token whose lifetime we cannot check is worse than none,
+     *  since it could only be trusted blindly or ignored.
      *
-     *  Absent on older pages, so both fields stay optional and the flow degrades to refresh-only. */
+     *  It proves the session works now, not that the refresh token is still live; the only test for
+     *  that is to spend it. See primeSessionOrFail for that residual and the durable fix.
+     *
+     *  Absent on older pages, so both fields stay optional and the flow degrades to the
+     *  forced-refresh route. */
     access?: string;
     /** Epoch SECONDS (Supabase's `session.expires_at`), matching AuthFile.expiresAt. */
     expiresAt?: number;

--- a/packages/cli/src/cliLogin.ts
+++ b/packages/cli/src/cliLogin.ts
@@ -49,8 +49,9 @@ export function loginApiBase(): string {
 
 export interface RendezvousDeps {
   fetchImpl?: typeof fetch;
-  /** Launch the system browser at `url`. Overridable in tests. Default: OS opener. */
-  open?: (url: string) => void;
+  /** Launch the system browser at `url`, reporting a failed launch through the callback.
+   *  Overridable in tests. Default: OS opener ({@link openInBrowser}). */
+  open?: (url: string, onLaunchFailure?: () => void) => void;
   now?: () => number;
   sleep?: (ms: number) => Promise<void>;
 }
@@ -67,9 +68,15 @@ export interface RendezvousLoginOptions extends RendezvousDeps {
   onNudge?: () => void;
   /** Bail out with {@link BrowserDidNotOpenError} when the page hasn't acked `opened` within this
    *  window. Lets a caller *try* launching a browser and fall back to the print-the-URL flow only
-   *  when the launch demonstrably failed — the ack is what makes that observable, since the
-   *  spawn itself is fire-and-forget. Unset (the default) waits the full `timeoutMs`. */
+   *  when the launch demonstrably failed. This is the BACKSTOP, not the primary signal: a timeout
+   *  cannot distinguish "no browser" from "a browser that is still starting", so keep it generous
+   *  and let `launchFailed` catch the common case. Unset (the default) waits the full `timeoutMs`. */
   openAckMs?: number;
+  /** Polled each iteration: has the browser launch already been observed to FAIL (the opener was
+   *  missing, or exited non-zero)? That is a definite answer rather than a timeout's guess, so it
+   *  ends the wait immediately with {@link BrowserDidNotOpenError} — no need to sit out `openAckMs`
+   *  when we already know no browser is coming. */
+  launchFailed?: () => boolean;
 }
 
 /** A login this process started (or a previous one left behind): everything a later invocation
@@ -297,6 +304,13 @@ export async function pollLoginSession(pending: PendingLogin, opts: RendezvousLo
       nudged = true;
       opts.onNudge?.();
     }
+    // The opener itself reported failure (missing binary, non-zero exit). That is knowledge, not a
+    // guess, so stop now rather than waiting out `openAckMs` — and check it BEFORE the deadline so
+    // the definite reason wins. `sawOpened` still overrides: if the page acked, a grumpy exit code
+    // from the launcher is irrelevant, the browser plainly got there.
+    if (!sawOpened && opts.launchFailed?.()) {
+      throw new BrowserDidNotOpenError("the browser could not be launched");
+    }
     // Give up EARLY (session untouched) when the caller only wanted to know whether the browser
     // came up: no `opened` ack inside the window means the launch failed, and the caller has a
     // better fallback than waiting out the full timeout.
@@ -373,19 +387,39 @@ export async function rendezvousLogin(opts: RendezvousLoginOptions = {}): Promis
   return pollLoginSession(pending, opts);
 }
 
-/** Best-effort: open `url` in the OS browser. Errors are swallowed — the URL is also
- *  printed so the user can open it by hand (and the 30 s no-`opened` nudge re-prompts). */
-export function openInBrowser(url: string): void {
+/**
+ * Best-effort: open `url` in the OS browser. Errors never propagate — the URL is also printed so
+ * the user can open it by hand (and the 30 s no-`opened` nudge re-prompts).
+ *
+ * `onLaunchFailure` turns the launch from fire-and-forget into something OBSERVABLE. The opener
+ * tells us plainly when it could not do its job: a missing `xdg-open` on a headless box (the main
+ * real "no browser" case) arrives as an async 'error' event, and macOS `open` / `xdg-open` exit
+ * NON-ZERO when they cannot handle the URL. Discarding those signals is what forced the caller to
+ * infer a failed launch from the *absence* of the page's ack — which can only ever be a timeout,
+ * and therefore can only ever call a slow browser a broken one. Fires at most once.
+ */
+export function openInBrowser(url: string, onLaunchFailure?: () => void): void {
   const cmd = process.platform === "darwin" ? "open" : process.platform === "win32" ? "cmd" : "xdg-open";
   const args = process.platform === "win32" ? ["/c", "start", "", url] : [url];
+  let reported = false;
+  const failed = (): void => {
+    if (reported) return;
+    reported = true;
+    onLaunchFailure?.();
+  };
   try {
     const child = spawn(cmd, args, { detached: true, stdio: "ignore" });
-    // A missing opener (headless/CI) surfaces as an async 'error' event, not a sync throw —
-    // swallow it so it can't become an unhandled error and crash before the printed-URL fallback.
-    child.on("error", () => {});
+    // A missing opener (headless/CI) surfaces as an async 'error' event, not a sync throw — handle
+    // it so it can't become an unhandled error and crash before the printed-URL fallback.
+    child.on("error", failed);
+    // The opener is a launcher, not the browser: it exits within milliseconds and its code says
+    // whether it handed the URL off. Non-zero ⇒ it did not, so there is no point waiting for an ack.
+    child.on("exit", (code) => {
+      if (code !== 0) failed();
+    });
     child.unref();
   } catch {
-    /* opener missing (headless/CI) — the printed URL is the fallback */
+    failed(); // opener missing (headless/CI) — the printed URL is the fallback
   }
 }
 
@@ -411,10 +445,17 @@ async function unsealHandoff(privateKeyPkcs8: string, sealed: { epk: string; iv:
     anon?: string;
     refresh?: string;
     email?: string;
-    /** OPTIONAL, and the reason this half exists: a refresh token is single-use, so a handoff that
-     *  carries one alone is only good for exactly one rotation — and if the page's own client
-     *  rotates first, for none at all. When the page also seals its live ACCESS token, the CLI can
-     *  work off that until it expires and never has to spend the refresh token to get started.
+    /** OPTIONAL. A refresh token is single-use, so a handoff carrying one alone is good for exactly
+     *  one rotation — and if the page's own client rotates first, for none at all. Sealing the live
+     *  ACCESS token alongside it gives the CLI a credential nobody rotates.
+     *
+     *  It does NOT let login skip the first refresh: `primeSessionOrFail` spends that rotation on
+     *  purpose, because a refresh token that turns out to be spent has to fail loudly at sign-in
+     *  rather than an hour later, mid-`wait`, with no way to recover. What the pair buys is that
+     *  the priming refresh can be *declined* without failing the login — `authedSession` falls back
+     *  to any unexpired cached token when it cannot get the refresh lock (a concurrent `wait`), so
+     *  a handoff with an access token signs in through contention that would otherwise stall.
+     *
      *  Absent on older pages, so both fields stay optional and the flow degrades to refresh-only. */
     access?: string;
     /** Epoch SECONDS (Supabase's `session.expires_at`), matching AuthFile.expiresAt. */

--- a/packages/cli/src/cliLogin.ts
+++ b/packages/cli/src/cliLogin.ts
@@ -72,11 +72,15 @@ export interface RendezvousLoginOptions extends RendezvousDeps {
    *  cannot distinguish "no browser" from "a browser that is still starting", so keep it generous
    *  and let `launchFailed` catch the common case. Unset (the default) waits the full `timeoutMs`. */
   openAckMs?: number;
-  /** Polled each iteration: has the browser launch already been observed to FAIL (the opener was
-   *  missing, or exited non-zero)? That is a definite answer rather than a timeout's guess, so it
-   *  ends the wait immediately with {@link BrowserDidNotOpenError} — no need to sit out `openAckMs`
-   *  when we already know no browser is coming. */
-  launchFailed?: () => boolean;
+  /** Fires when the browser launch has been observed to FAIL (the opener was missing, or exited
+   *  non-zero). A definite answer rather than a timeout's guess, so it ends the wait immediately
+   *  with {@link BrowserDidNotOpenError} instead of sitting out `openAckMs`.
+   *
+   *  A SIGNAL, not a predicate, because the opener reports asynchronously: the report can land
+   *  while a stalled poll request is in flight, and a predicate could only be re-read after that
+   *  request had run its budget out. Wiring it into the request's abort makes the fallback immediate
+   *  in that case too. */
+  launchSignal?: AbortSignal;
 }
 
 /** A login this process started (or a previous one left behind): everything a later invocation
@@ -286,6 +290,13 @@ export function pollRequestBudgetMs(nowMs: number, deadline: number, openAckDead
   return Math.max(1, Math.min(...budgets));
 }
 
+/** One abort signal covering both reasons to stop a poll request early: its own time budget, and
+ *  the launcher reporting that no browser is coming. */
+function launchAwareSignal(budgetMs: number, launchSignal?: AbortSignal): AbortSignal {
+  const budget = AbortSignal.timeout(budgetMs);
+  return launchSignal ? AbortSignal.any([budget, launchSignal]) : budget;
+}
+
 export async function pollLoginSession(pending: PendingLogin, opts: RendezvousLoginOptions = {}): Promise<AuthFile> {
   const fetchImpl = opts.fetchImpl ?? fetch;
   const now = opts.now ?? Date.now;
@@ -295,6 +306,8 @@ export async function pollLoginSession(pending: PendingLogin, opts: RendezvousLo
   const openAckDeadline = opts.openAckMs === undefined ? undefined : now() + opts.openAckMs;
   let nudged = false;
   let sawOpened = false;
+  /** The launch is known to have failed AND the page never acked — an ack outranks the launcher. */
+  const launchDead = (): boolean => !sawOpened && Boolean(opts.launchSignal?.aborted);
 
   while (true) {
     // The nudge is a TIMER, not a response property: if the page hasn't acked `opened` by the
@@ -308,9 +321,7 @@ export async function pollLoginSession(pending: PendingLogin, opts: RendezvousLo
     // guess, so stop now rather than waiting out `openAckMs` — and check it BEFORE the deadline so
     // the definite reason wins. `sawOpened` still overrides: if the page acked, a grumpy exit code
     // from the launcher is irrelevant, the browser plainly got there.
-    if (!sawOpened && opts.launchFailed?.()) {
-      throw new BrowserDidNotOpenError("the browser could not be launched");
-    }
+    if (launchDead()) throw new BrowserDidNotOpenError("the browser could not be launched");
     // Give up EARLY (session untouched) when the caller only wanted to know whether the browser
     // came up: no `opened` ack inside the window means the launch failed, and the caller has a
     // better fallback than waiting out the full timeout.
@@ -334,9 +345,15 @@ export async function pollLoginSession(pending: PendingLogin, opts: RendezvousLo
         // in-flight request must not let either budget overrun by a whole request-timeout. Without
         // the second cap a stalled poll could burn the full REQUEST_TIMEOUT_MS (plus a POLL_MS
         // sleep) before the loop ever re-checks a 6-second ack window.
-        signal: AbortSignal.timeout(pollRequestBudgetMs(now(), deadline, sawOpened ? undefined : openAckDeadline)),
+        // Cut the request short on a launch failure too, not just on the budget: the opener reports
+        // asynchronously, so without this a report landing mid-request would sit behind a stalled
+        // connection for the whole budget before the loop could act on it.
+        signal: launchAwareSignal(pollRequestBudgetMs(now(), deadline, sawOpened ? undefined : openAckDeadline), opts.launchSignal),
       });
     } catch {
+      // Was that abort the launcher telling us there is no browser? Then it is the answer, not a
+      // blip — fall back now instead of sleeping and retrying against a browser that never opened.
+      if (launchDead()) throw new BrowserDidNotOpenError("the browser could not be launched");
       // Transient transport failure (DNS blip, dropped connection, a stalled request cut by the
       // per-request timeout): retry like a 5xx — the session is still valid, and the foreground
       // deadline above bounds the total wait. Only a 404 (below) ends the session for good.

--- a/packages/cli/src/cliLogin.ts
+++ b/packages/cli/src/cliLogin.ts
@@ -65,6 +65,11 @@ export interface RendezvousLoginOptions extends RendezvousDeps {
   onUrl?: (url: string) => void;
   /** Fired once if the page hasn't acked `opened` within NUDGE_MS — "open the URL manually". */
   onNudge?: () => void;
+  /** Bail out with {@link BrowserDidNotOpenError} when the page hasn't acked `opened` within this
+   *  window. Lets a caller *try* launching a browser and fall back to the print-the-URL flow only
+   *  when the launch demonstrably failed — the ack is what makes that observable, since the
+   *  spawn itself is fire-and-forget. Unset (the default) waits the full `timeoutMs`. */
+  openAckMs?: number;
 }
 
 /** A login this process started (or a previous one left behind): everything a later invocation
@@ -251,6 +256,11 @@ export async function createLoginSession(opts: RendezvousLoginOptions = {}): Pro
  *  foreground timeout (sidecar kept; a later invocation resumes). */
 export class LoginSessionExpiredError extends Error {}
 
+/** The browser never acked `opened` within `openAckMs`, so the launch almost certainly failed.
+ *  The rendezvous session is left INTACT (not cleared): the caller is expected to hand the URL to
+ *  a human and resume this same session, so it must stay claimable. */
+export class BrowserDidNotOpenError extends Error {}
+
 /**
  * Poll `pending` until the page posts the sealed handoff, then decrypt + return the credentials
  * (the sidecar is deleted on success — sessions are single-use). Throws LoginSessionExpiredError
@@ -263,6 +273,7 @@ export async function pollLoginSession(pending: PendingLogin, opts: RendezvousLo
   const sleep = opts.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
   const deadline = now() + (opts.timeoutMs ?? DEFAULT_TIMEOUT_MS);
   const nudgeAt = now() + NUDGE_MS;
+  const openAckDeadline = opts.openAckMs === undefined ? undefined : now() + opts.openAckMs;
   let nudged = false;
   let sawOpened = false;
 
@@ -273,6 +284,12 @@ export async function pollLoginSession(pending: PendingLogin, opts: RendezvousLo
     if (!nudged && !sawOpened && now() >= nudgeAt) {
       nudged = true;
       opts.onNudge?.();
+    }
+    // Give up EARLY (session untouched) when the caller only wanted to know whether the browser
+    // came up: no `opened` ack inside the window means the launch failed, and the caller has a
+    // better fallback than waiting out the full timeout.
+    if (openAckDeadline !== undefined && !sawOpened && now() >= openAckDeadline) {
+      throw new BrowserDidNotOpenError("the browser did not open");
     }
     if (now() >= pending.expiresAt) {
       await clearPendingLoginFor(pending.sessionId);
@@ -375,9 +392,31 @@ async function unsealHandoff(privateKeyPkcs8: string, sealed: { epk: string; iv:
     ["decrypt"],
   );
   const pt = await subtle.decrypt({ name: "AES-GCM", iv: Buffer.from(sealed.iv, "base64") }, aes, Buffer.from(sealed.ct, "base64"));
-  const parsed = JSON.parse(new TextDecoder().decode(pt)) as { url?: string; anon?: string; refresh?: string; email?: string };
+  const parsed = JSON.parse(new TextDecoder().decode(pt)) as {
+    url?: string;
+    anon?: string;
+    refresh?: string;
+    email?: string;
+    /** OPTIONAL, and the reason this half exists: a refresh token is single-use, so a handoff that
+     *  carries one alone is only good for exactly one rotation — and if the page's own client
+     *  rotates first, for none at all. When the page also seals its live ACCESS token, the CLI can
+     *  work off that until it expires and never has to spend the refresh token to get started.
+     *  Absent on older pages, so both fields stay optional and the flow degrades to refresh-only. */
+    access?: string;
+    /** Epoch SECONDS (Supabase's `session.expires_at`), matching AuthFile.expiresAt. */
+    expiresAt?: number;
+  };
   if (typeof parsed.url !== "string" || typeof parsed.anon !== "string" || typeof parsed.refresh !== "string") {
     throw new Error("sign-in handoff was malformed");
   }
-  return { url: parsed.url, anonKey: parsed.anon, refreshToken: parsed.refresh, ...(parsed.email ? { email: parsed.email } : {}) };
+  // Take the access token only as a matched pair with its expiry: a token whose lifetime we can't
+  // check is worse than none, since reuseCached would have to either trust it blindly or ignore it.
+  const cached = typeof parsed.access === "string" && typeof parsed.expiresAt === "number" ? { accessToken: parsed.access, expiresAt: parsed.expiresAt } : {};
+  return {
+    url: parsed.url,
+    anonKey: parsed.anon,
+    refreshToken: parsed.refresh,
+    ...(parsed.email ? { email: parsed.email } : {}),
+    ...cached,
+  };
 }

--- a/packages/cli/src/cliLogin.ts
+++ b/packages/cli/src/cliLogin.ts
@@ -267,6 +267,18 @@ export class BrowserDidNotOpenError extends Error {}
  * when the session is gone server-side (also clears the sidecar), or a plain Error on foreground
  * timeout (the sidecar survives so the NEXT invocation picks the login up — the coding-agent loop).
  */
+/** How long a single poll request may take: the smaller of the per-request cap, the foreground
+ *  budget, and — while we are still waiting for the page's `opened` ack — the ack window. Without
+ *  that last term a stalled request burns the full REQUEST_TIMEOUT_MS (plus a POLL_MS sleep) before
+ *  the loop re-checks a 6-second window, so the browser-did-not-open fallback arrives far too late
+ *  to be the "cheap attempt" it is meant to be. Never returns 0 — AbortSignal.timeout(0) aborts
+ *  immediately, turning a tight budget into a request that never goes out at all. */
+export function pollRequestBudgetMs(nowMs: number, deadline: number, openAckDeadline?: number): number {
+  const budgets = [REQUEST_TIMEOUT_MS, deadline - nowMs];
+  if (openAckDeadline !== undefined) budgets.push(openAckDeadline - nowMs);
+  return Math.max(1, Math.min(...budgets));
+}
+
 export async function pollLoginSession(pending: PendingLogin, opts: RendezvousLoginOptions = {}): Promise<AuthFile> {
   const fetchImpl = opts.fetchImpl ?? fetch;
   const now = opts.now ?? Date.now;
@@ -304,9 +316,11 @@ export async function pollLoginSession(pending: PendingLogin, opts: RendezvousLo
         // The poll credential rides a header (never a URL, so never an access log) — see
         // PendingLogin.pollToken: the session id alone must not read or destroy the handoff.
         headers: { "x-inplan-poll-token": pending.pollToken },
-        // Capped to the REMAINING deadline: an in-flight request must not let the foreground
-        // wait overrun its budget by a whole request-timeout.
-        signal: AbortSignal.timeout(Math.max(1, Math.min(REQUEST_TIMEOUT_MS, deadline - now()))),
+        // Capped to the REMAINING deadline — and to the openAck deadline when one is set: an
+        // in-flight request must not let either budget overrun by a whole request-timeout. Without
+        // the second cap a stalled poll could burn the full REQUEST_TIMEOUT_MS (plus a POLL_MS
+        // sleep) before the loop ever re-checks a 6-second ack window.
+        signal: AbortSignal.timeout(pollRequestBudgetMs(now(), deadline, sawOpened ? undefined : openAckDeadline)),
       });
     } catch {
       // Transient transport failure (DNS blip, dropped connection, a stalled request cut by the

--- a/packages/cli/test/cliAuthSession.test.ts
+++ b/packages/cli/test/cliAuthSession.test.ts
@@ -125,6 +125,83 @@ describe("authedSession", () => {
   });
 });
 
+// authedSession returns a bare null for every kind of failure, which is all its usual callers need
+// ("can I act as this user?"). Login's credential priming is the exception: it decides whether to
+// DELETE the credential, and that is only defensible when the server actually refused it. These
+// cases pin which failures count as a verdict and which are merely an absence of one.
+describe("authedSession failure reasons", () => {
+  /** Run authedSession and collect whatever reason it reported. */
+  const reasonOf = async (skewS?: number): Promise<Array<"rejected" | "inconclusive">> => {
+    const seen: Array<"rejected" | "inconclusive"> = [];
+    await authedSession(skewS, (r) => seen.push(r));
+    return seen;
+  };
+
+  it("a 400 from GoTrue is a verdict on the credential ⇒ rejected", async () => {
+    seed();
+    // What a spent handoff token actually looks like: HTTP 400 refresh_token_already_used.
+    refreshResult = { data: { session: null }, error: { message: "Invalid Refresh Token: Already Used", status: 400 } };
+    expect(await reasonOf()).toEqual(["rejected"]);
+  });
+
+  it("401/403 are the same class of refusal ⇒ rejected", async () => {
+    for (const status of [401, 403]) {
+      seed();
+      refreshResult = { data: { session: null }, error: { message: "nope", status } };
+      expect(await reasonOf()).toEqual(["rejected"]);
+    }
+  });
+
+  it("a 5xx never looked at the credential ⇒ inconclusive", async () => {
+    seed();
+    refreshResult = { data: { session: null }, error: { message: "bad gateway", status: 502 } };
+    expect(await reasonOf()).toEqual(["inconclusive"]);
+  });
+
+  it("a transport failure (supabase-js reports status 0) ⇒ inconclusive", async () => {
+    seed();
+    refreshResult = { data: { session: null }, error: { message: "fetch failed", status: 0 } };
+    expect(await reasonOf()).toEqual(["inconclusive"]);
+  });
+
+  it("an error with no status at all ⇒ inconclusive (unrecognised means unproven)", async () => {
+    seed();
+    refreshResult = { data: { session: null }, error: { message: "something went wrong" } };
+    expect(await reasonOf()).toEqual(["inconclusive"]);
+  });
+
+  it("429 is 'try later', NOT a refusal ⇒ inconclusive", async () => {
+    seed();
+    refreshResult = { data: { session: null }, error: { message: "rate limited", status: 429 } };
+    expect(await reasonOf()).toEqual(["inconclusive"]);
+  });
+
+  it("a response with no rotated token ⇒ inconclusive (we declined it; nobody refused us)", async () => {
+    // The stderr line on this path says it is KEEPING the stored token — so the reason must not be
+    // one that makes a caller delete it a moment later.
+    seed();
+    refreshResult = { data: { session: session({ refresh_token: undefined }) }, error: null };
+    expect(await reasonOf()).toEqual(["inconclusive"]);
+  });
+
+  it("an empty session with no error ⇒ inconclusive", async () => {
+    seed();
+    refreshResult = { data: { session: null }, error: null };
+    expect(await reasonOf()).toEqual(["inconclusive"]);
+  });
+
+  it("no credentials at all ⇒ inconclusive (there was nothing to refuse)", async () => {
+    expect(await reasonOf()).toEqual(["inconclusive"]);
+  });
+
+  it("stays silent on success, including the cached fast path", async () => {
+    saveAuth({ url: "https://x.supabase.co", anonKey: "anon", refreshToken: "rt", accessToken: "cached-jwt", expiresAt: Math.floor(Date.now() / 1000) + 3600 });
+    expect(await reasonOf()).toEqual([]); // fast path
+    refreshResult = { data: { session: session() }, error: null };
+    expect(await reasonOf(10 * 365 * 24 * 3600)).toEqual([]); // forced refresh, succeeded
+  });
+});
+
 describe("currentUser", () => {
   it("maps the session to {id,email}, or null when logged out", async () => {
     expect(await currentUser()).toBeNull();

--- a/packages/cli/test/cliAuthSession.test.ts
+++ b/packages/cli/test/cliAuthSession.test.ts
@@ -209,6 +209,47 @@ describe("authedSession failure reasons", () => {
   });
 });
 
+// A `rejected` verdict spans 400/401/403 — a spent refresh token, but equally a bad anon key or a
+// revoked user. The CAUSE is what lets login explain itself without asserting more than it knows,
+// so it must be reported only when GoTrue actually named it.
+describe("authedSession rejection causes", () => {
+  const gradeOf = async (): Promise<Array<[string, string | undefined]>> => {
+    const seen: Array<[string, string | undefined]> = [];
+    await authedSession(undefined, (reason, cause) => seen.push([reason, cause]));
+    return seen;
+  };
+
+  it("names the spent-token case from GoTrue's structured code", async () => {
+    seed();
+    refreshResult = { data: { session: null }, error: { code: "refresh_token_already_used", message: "whatever", status: 400 } };
+    expect(await gradeOf()).toEqual([["rejected", "refresh-token-spent"]]);
+  });
+
+  it("also names it from the message alone, for deployments predating `error_code`", async () => {
+    seed();
+    refreshResult = { data: { session: null }, error: { message: "Invalid Refresh Token: Already Used", status: 400 } };
+    expect(await gradeOf()).toEqual([["rejected", "refresh-token-spent"]]);
+  });
+
+  it("does NOT name it for other refusals — a 401 from a bad anon key is not a spent token", async () => {
+    seed();
+    refreshResult = { data: { session: null }, error: { message: "Invalid API key", status: 401 } };
+    expect(await gradeOf()).toEqual([["rejected", "unspecified"]]);
+  });
+
+  it("does NOT name it for a generic 400 either", async () => {
+    seed();
+    refreshResult = { data: { session: null }, error: { code: "invalid_grant", message: "Invalid Refresh Token", status: 400 } };
+    expect(await gradeOf()).toEqual([["rejected", "unspecified"]]);
+  });
+
+  it("reports no cause worth acting on when the failure was merely unanswered", async () => {
+    seed();
+    refreshResult = { data: { session: null }, error: { message: "fetch failed", status: 0 } };
+    expect(await gradeOf()).toEqual([["inconclusive", "unspecified"]]);
+  });
+});
+
 // The sign-in page seals its live access token so the CLI has a credential nobody rotates. Proving
 // that credential must therefore NOT spend the single-use refresh token — otherwise the CLI re-runs
 // the exact race the sealed token exists to avoid, and the page's half of the fix buys nothing.

--- a/packages/cli/test/cliAuthSession.test.ts
+++ b/packages/cli/test/cliAuthSession.test.ts
@@ -93,6 +93,24 @@ describe("authedSession", () => {
     expect(readFileSync(authPath(), "utf8")).toBe(before); // …and no rewrite of auth.json
   });
 
+  it("a skew wider than the token's life forces a refresh, so login can prove the refresh token works", async () => {
+    // What `primeSessionOrFail` relies on: with a valid cached access token the fast path would
+    // return a session without ever redeeming the refresh token, so a token the sign-in page had
+    // already spent would pass login and only fail an hour later, mid-`wait`.
+    saveAuth({
+      url: "https://x.supabase.co",
+      anonKey: "anon",
+      refreshToken: "rt",
+      email: "e@x.io",
+      accessToken: "cached-jwt",
+      expiresAt: Math.floor(Date.now() / 1000) + 3600,
+    });
+    refreshResult = { data: { session: session() }, error: null };
+    const s = await authedSession(10 * 365 * 24 * 3600);
+    expect(refreshSession).toHaveBeenCalled(); // the cached token was declined ⇒ refresh ran
+    expect(s?.session.access_token).toBe("jwt-123"); // and its result is what we got back
+  });
+
   it("falls through to refresh when the cached access token is expired", async () => {
     saveAuth({
       url: "https://x.supabase.co",

--- a/packages/cli/test/cliAuthSession.test.ts
+++ b/packages/cli/test/cliAuthSession.test.ts
@@ -16,8 +16,13 @@ const setSession = vi.fn(async ({ access_token, refresh_token }: { access_token:
   error: null,
 }));
 
+// getUser is the ONE authenticated round-trip the non-destructive check makes: setSession is a local
+// decode, so only this can tell us the server still accepts the token.
+let getUserResult: { data: { user: unknown }; error: unknown } = { data: { user: { id: "user-1" } }, error: null };
+const getUser = vi.fn(async (_jwt?: string) => getUserResult);
+
 vi.mock("@supabase/supabase-js", () => ({
-  createClient: vi.fn(() => ({ auth: { refreshSession, setSession } })),
+  createClient: vi.fn(() => ({ auth: { refreshSession, setSession, getUser } })),
 }));
 vi.mock("@inplan/backend-supabase", () => ({
   // A minimal channel: getCursor/readSince are stubbed so a delegating call has something to hit.
@@ -30,15 +35,17 @@ vi.mock("@inplan/backend-supabase", () => ({
   SupabaseDocumentStore: class { constructor(public db: unknown, public docId: string) {} },
 }));
 
-import { authedSession, currentUser, liveRemoteBackend, remoteBackend, saveAuth, authPath, withAuthLock } from "../src/cliAuth";
+import { authedSession, currentUser, liveRemoteBackend, remoteBackend, saveAuth, authPath, verifyCachedAccessToken, withAuthLock } from "../src/cliAuth";
 
 let home: string;
 beforeEach(() => {
   home = mkdtempSync(join(tmpdir(), "inplan-auth-"));
   process.env.INPLAN_HOME = home;
   refreshResult = { data: { session: null }, error: null }; // reset so tests don't inherit a prior one's value
+  getUserResult = { data: { user: { id: "user-1" } }, error: null };
   refreshSession.mockClear();
   setSession.mockClear();
+  getUser.mockClear();
 });
 afterEach(() => {
   delete process.env.INPLAN_HOME;
@@ -199,6 +206,56 @@ describe("authedSession failure reasons", () => {
     expect(await reasonOf()).toEqual([]); // fast path
     refreshResult = { data: { session: session() }, error: null };
     expect(await reasonOf(10 * 365 * 24 * 3600)).toEqual([]); // forced refresh, succeeded
+  });
+});
+
+// The sign-in page seals its live access token so the CLI has a credential nobody rotates. Proving
+// that credential must therefore NOT spend the single-use refresh token — otherwise the CLI re-runs
+// the exact race the sealed token exists to avoid, and the page's half of the fix buys nothing.
+describe("verifyCachedAccessToken", () => {
+  const live = () => Math.floor(Date.now() / 1000) + 3600;
+  const withToken = (expiresAt = live()) =>
+    saveAuth({ url: "https://x.supabase.co", anonKey: "anon", refreshToken: "rt", accessToken: "cached-jwt", expiresAt });
+
+  it("confirms a live token against the server WITHOUT refreshing — the whole point", async () => {
+    withToken();
+    const before = readFileSync(authPath(), "utf8");
+    expect(await verifyCachedAccessToken()).toBe("ok");
+    expect(getUser).toHaveBeenCalledWith("cached-jwt"); // a real round-trip, not a local decode
+    expect(refreshSession).not.toHaveBeenCalled(); // …and the single-use token is still unspent
+    expect(readFileSync(authPath(), "utf8")).toBe(before); // no rotation ⇒ nothing rewritten
+  });
+
+  it("a 401 on the identity check is a refusal ⇒ rejected", async () => {
+    withToken();
+    getUserResult = { data: { user: null }, error: { message: "invalid JWT", status: 401 } };
+    expect(await verifyCachedAccessToken()).toBe("rejected");
+    expect(refreshSession).not.toHaveBeenCalled(); // still no rotation, even on the failure path
+  });
+
+  it("a 5xx or a dropped connection ⇒ inconclusive, never a refusal", async () => {
+    withToken();
+    getUserResult = { data: { user: null }, error: { message: "bad gateway", status: 502 } };
+    expect(await verifyCachedAccessToken()).toBe("inconclusive");
+    getUserResult = { data: { user: null }, error: { message: "fetch failed", status: 0 } };
+    expect(await verifyCachedAccessToken()).toBe("inconclusive");
+  });
+
+  it("no user and no error ⇒ inconclusive (nothing was actually established)", async () => {
+    withToken();
+    getUserResult = { data: { user: null }, error: null };
+    expect(await verifyCachedAccessToken()).toBe("inconclusive");
+  });
+
+  it("reports `absent` when there is no token worth checking", async () => {
+    expect(await verifyCachedAccessToken()).toBe("absent"); // logged out entirely
+    seed(); // credentials, but the handoff sealed no access token (today's page)
+    expect(await verifyCachedAccessToken()).toBe("absent");
+    withToken(Math.floor(Date.now() / 1000) - 10); // expired
+    expect(await verifyCachedAccessToken()).toBe("absent");
+    withToken(Math.floor(Date.now() / 1000) + 30); // inside ACCESS_SKEW_S: the next command would refresh it anyway
+    expect(await verifyCachedAccessToken()).toBe("absent");
+    expect(getUser).not.toHaveBeenCalled(); // nothing to check ⇒ no round-trip at all
   });
 });
 

--- a/packages/cli/test/cliLogin.test.ts
+++ b/packages/cli/test/cliLogin.test.ts
@@ -245,7 +245,7 @@ describe("pollLoginSession", () => {
     expect(auth.refreshToken).toBe(payload.refresh);
   });
 
-  it("launchFailed: a reported launch failure ends the wait AT ONCE, without sitting out openAckMs", async () => {
+  it("launchSignal: a reported launch failure ends the wait AT ONCE, without sitting out openAckMs", async () => {
     // The opener's own error/exit code is knowledge, not a guess. Waiting out the ack window on top
     // of it is pure latency — and the window has to be generous (a cold browser is slow), so the
     // two must not be serialised.
@@ -253,30 +253,52 @@ describe("pollLoginSession", () => {
     const { fetchImpl: createFetch } = fakeServer([]);
     const pending = await createLoginSession({ ...OPTS, fetchImpl: createFetch, now: c.now });
     const { fetchImpl, seen } = fakeServer(Array.from({ length: 200 }, () => () => ({ status: "pending" })));
+    const launch = new AbortController();
+    launch.abort(); // the opener was missing / exited non-zero before the first poll
     await expect(
-      pollLoginSession(pending, { fetchImpl, now: c.now, sleep: c.sleep, openAckMs: 20_000, launchFailed: () => true }),
+      pollLoginSession(pending, { fetchImpl, now: c.now, sleep: c.sleep, openAckMs: 20_000, launchSignal: launch.signal }),
     ).rejects.toThrow(BrowserDidNotOpenError);
     expect(seen).toEqual([]); // gave up before even polling…
     expect(c.now()).toBe(0); // …and without burning a single sleep of the 20s window
     expect(await loadPendingLogin(c.now())).toEqual(pending); // the URL stays claimable for the human
   });
 
-  it("launchFailed: an `opened` ack outranks a grumpy exit code from the launcher", async () => {
+  it("launchSignal: a failure reported DURING a stalled request aborts it, rather than waiting out its budget", async () => {
+    // The opener reports asynchronously, so the report routinely lands mid-request. A request that
+    // hangs (captive portal, black-holed connection) would otherwise hold the fallback hostage for
+    // the whole per-request budget, which is the delay this signal exists to remove.
+    const c = clock();
+    const { fetchImpl: createFetch } = fakeServer([]);
+    const pending = await createLoginSession({ ...OPTS, fetchImpl: createFetch, now: c.now });
+    const launch = new AbortController();
+    // A fetch that never resolves on its own: it settles only when its abort signal fires.
+    const fetchImpl = ((_url: string, init?: { signal?: AbortSignal }) =>
+      new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(new Error("aborted")));
+        setTimeout(() => launch.abort(), 5); // the launcher's verdict arrives while we hang here
+      })) as unknown as typeof fetch;
+    await expect(
+      pollLoginSession(pending, { fetchImpl, now: c.now, sleep: c.sleep, openAckMs: 20_000, launchSignal: launch.signal }),
+    ).rejects.toThrow(BrowserDidNotOpenError);
+    expect(c.now()).toBe(0); // no POLL_MS sleep, no ack window burned — the abort WAS the answer
+  });
+
+  it("launchSignal: an `opened` ack outranks a grumpy exit code from the launcher", async () => {
     // Some openers hand the URL off successfully and still exit non-zero. Once the page has acked,
     // the browser is demonstrably there and the launcher's opinion is irrelevant.
     const c = clock();
     const { fetchImpl: createFetch } = fakeServer([]);
     const pending = await createLoginSession({ ...OPTS, fetchImpl: createFetch, now: c.now });
     const pub = pubOf(pending.url);
-    let launchFailed = false;
+    const launch = new AbortController();
     const { fetchImpl } = fakeServer([
       () => {
-        launchFailed = true; // the opener exits non-zero right after the page reports itself open
+        launch.abort(); // the opener exits non-zero right after the page reports itself open
         return { status: "opened" };
       },
       async () => ({ status: "completed", ...(await sealLikeThePage(pub, payload)) }),
     ]);
-    const auth = await pollLoginSession(pending, { fetchImpl, now: c.now, sleep: c.sleep, openAckMs: 20_000, launchFailed: () => launchFailed });
+    const auth = await pollLoginSession(pending, { fetchImpl, now: c.now, sleep: c.sleep, openAckMs: 20_000, launchSignal: launch.signal });
     expect(auth.refreshToken).toBe(payload.refresh);
   });
 

--- a/packages/cli/test/cliLogin.test.ts
+++ b/packages/cli/test/cliLogin.test.ts
@@ -302,6 +302,43 @@ describe("pollLoginSession", () => {
     expect(auth.refreshToken).toBe(payload.refresh);
   });
 
+  it("launchSignal: a launch failure AFTER the page acked must not poison every later poll", async () => {
+    // Regression. An AbortSignal stays aborted forever, so composing an already-fired launchSignal
+    // into every request makes AbortSignal.any born-aborted from then on: each poll dies before it
+    // leaves, launchDead() rightly declines to throw (the page acked), and the loop sleeps/retries
+    // into the same instant abort until the foreground deadline — turning a login that was about to
+    // complete into "login timed out". The trigger is real: a slow or delegating opener that
+    // eventually exits non-zero, at any point inside a three-minute poll window.
+    const c = clock();
+    const { fetchImpl: createFetch } = fakeServer([]);
+    const pending = await createLoginSession({ ...OPTS, fetchImpl: createFetch, now: c.now });
+    const pub = pubOf(pending.url);
+    const launch = new AbortController();
+    let polls = 0;
+    let sentBeforeAbort = 0;
+    let sentAfterAbort = 0;
+    let rejectedAtFetch = 0;
+    // A signal-RESPECTING fetch, unlike the plain fake server: that is what makes the bug visible.
+    const fetchImpl = (async (_url: string, init?: { signal?: AbortSignal }) => {
+      if (init?.signal?.aborted) {
+        rejectedAtFetch += 1;
+        throw new Error("aborted before the request left");
+      }
+      if (launch.signal.aborted) sentAfterAbort += 1;
+      else sentBeforeAbort += 1;
+      polls += 1;
+      if (polls === 1) {
+        launch.abort(); // the opener finally exits non-zero, moments after the page reported itself open
+        return res(200, { status: "opened" });
+      }
+      return res(200, { status: "completed", ...(await sealLikeThePage(pub, payload)) });
+    }) as unknown as typeof fetch;
+    const auth = await pollLoginSession(pending, { fetchImpl, now: c.now, sleep: c.sleep, openAckMs: 20_000, launchSignal: launch.signal });
+    expect(auth.refreshToken).toBe(payload.refresh); // the login COMPLETES instead of timing out
+    expect(rejectedAtFetch).toBe(0); // no request was ever killed before it went out
+    expect(sentAfterAbort).toBeGreaterThan(0); // polls keep leaving after the launcher's verdict
+  });
+
   it("openAckMs unset (default) waits out the full timeout rather than bailing early", async () => {
     const c = clock();
     const { fetchImpl: createFetch } = fakeServer([]);

--- a/packages/cli/test/cliLogin.test.ts
+++ b/packages/cli/test/cliLogin.test.ts
@@ -15,6 +15,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   BrowserDidNotOpenError,
   LoginSessionExpiredError,
+  pollRequestBudgetMs,
   createLoginSession,
   loadPendingLogin,
   pendingLoginPath,
@@ -114,6 +115,29 @@ describe("createLoginSession", () => {
     await createLoginSession({ ...OPTS, fetchImpl, now: clock().now });
     expect(existsSync(pendingLoginPath())).toBe(true);
     if (process.platform !== "win32") expect(statSync(process.env.INPLAN_HOME).mode & 0o777).toBe(0o700);
+  });
+});
+
+describe("pollRequestBudgetMs", () => {
+  const REQ = 15_000;
+
+  it("caps a single request by the ack window, so the bail-out isn't delayed by a stalled poll", () => {
+    // 6s ack window still open, foreground budget huge: the request must not be allowed the full
+    // 15s per-request cap, or the 6s window is missed by ~11s (request + POLL_MS sleep).
+    expect(pollRequestBudgetMs(1_000, 1_000 + 180_000, 1_000 + 6_000)).toBe(6_000);
+  });
+
+  it("falls back to the per-request cap once the ack arrived (no ack deadline passed in)", () => {
+    expect(pollRequestBudgetMs(1_000, 1_000 + 180_000, undefined)).toBe(REQ);
+  });
+
+  it("still honours the foreground deadline when it is the tightest budget", () => {
+    expect(pollRequestBudgetMs(1_000, 1_000 + 900, 1_000 + 6_000)).toBe(900);
+  });
+
+  it("never returns 0 — AbortSignal.timeout(0) would abort before the request leaves", () => {
+    expect(pollRequestBudgetMs(5_000, 5_000, 5_000)).toBe(1);
+    expect(pollRequestBudgetMs(9_000, 1_000, 1_000)).toBe(1);
   });
 });
 

--- a/packages/cli/test/cliLogin.test.ts
+++ b/packages/cli/test/cliLogin.test.ts
@@ -13,6 +13,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  BrowserDidNotOpenError,
   LoginSessionExpiredError,
   createLoginSession,
   loadPendingLogin,
@@ -167,6 +168,65 @@ describe("pollLoginSession", () => {
     const onNudge = vi.fn();
     await pollLoginSession(pending, { fetchImpl, now: c.now, sleep: c.sleep, onNudge });
     expect(onNudge).not.toHaveBeenCalled();
+  });
+
+  it("handoff carrying an access token + expiry caches them (no refresh needed to get started)", async () => {
+    const c = clock();
+    const { fetchImpl: createFetch } = fakeServer([]);
+    const pending = await createLoginSession({ ...OPTS, fetchImpl: createFetch, now: c.now });
+    const pub = pubOf(pending.url);
+    const withAccess = { ...payload, access: "jwt-access-token", expiresAt: 1893456000 };
+    const { fetchImpl } = fakeServer([async () => ({ status: "completed", ...(await sealLikeThePage(pub, withAccess)) })]);
+    const auth = await pollLoginSession(pending, { fetchImpl, now: c.now, sleep: c.sleep });
+    expect(auth.accessToken).toBe("jwt-access-token");
+    expect(auth.expiresAt).toBe(1893456000);
+  });
+
+  it("an access token WITHOUT its expiry is ignored (an uncheckable lifetime is worse than none)", async () => {
+    const c = clock();
+    const { fetchImpl: createFetch } = fakeServer([]);
+    const pending = await createLoginSession({ ...OPTS, fetchImpl: createFetch, now: c.now });
+    const pub = pubOf(pending.url);
+    const { fetchImpl } = fakeServer([
+      async () => ({ status: "completed", ...(await sealLikeThePage(pub, { ...payload, access: "jwt-access-token" })) }),
+    ]);
+    const auth = await pollLoginSession(pending, { fetchImpl, now: c.now, sleep: c.sleep });
+    expect(auth.accessToken).toBeUndefined();
+    expect(auth.refreshToken).toBe(payload.refresh);
+  });
+
+  it("openAckMs: no `opened` ack inside the window throws BrowserDidNotOpenError, sidecar INTACT", async () => {
+    const c = clock();
+    const { fetchImpl: createFetch } = fakeServer([]);
+    const pending = await createLoginSession({ ...OPTS, fetchImpl: createFetch, now: c.now });
+    const { fetchImpl } = fakeServer(Array.from({ length: 200 }, () => () => ({ status: "pending" })));
+    await expect(pollLoginSession(pending, { fetchImpl, now: c.now, sleep: c.sleep, openAckMs: 6_000 })).rejects.toThrow(
+      BrowserDidNotOpenError,
+    );
+    // The caller's whole point is to hand this same URL to a human — the row must stay claimable.
+    expect(existsSync(pendingLoginPath())).toBe(true);
+    expect(await loadPendingLogin(c.now())).toEqual(pending);
+  });
+
+  it("openAckMs: an `opened` ack disarms the bail-out, so a slow human still completes", async () => {
+    const c = clock();
+    const { fetchImpl: createFetch } = fakeServer([]);
+    const pending = await createLoginSession({ ...OPTS, fetchImpl: createFetch, now: c.now });
+    const pub = pubOf(pending.url);
+    // Acked immediately, then a long sign-in that runs well past openAckMs.
+    const polls: Array<() => Promise<unknown> | unknown> = Array.from({ length: 30 }, () => () => ({ status: "opened" }));
+    polls.push(async () => ({ status: "completed", ...(await sealLikeThePage(pub, payload)) }));
+    const { fetchImpl } = fakeServer(polls);
+    const auth = await pollLoginSession(pending, { fetchImpl, now: c.now, sleep: c.sleep, openAckMs: 6_000 });
+    expect(auth.refreshToken).toBe(payload.refresh);
+  });
+
+  it("openAckMs unset (default) waits out the full timeout rather than bailing early", async () => {
+    const c = clock();
+    const { fetchImpl: createFetch } = fakeServer([]);
+    const pending = await createLoginSession({ ...OPTS, fetchImpl: createFetch, now: c.now });
+    const { fetchImpl } = fakeServer(Array.from({ length: 200 }, () => () => ({ status: "pending" })));
+    await expect(pollLoginSession(pending, { fetchImpl, now: c.now, sleep: c.sleep, timeoutMs: 10_000 })).rejects.toThrow(/timed out/);
   });
 
   it("foreground timeout keeps the sidecar (the NEXT invocation resumes the login)", async () => {

--- a/packages/cli/test/cliLogin.test.ts
+++ b/packages/cli/test/cliLogin.test.ts
@@ -245,6 +245,41 @@ describe("pollLoginSession", () => {
     expect(auth.refreshToken).toBe(payload.refresh);
   });
 
+  it("launchFailed: a reported launch failure ends the wait AT ONCE, without sitting out openAckMs", async () => {
+    // The opener's own error/exit code is knowledge, not a guess. Waiting out the ack window on top
+    // of it is pure latency — and the window has to be generous (a cold browser is slow), so the
+    // two must not be serialised.
+    const c = clock();
+    const { fetchImpl: createFetch } = fakeServer([]);
+    const pending = await createLoginSession({ ...OPTS, fetchImpl: createFetch, now: c.now });
+    const { fetchImpl, seen } = fakeServer(Array.from({ length: 200 }, () => () => ({ status: "pending" })));
+    await expect(
+      pollLoginSession(pending, { fetchImpl, now: c.now, sleep: c.sleep, openAckMs: 20_000, launchFailed: () => true }),
+    ).rejects.toThrow(BrowserDidNotOpenError);
+    expect(seen).toEqual([]); // gave up before even polling…
+    expect(c.now()).toBe(0); // …and without burning a single sleep of the 20s window
+    expect(await loadPendingLogin(c.now())).toEqual(pending); // the URL stays claimable for the human
+  });
+
+  it("launchFailed: an `opened` ack outranks a grumpy exit code from the launcher", async () => {
+    // Some openers hand the URL off successfully and still exit non-zero. Once the page has acked,
+    // the browser is demonstrably there and the launcher's opinion is irrelevant.
+    const c = clock();
+    const { fetchImpl: createFetch } = fakeServer([]);
+    const pending = await createLoginSession({ ...OPTS, fetchImpl: createFetch, now: c.now });
+    const pub = pubOf(pending.url);
+    let launchFailed = false;
+    const { fetchImpl } = fakeServer([
+      () => {
+        launchFailed = true; // the opener exits non-zero right after the page reports itself open
+        return { status: "opened" };
+      },
+      async () => ({ status: "completed", ...(await sealLikeThePage(pub, payload)) }),
+    ]);
+    const auth = await pollLoginSession(pending, { fetchImpl, now: c.now, sleep: c.sleep, openAckMs: 20_000, launchFailed: () => launchFailed });
+    expect(auth.refreshToken).toBe(payload.refresh);
+  });
+
   it("openAckMs unset (default) waits out the full timeout rather than bailing early", async () => {
     const c = clock();
     const { fetchImpl: createFetch } = fakeServer([]);

--- a/packages/cli/test/openInBrowser.test.ts
+++ b/packages/cli/test/openInBrowser.test.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// openInBrowser's launch REPORT (cliLogin.ts). The spawn was long treated as fire-and-forget, so
+// the only way login could tell whether a browser had come up was to wait for the page's ack and
+// give up on a timeout — which cannot tell "there is no browser here" apart from "the browser is
+// still starting", and therefore called slow machines broken. The opener does say so, plainly: a
+// missing binary arrives as an 'error' event, and `open`/`xdg-open` exit non-zero when they cannot
+// handle the URL. These cases pin that those signals reach the caller — exactly once.
+
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { spawn } = vi.hoisted(() => ({ spawn: vi.fn() }));
+vi.mock("node:child_process", () => ({ spawn }));
+
+import { openInBrowser } from "../src/cliLogin";
+
+/** A stand-in for the opener process: an emitter with the `unref` the real code calls. */
+class FakeChild extends EventEmitter {
+  unref = vi.fn();
+}
+
+let child: FakeChild;
+beforeEach(() => {
+  child = new FakeChild();
+  spawn.mockReset();
+  spawn.mockReturnValue(child);
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("openInBrowser", () => {
+  it("reports nothing while the launch looks healthy (exit 0)", () => {
+    const onLaunchFailure = vi.fn();
+    openInBrowser("https://web.test/cli-auth", onLaunchFailure);
+    child.emit("exit", 0);
+    expect(onLaunchFailure).not.toHaveBeenCalled();
+    expect(child.unref).toHaveBeenCalledOnce(); // never keeps the CLI alive waiting on the browser
+  });
+
+  it("reports a MISSING opener — the async 'error' event, which is the real headless-Linux case", () => {
+    const onLaunchFailure = vi.fn();
+    openInBrowser("https://web.test/cli-auth", onLaunchFailure);
+    child.emit("error", Object.assign(new Error("spawn xdg-open ENOENT"), { code: "ENOENT" }));
+    expect(onLaunchFailure).toHaveBeenCalledOnce();
+  });
+
+  it("reports an opener that could not handle the URL (non-zero exit)", () => {
+    const onLaunchFailure = vi.fn();
+    openInBrowser("https://web.test/cli-auth", onLaunchFailure);
+    child.emit("exit", 1);
+    expect(onLaunchFailure).toHaveBeenCalledOnce();
+  });
+
+  it("reports a synchronous spawn throw too (no opener binary at all)", () => {
+    spawn.mockImplementation(() => {
+      throw new Error("EACCES");
+    });
+    const onLaunchFailure = vi.fn();
+    openInBrowser("https://web.test/cli-auth", onLaunchFailure);
+    expect(onLaunchFailure).toHaveBeenCalledOnce();
+  });
+
+  it("reports at most ONCE, however many ways the same launch fails", () => {
+    // 'error' is normally followed by an 'exit' with a non-zero/null code. One failed launch must
+    // not look like several to a caller that counts.
+    const onLaunchFailure = vi.fn();
+    openInBrowser("https://web.test/cli-auth", onLaunchFailure);
+    child.emit("error", new Error("ENOENT"));
+    child.emit("exit", null);
+    expect(onLaunchFailure).toHaveBeenCalledOnce();
+  });
+
+  it("survives being called with no callback at all (the pre-existing best-effort contract)", () => {
+    expect(() => openInBrowser("https://web.test/cli-auth")).not.toThrow();
+    expect(() => child.emit("error", new Error("ENOENT"))).not.toThrow(); // must never become an unhandled 'error'
+    expect(() => child.emit("exit", 1)).not.toThrow();
+  });
+});

--- a/packages/cli/test/openInBrowser.test.ts
+++ b/packages/cli/test/openInBrowser.test.ts
@@ -43,14 +43,20 @@ describe("openInBrowser", () => {
     const onLaunchFailure = vi.fn();
     openInBrowser("https://web.test/cli-auth", onLaunchFailure);
     child.emit("error", Object.assign(new Error("spawn xdg-open ENOENT"), { code: "ENOENT" }));
+    // CERTAIN: no opener process exists, so no browser is coming and the caller may bail at once.
     expect(onLaunchFailure).toHaveBeenCalledOnce();
+    expect(onLaunchFailure).toHaveBeenCalledWith("no-opener");
   });
 
-  it("reports an opener that could not handle the URL (non-zero exit)", () => {
+  it("reports a non-zero exit as SUSPICION, not a verdict — some configs exit non-zero having launched", () => {
     const onLaunchFailure = vi.fn();
     openInBrowser("https://web.test/cli-auth", onLaunchFailure);
     child.emit("exit", 1);
+    // The distinction is the whole point: `opener-declined` must not license an immediate
+    // "the browser did not open", because the opener exits in milliseconds and would always beat
+    // the page's ack — so acting on it would call a working browser broken.
     expect(onLaunchFailure).toHaveBeenCalledOnce();
+    expect(onLaunchFailure).toHaveBeenCalledWith("opener-declined");
   });
 
   it("reports a synchronous spawn throw too (no opener binary at all)", () => {
@@ -60,6 +66,7 @@ describe("openInBrowser", () => {
     const onLaunchFailure = vi.fn();
     openInBrowser("https://web.test/cli-auth", onLaunchFailure);
     expect(onLaunchFailure).toHaveBeenCalledOnce();
+    expect(onLaunchFailure).toHaveBeenCalledWith("no-opener"); // nothing spawned at all
   });
 
   it("reports at most ONCE, however many ways the same launch fails", () => {
@@ -69,7 +76,9 @@ describe("openInBrowser", () => {
     openInBrowser("https://web.test/cli-auth", onLaunchFailure);
     child.emit("error", new Error("ENOENT"));
     child.emit("exit", null);
+    // …and the FIRST, most certain report is the one that stands.
     expect(onLaunchFailure).toHaveBeenCalledOnce();
+    expect(onLaunchFailure).toHaveBeenCalledWith("no-opener");
   });
 
   it("survives being called with no callback at all (the pre-existing best-effort contract)", () => {

--- a/packages/cli/test/primeSession.test.ts
+++ b/packages/cli/test/primeSession.test.ts
@@ -13,11 +13,11 @@
 // credential is dead — delete it), and unanswered (a blip or a held refresh lock — KEEP it).
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { AuthedSession, CachedSessionCheck, SessionFailure } from "../src/cliAuth";
+import type { AuthedSession, CachedSessionCheck, RejectionCause, SessionFailure } from "../src/cliAuth";
 
 // vi.mock's factory is hoisted above the file body, so the stubs it installs have to be hoisted too.
 const { authedSession, verifyCachedAccessToken, clearAuth, loadAuth } = vi.hoisted(() => ({
-  authedSession: vi.fn<(skewS?: number, onFailure?: (r: SessionFailure) => void) => Promise<AuthedSession | null>>(),
+  authedSession: vi.fn<(skewS?: number, onFailure?: (r: SessionFailure, c?: RejectionCause) => void) => Promise<AuthedSession | null>>(),
   verifyCachedAccessToken: vi.fn<() => Promise<CachedSessionCheck>>(),
   clearAuth: vi.fn(),
   loadAuth: vi.fn<() => { refreshToken: string } | null>(),
@@ -61,11 +61,13 @@ afterEach(() => {
 
 /** A stand-in for a usable session — primeSessionOrFail only checks truthiness. */
 const ok = { db: {}, session: {} } as unknown as AuthedSession;
-/** One failed authedSession attempt reporting `reason`, the way the real one does. */
-const fails = (reason: SessionFailure) => async (_skew?: number, onFailure?: (r: SessionFailure) => void) => {
-  onFailure?.(reason);
-  return null;
-};
+/** One failed authedSession attempt reporting `reason` (and cause), the way the real one does. */
+const fails =
+  (reason: SessionFailure, cause: RejectionCause = "unspecified") =>
+  async (_skew?: number, onFailure?: (r: SessionFailure, c?: RejectionCause) => void) => {
+    onFailure?.(reason, cause);
+    return null;
+  };
 /** The refresh token rotating is what proves the refresh really happened. */
 const rotates = () => {
   let n = 0;
@@ -130,15 +132,30 @@ describe("primeSessionOrFail — route 2: no usable access token, so spend the r
     expect(exits).toEqual([]);
   });
 
-  it("deletes the credential and names the cause when the server REFUSES the refresh token", async () => {
+  it("names the spent-token case only when GoTrue named it", async () => {
     neverRotates();
-    authedSession.mockImplementation(fails("rejected"));
+    authedSession.mockImplementation(fails("rejected", "refresh-token-spent"));
     await expect(primeSessionOrFail(0)).rejects.toThrow("exit:1");
     expect(clearAuth).toHaveBeenCalledOnce();
     expect(stderr).toMatch(/refresh token had already been spent/);
-    // No second attempt: a verdict does not change, and re-presenting a spent token is exactly the
-    // reuse GoTrue punishes by revoking the whole token family.
+    // No second attempt, for one sufficient reason: a definitive refusal does not become an
+    // acceptance 750ms later. (Not for fear of tripping GoTrue's reuse detection — if the page spent
+    // the token minutes ago, our FIRST presentation is already outside the reuse interval and is the
+    // one that trips it. Skipping the retry protects nothing; it is simply pointless work.)
     expect(authedSession).toHaveBeenCalledOnce();
+  });
+
+  it("does NOT claim a spent token for a refusal GoTrue did not explain (e.g. a bad anon key)", async () => {
+    // `rejected` spans 400/401/403. Printing "its refresh token had already been spent" for a 401
+    // from a stale anon key is a confident falsehood — the same mistake as reporting a network blip
+    // as a refusal, one level down.
+    neverRotates();
+    authedSession.mockImplementation(fails("rejected", "unspecified"));
+    await expect(primeSessionOrFail(0)).rejects.toThrow("exit:1");
+    expect(clearAuth).toHaveBeenCalledOnce(); // still a refusal ⇒ still deleted
+    expect(stderr).toMatch(/the server refused it/);
+    expect(stderr).toMatch(/anon key/);
+    expect(stderr).not.toMatch(/already been spent/); // …but the cause is not invented
   });
 
   it("KEEPS the credential when the refresh never got an answer", async () => {
@@ -176,7 +193,7 @@ describe("primeSessionOrFail — route 2: no usable access token, so spend the r
 
   it("stops retrying the moment an inconclusive first attempt turns into a refusal", async () => {
     neverRotates();
-    authedSession.mockImplementationOnce(fails("inconclusive")).mockImplementation(fails("rejected"));
+    authedSession.mockImplementationOnce(fails("inconclusive")).mockImplementation(fails("rejected", "refresh-token-spent"));
     await expect(primeSessionOrFail(0)).rejects.toThrow("exit:1");
     expect(authedSession).toHaveBeenCalledTimes(2); // the retry ran, and its verdict is the one that counts
     expect(clearAuth).toHaveBeenCalledOnce();

--- a/packages/cli/test/primeSession.test.ts
+++ b/packages/cli/test/primeSession.test.ts
@@ -1,36 +1,43 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //
-// `inplan login`'s credential priming (cli.ts → primeSessionOrFail) — the fix's headline
-// behaviour, and the reason the command may print `logged_in` at all. Three outcomes have to stay
-// distinguishable, because two of them used to be the same code path:
-//   proved      — the forced refresh went through, so the credential demonstrably works;
-//   REFUSED     — the server looked at the refresh token and rejected it ⇒ delete it, say so;
-//   unanswered  — a blip, an outage, or a live `wait` holding the refresh lock ⇒ KEEP it.
-// Collapsing the third into the second is what let a dropped connection delete a perfectly good
-// credential while blaming a "spent refresh token" that had never been presented to anyone.
+// `inplan login`'s credential priming (cli.ts → primeSessionOrFail) — the reason the command may
+// print `logged_in` at all. It has two routes, and which one runs is the whole design:
+//
+//   1. the handoff sealed a live ACCESS token ⇒ prove the session non-destructively. The sign-in
+//      page seals that token so the CLI has a credential nobody rotates, so spending the refresh
+//      token here would re-run the very race the sealed token exists to avoid;
+//   2. no usable access token ⇒ force the refresh, the only proof available, so a spent token fails
+//      at sign-in rather than an hour later mid-`wait`.
+//
+// And three outcomes per route, two of which used to be one code path: proved, REFUSED (the
+// credential is dead — delete it), and unanswered (a blip or a held refresh lock — KEEP it).
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { AuthedSession, SessionFailure } from "../src/cliAuth";
+import type { AuthedSession, CachedSessionCheck, SessionFailure } from "../src/cliAuth";
 
 // vi.mock's factory is hoisted above the file body, so the stubs it installs have to be hoisted too.
-const { authedSession, clearAuth } = vi.hoisted(() => ({
+const { authedSession, verifyCachedAccessToken, clearAuth, loadAuth } = vi.hoisted(() => ({
   authedSession: vi.fn<(skewS?: number, onFailure?: (r: SessionFailure) => void) => Promise<AuthedSession | null>>(),
+  verifyCachedAccessToken: vi.fn<() => Promise<CachedSessionCheck>>(),
   clearAuth: vi.fn(),
+  loadAuth: vi.fn<() => { refreshToken: string } | null>(),
 }));
 
-// Only the two functions primeSessionOrFail acts through are stubbed; everything else in cliAuth
-// stays real. currentUser is stubbed too so no sibling import reaches for the network.
+// Only the functions primeSessionOrFail acts through are stubbed; the rest of cliAuth stays real.
+// currentUser is stubbed too so no sibling import reaches for the network.
 vi.mock("../src/cliAuth", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../src/cliAuth")>()),
   authedSession,
+  verifyCachedAccessToken,
   clearAuth,
+  loadAuth,
   currentUser: vi.fn(async () => null),
 }));
 
 import { primeSessionOrFail } from "../src/cli";
 
-/** The skew primeSessionOrFail uses to force the refresh path: wider than any token's lifetime,
- *  so reuseCached declines the cache and the single-use token is actually redeemed. */
+/** The skew that forces the refresh path: wider than any token's lifetime, so reuseCached declines
+ *  the cache and the single-use token is actually redeemed. */
 const FORCE_REFRESH_SKEW_S = 10 * 365 * 24 * 3600;
 
 let stderr: string;
@@ -38,8 +45,7 @@ let exits: number[];
 beforeEach(() => {
   stderr = "";
   exits = [];
-  authedSession.mockReset();
-  clearAuth.mockReset();
+  for (const m of [authedSession, verifyCachedAccessToken, clearAuth, loadAuth]) m.mockReset();
   vi.spyOn(process.stderr, "write").mockImplementation(((s: string) => {
     stderr += s;
     return true;
@@ -55,49 +61,113 @@ afterEach(() => {
 
 /** A stand-in for a usable session — primeSessionOrFail only checks truthiness. */
 const ok = { db: {}, session: {} } as unknown as AuthedSession;
-/** One failed attempt that reports `reason` the way the real authedSession does. */
+/** One failed authedSession attempt reporting `reason`, the way the real one does. */
 const fails = (reason: SessionFailure) => async (_skew?: number, onFailure?: (r: SessionFailure) => void) => {
   onFailure?.(reason);
   return null;
 };
+/** The refresh token rotating is what proves the refresh really happened. */
+const rotates = () => {
+  let n = 0;
+  loadAuth.mockImplementation(() => ({ refreshToken: `rt-${n++}` }));
+};
+/** A stored token that never changes — what lock contention looks like from the outside. */
+const neverRotates = () => loadAuth.mockReturnValue({ refreshToken: "rt-same" });
 
-describe("primeSessionOrFail", () => {
-  it("forces the refresh path and returns quietly once the credential is proved", async () => {
-    authedSession.mockResolvedValue(ok);
+describe("primeSessionOrFail — route 1: a sealed access token (no rotation spent)", () => {
+  it("accepts a validated access token and NEVER touches the refresh token", async () => {
+    verifyCachedAccessToken.mockResolvedValue("ok");
     await expect(primeSessionOrFail(0)).resolves.toBeUndefined();
-    // The skew is the whole mechanism: without it the cached access token from the handoff would
-    // satisfy authedSession's fast path and the refresh token would never be redeemed at all.
-    expect(authedSession).toHaveBeenCalledOnce();
-    expect(authedSession).toHaveBeenCalledWith(FORCE_REFRESH_SKEW_S, expect.any(Function));
+    // The point of the companion sign-in-page change: the single-use token stays unspent, so the
+    // CLI never races the browser for it.
+    expect(authedSession).not.toHaveBeenCalled();
     expect(clearAuth).not.toHaveBeenCalled();
     expect(exits).toEqual([]);
   });
 
-  it("deletes the credential and names the cause when the server REFUSES it", async () => {
+  it("fails loudly, and deletes, when the server refuses that access token", async () => {
+    verifyCachedAccessToken.mockResolvedValue("rejected");
+    await expect(primeSessionOrFail(0)).rejects.toThrow("exit:1");
+    expect(clearAuth).toHaveBeenCalledOnce();
+    expect(stderr).toMatch(/access token was not accepted/);
+    expect(stderr).not.toMatch(/refresh token had already been spent/); // a cause we never observed
+    expect(authedSession).not.toHaveBeenCalled(); // no consolation rotation on the way out
+  });
+
+  it("keeps the credential when the check is unanswered, and does not escalate to spending the rotation", async () => {
+    verifyCachedAccessToken.mockResolvedValue("inconclusive");
+    await expect(primeSessionOrFail(0)).rejects.toThrow("exit:1");
+    expect(verifyCachedAccessToken).toHaveBeenCalledTimes(2); // one retry, for the blip
+    expect(clearAuth).not.toHaveBeenCalled();
+    expect(stderr).toMatch(/could not be verified/);
+    expect(stderr).toMatch(/KEPT/);
+    // A blip is not evidence the access token is bad, so it must not become a reason to burn the
+    // refresh token — that would spend the rotation precisely when the network is unreliable.
+    expect(authedSession).not.toHaveBeenCalled();
+  });
+
+  it("retries once through a blip and then reports success", async () => {
+    verifyCachedAccessToken.mockResolvedValueOnce("inconclusive").mockResolvedValue("ok");
+    await expect(primeSessionOrFail(0)).resolves.toBeUndefined();
+    expect(authedSession).not.toHaveBeenCalled();
+    expect(exits).toEqual([]);
+  });
+});
+
+describe("primeSessionOrFail — route 2: no usable access token, so spend the rotation", () => {
+  beforeEach(() => {
+    verifyCachedAccessToken.mockResolvedValue("absent"); // today's page, or a token near expiry
+  });
+
+  it("forces the refresh and returns once the rotation lands", async () => {
+    rotates();
+    authedSession.mockResolvedValue(ok);
+    await expect(primeSessionOrFail(0)).resolves.toBeUndefined();
+    // The wide skew IS the mechanism: without it a cached token would satisfy the fast path and the
+    // refresh token would never be redeemed at all.
+    expect(authedSession).toHaveBeenCalledOnce();
+    expect(authedSession).toHaveBeenCalledWith(FORCE_REFRESH_SKEW_S, expect.any(Function));
+    expect(exits).toEqual([]);
+  });
+
+  it("deletes the credential and names the cause when the server REFUSES the refresh token", async () => {
+    neverRotates();
     authedSession.mockImplementation(fails("rejected"));
     await expect(primeSessionOrFail(0)).rejects.toThrow("exit:1");
     expect(clearAuth).toHaveBeenCalledOnce();
-    expect(stderr).toMatch(/rejected the credential/);
-    expect(exits).toEqual([1]);
-    // No second attempt: a verdict does not change, and re-presenting a spent token is exactly
-    // the reuse GoTrue punishes by revoking the whole token family.
+    expect(stderr).toMatch(/refresh token had already been spent/);
+    // No second attempt: a verdict does not change, and re-presenting a spent token is exactly the
+    // reuse GoTrue punishes by revoking the whole token family.
     expect(authedSession).toHaveBeenCalledOnce();
   });
 
-  it("KEEPS the credential when the check never got an answer, and says so instead of guessing", async () => {
+  it("KEEPS the credential when the refresh never got an answer", async () => {
+    neverRotates();
     authedSession.mockImplementation(fails("inconclusive"));
     await expect(primeSessionOrFail(0)).rejects.toThrow("exit:1");
-    expect(clearAuth).not.toHaveBeenCalled(); // a network blip must not cost the user their session
+    expect(clearAuth).not.toHaveBeenCalled();
     expect(stderr).toMatch(/could not be verified/);
-    expect(stderr).toMatch(/KEPT/);
-    expect(stderr).not.toMatch(/already been spent/); // …and must not claim a cause it never saw
-    expect(exits).toEqual([1]);
+    expect(stderr).not.toMatch(/already been spent/);
   });
 
-  it("retries once through lock contention, then reports success", async () => {
-    // authedSession also returns null when a concurrent `inplan wait` holds the refresh lock.
-    // That is contention, not a bad credential, so the one retry has to be able to win.
-    authedSession.mockImplementationOnce(fails("inconclusive")).mockResolvedValue(ok);
+  it("does NOT accept a cached session served through lock contention as proof of the refresh", async () => {
+    // authedSession falls back to any unexpired cached token when it cannot get the refresh lock —
+    // on purpose, so a long `wait` survives lock churn. But on THIS path that fallback redeems
+    // nothing, so a handoff whose refresh token is spent would otherwise report logged_in having
+    // proved nothing at all. The rotation is the proof; an unchanged stored token is not one.
+    neverRotates();
+    authedSession.mockResolvedValue(ok); // a session, but no rotation behind it
+    await expect(primeSessionOrFail(0)).rejects.toThrow("exit:1");
+    expect(authedSession).toHaveBeenCalledTimes(2); // treated as contention ⇒ retried…
+    expect(clearAuth).not.toHaveBeenCalled(); // …and unproven, so the credential is kept
+    expect(stderr).toMatch(/could not be verified/);
+  });
+
+  it("retries once through lock contention, then reports success when the rotation finally lands", async () => {
+    authedSession.mockResolvedValue(ok);
+    let attempt = 0;
+    // First attempt: the stored token is unchanged (the lock was held). Second: it rotated.
+    loadAuth.mockImplementation(() => ({ refreshToken: ++attempt <= 2 ? "rt-same" : `rt-new-${attempt}` }));
     await expect(primeSessionOrFail(0)).resolves.toBeUndefined();
     expect(authedSession).toHaveBeenCalledTimes(2);
     expect(clearAuth).not.toHaveBeenCalled();
@@ -105,10 +175,11 @@ describe("primeSessionOrFail", () => {
   });
 
   it("stops retrying the moment an inconclusive first attempt turns into a refusal", async () => {
+    neverRotates();
     authedSession.mockImplementationOnce(fails("inconclusive")).mockImplementation(fails("rejected"));
     await expect(primeSessionOrFail(0)).rejects.toThrow("exit:1");
     expect(authedSession).toHaveBeenCalledTimes(2); // the retry ran, and its verdict is the one that counts
     expect(clearAuth).toHaveBeenCalledOnce();
-    expect(stderr).toMatch(/rejected the credential/);
+    expect(stderr).toMatch(/refresh token had already been spent/);
   });
 });

--- a/packages/cli/test/primeSession.test.ts
+++ b/packages/cli/test/primeSession.test.ts
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// `inplan login`'s credential priming (cli.ts → primeSessionOrFail) — the fix's headline
+// behaviour, and the reason the command may print `logged_in` at all. Three outcomes have to stay
+// distinguishable, because two of them used to be the same code path:
+//   proved      — the forced refresh went through, so the credential demonstrably works;
+//   REFUSED     — the server looked at the refresh token and rejected it ⇒ delete it, say so;
+//   unanswered  — a blip, an outage, or a live `wait` holding the refresh lock ⇒ KEEP it.
+// Collapsing the third into the second is what let a dropped connection delete a perfectly good
+// credential while blaming a "spent refresh token" that had never been presented to anyone.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AuthedSession, SessionFailure } from "../src/cliAuth";
+
+// vi.mock's factory is hoisted above the file body, so the stubs it installs have to be hoisted too.
+const { authedSession, clearAuth } = vi.hoisted(() => ({
+  authedSession: vi.fn<(skewS?: number, onFailure?: (r: SessionFailure) => void) => Promise<AuthedSession | null>>(),
+  clearAuth: vi.fn(),
+}));
+
+// Only the two functions primeSessionOrFail acts through are stubbed; everything else in cliAuth
+// stays real. currentUser is stubbed too so no sibling import reaches for the network.
+vi.mock("../src/cliAuth", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/cliAuth")>()),
+  authedSession,
+  clearAuth,
+  currentUser: vi.fn(async () => null),
+}));
+
+import { primeSessionOrFail } from "../src/cli";
+
+/** The skew primeSessionOrFail uses to force the refresh path: wider than any token's lifetime,
+ *  so reuseCached declines the cache and the single-use token is actually redeemed. */
+const FORCE_REFRESH_SKEW_S = 10 * 365 * 24 * 3600;
+
+let stderr: string;
+let exits: number[];
+beforeEach(() => {
+  stderr = "";
+  exits = [];
+  authedSession.mockReset();
+  clearAuth.mockReset();
+  vi.spyOn(process.stderr, "write").mockImplementation(((s: string) => {
+    stderr += s;
+    return true;
+  }) as never);
+  vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+    exits.push(code ?? 0);
+    throw new Error(`exit:${code}`); // halt the flow the way the real process.exit does
+  }) as never);
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/** A stand-in for a usable session — primeSessionOrFail only checks truthiness. */
+const ok = { db: {}, session: {} } as unknown as AuthedSession;
+/** One failed attempt that reports `reason` the way the real authedSession does. */
+const fails = (reason: SessionFailure) => async (_skew?: number, onFailure?: (r: SessionFailure) => void) => {
+  onFailure?.(reason);
+  return null;
+};
+
+describe("primeSessionOrFail", () => {
+  it("forces the refresh path and returns quietly once the credential is proved", async () => {
+    authedSession.mockResolvedValue(ok);
+    await expect(primeSessionOrFail(0)).resolves.toBeUndefined();
+    // The skew is the whole mechanism: without it the cached access token from the handoff would
+    // satisfy authedSession's fast path and the refresh token would never be redeemed at all.
+    expect(authedSession).toHaveBeenCalledOnce();
+    expect(authedSession).toHaveBeenCalledWith(FORCE_REFRESH_SKEW_S, expect.any(Function));
+    expect(clearAuth).not.toHaveBeenCalled();
+    expect(exits).toEqual([]);
+  });
+
+  it("deletes the credential and names the cause when the server REFUSES it", async () => {
+    authedSession.mockImplementation(fails("rejected"));
+    await expect(primeSessionOrFail(0)).rejects.toThrow("exit:1");
+    expect(clearAuth).toHaveBeenCalledOnce();
+    expect(stderr).toMatch(/rejected the credential/);
+    expect(exits).toEqual([1]);
+    // No second attempt: a verdict does not change, and re-presenting a spent token is exactly
+    // the reuse GoTrue punishes by revoking the whole token family.
+    expect(authedSession).toHaveBeenCalledOnce();
+  });
+
+  it("KEEPS the credential when the check never got an answer, and says so instead of guessing", async () => {
+    authedSession.mockImplementation(fails("inconclusive"));
+    await expect(primeSessionOrFail(0)).rejects.toThrow("exit:1");
+    expect(clearAuth).not.toHaveBeenCalled(); // a network blip must not cost the user their session
+    expect(stderr).toMatch(/could not be verified/);
+    expect(stderr).toMatch(/KEPT/);
+    expect(stderr).not.toMatch(/already been spent/); // …and must not claim a cause it never saw
+    expect(exits).toEqual([1]);
+  });
+
+  it("retries once through lock contention, then reports success", async () => {
+    // authedSession also returns null when a concurrent `inplan wait` holds the refresh lock.
+    // That is contention, not a bad credential, so the one retry has to be able to win.
+    authedSession.mockImplementationOnce(fails("inconclusive")).mockResolvedValue(ok);
+    await expect(primeSessionOrFail(0)).resolves.toBeUndefined();
+    expect(authedSession).toHaveBeenCalledTimes(2);
+    expect(clearAuth).not.toHaveBeenCalled();
+    expect(exits).toEqual([]);
+  });
+
+  it("stops retrying the moment an inconclusive first attempt turns into a refusal", async () => {
+    authedSession.mockImplementationOnce(fails("inconclusive")).mockImplementation(fails("rejected"));
+    await expect(primeSessionOrFail(0)).rejects.toThrow("exit:1");
+    expect(authedSession).toHaveBeenCalledTimes(2); // the retry ran, and its verdict is the one that counts
+    expect(clearAuth).toHaveBeenCalledOnce();
+    expect(stderr).toMatch(/rejected the credential/);
+  });
+});


### PR DESCRIPTION
## The bug

`inplan login` printed `{"status":"logged_in"}` for credentials it had never checked, and the failure surfaced much later as an unexplained "not logged in" on an unrelated command.

The rendezvous handoff carries a refresh token but **no access token**, so the first real command must refresh — and Supabase refresh tokens are single-use. When the handed-over token arrives already spent, the only code that would have noticed is `persistCloudIdentity`, whose `catch {}` swallows exactly that signal.

Reproduced against prod: `auth.json` held `[anonKey, email, refreshToken, url]` (no access token), and redeeming that refresh token directly returned

```
HTTP 400 {"error_code":"refresh_token_already_used","msg":"Invalid Refresh Token: Already Used"}
```

while login had already reported success.

## Changes

- **`primeSessionOrFail()`** — validate the credential during `login`, so a dead one fails at its source with an actionable message instead of being stored. It picks its proof by what it has:
  1. **a usable sealed access token ⇒ non-destructive check.** One authenticated round-trip (`getUser`; `setSession` alone is a local decode and proves nothing), and the single-use refresh token stays **unspent**. This is the point of the page sealing that token — forcing a refresh here would re-run the very race the sealed token exists to avoid.
  2. **no usable access token** (an older page, or one already inside the ordinary refresh skew) **⇒ force the refresh**, which is then the only proof available, and still catches a spent token at sign-in rather than an hour later mid-`wait`.

  On route 2 the **rotation** is the proof, not merely a returned session: `authedSession` falls back to any unexpired cached token when it cannot acquire the refresh lock (deliberately, so a long `wait` survives lock churn), and that fallback redeems nothing — so an unchanged stored refresh token reads as contention and retries rather than passing.
- **Auth failures report *why*** (`SessionFailure`) — `authedSession()` collapses a spent token, a dropped connection, a 5xx, lost lock contention and a response it declines to trust into the same `null`, so priming used to treat all of them as proof of a dead credential: it printed "the refresh token had already been spent" and called `clearAuth()`. A 400/401/403 from GoTrue is a verdict on the credential (`refresh_token_already_used` is a 400) and is the only case that justifies deleting it; everything else keeps the credential and says the check was inconclusive. Priming also stops retrying once it holds a refusal — no retry revives a spent token, and re-presenting one is the reuse GoTrue punishes by revoking the whole family.
- **`unsealHandoff()` accepts an optional `access` + `expiresAt` pair** — a credential nobody rotates, accepted only as a matched pair (a token whose lifetime cannot be checked is worse than none). When it is present, priming validates through it and never spends the rotation at all. Backwards compatible — absent on today's page, the flow degrades to the forced-refresh route.
- **Attempt the browser before concluding this is a coding agent** — `isKnownAgentEnv()` now decides where to fall *back* to, not whether to try at all. Plenty of agent shells can open a browser, and doing so saves the human two round-trips of copy-pasting a URL. Two signals make the attempt verifiable. `openInBrowser` reports a failed launch directly — a missing opener arrives as an `'error'` event, and `open`/`xdg-open` exit non-zero when they cannot handle the URL. That report is an `AbortSignal`, not a predicate, because the opener reports asynchronously: it aborts the in-flight poll request rather than waiting for it to run its budget out, and the abort converts to `BrowserDidNotOpenError` instead of a retry. The page's `opened` ack is the backstop behind it, at a deliberately generous `OPEN_ACK_MS` (20s): a timeout cannot tell "no browser" from "a browser that is still starting", so it must not be the primary signal. The earlier 6s window was about three polls — less than a cold Chrome start plus the page's own load — so its most likely victim was a machine where the browser did open. That fallback now reuses the **same** rendezvous session via `pendingLoginExit(existing?)` instead of minting a second one, so the URL handed to the human stays claimable.

## Tests

- `packages/cli/test/primeSession.test.ts` (new) — the headline behaviour, previously uncovered: both routes × {proved, refused (deleted, no retry), unanswered (**kept**, no invented cause)}, that route 1 never calls `authedSession` at all, and that a cached session served through lock contention is **not** accepted as proof on route 2.
- `verifyCachedAccessToken` — covered per outcome, including that it never calls `refreshSession`: the property the whole design turns on.
- `packages/cli/test/openInBrowser.test.ts` (new) — the launch report: missing opener (`'error'`), non-zero exit, a synchronous spawn throw, healthy exit 0, and at most one report per failed launch.
- `cliAuthSession.test.ts` — the failure classification pinned per status (400/401/403 refuse; 429, 5xx, transport, no-status, no-rotated-token are inconclusive).
- `cliLogin.test.ts` — a reported launch failure ends the poll at once without burning the ack window, and an `opened` ack outranks a grumpy exit code from the launcher.

Each fix was checked by reverting it and watching the matching case fail. `467` CLI tests pass; typecheck clean; coverage gate ≥95% green.

## Note

This is the client half. The remaining root cause is on the sign-in page, which seals only `refresh_token` while its own Supabase client (`autoRefreshToken` defaults on) keeps rotating that same session, so the token can be spent before the CLI ever claims it. The page change is tracked separately; fixing it is sufficient once this lands, since the receiving half is here.

**Known residual.** The non-destructive route proves the session works *now*; it deliberately does not prove the refresh token is still live, because the only way to test that is to spend it. A long `wait` can therefore still meet a dead refresh token when the access token expires. That is inherent to handing the CLI a **copy** of the browser's session — the durable fix is for the CLI to receive a session of its **own**, minted server-side at the rendezvous `/complete` step. Tracked as follow-up; deliberately not built here.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Login now detects browser launch failures promptly and provides a URL fallback when needed.
  - Browser acknowledgement waits longer, improving login completion on slower systems.
  - Session refreshes now retry temporary or inconclusive failures while preserving potentially valid credentials.

- **Bug Fixes**
  - Invalid credentials are cleared only after rejection is confirmed.
  - Improved handling of browser launch errors, delayed responses, and incomplete authentication results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

