### PR TITLE
release: 0.2.1 — sign-in stops reporting success it hasn't verified

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5335,7 +5335,7 @@
     },
     "packages/cli": {
       "name": "@inplan/cli",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@hocuspocus/provider": "^2.15.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inplan/cli",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "description": "inplan CLI: open / wait / signal orchestration over the document core.",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
Patch release for the sign-in fixes merged in #108. Version lives only in `packages/cli/package.json`; `package-lock.json` synced per `scripts/check-lockfile-sync.mjs`.

**Patch, not minor** — no interface changes, and no older-CLI-versus-current-host incompatibility. Contrast with 0.2.0, where upgrading was required against row-backed hosts.

## What a user gets

`inplan login` no longer reports `{"status":"logged_in"}` for a credential it never verified. The handoff carries a single-use refresh token that the sign-in page may already have rotated, and the only code that would have noticed was `persistCloudIdentity`, whose `catch {}` swallowed it — so the failure resurfaced later as an unexplained "not logged in" on an unrelated command. Sign-in now proves the credential: non-destructively when the page seals a live access token, by redeeming the rotation when it does not.

Three further fixes ride along:

- **A credential is deleted only when the server actually refused it** (400/401/403). A 5xx, a dropped connection, or lock contention previously wiped it and misreported the cause — including in the branch that had just logged that it was *keeping* the token.
- **The browser is attempted before concluding the environment is a coding agent**, so an agent shell that can open one saves the human two round-trips of pasting a URL. The page's `opened` ack makes the attempt verifiable; a certain launch failure falls back immediately, an ambiguous exit code waits out the backstop.
- **A poll request is bounded by the ack window** as well as the foreground deadline, so a stalled request cannot outlive the window it was meant to respect.

## Verification

474 CLI tests pass; typecheck clean; pre-commit gate green. Reviewed over four rounds on #108.

Note the companion cloud change (sealing the access token alongside the refresh token) is what makes the non-destructive path reachable — it ships with the inplan-cloud deploy, not with this package.

## After merge

Publishing is a GitHub Release with tag `v0.2.1`, which triggers `release.yml` (npm OIDC trusted publishing, provenance attached). npm versions are immutable, so the tag must be new.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the CLI package version to 0.2.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->