### PR TITLE
Stop reporting a completed turn as crashed_or_killed

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -387,6 +387,27 @@ function logWaitExit(p: DocPaths, reason: string): void {
  * cursor, else "start from now" (current max). It is persisted on return so the
  * agent never hand-manages it and turns can't be skipped.
  */
+/** Which of the three statuses this wait ended in, and why. Pure so the precedence is testable on
+ *  its own — the interesting cases are combinations of signals, not whole wait cycles.
+ *
+ *  Precedence, strongest evidence first:
+ *   1. A LOGGED close — the editor said it was leaving, and said why.
+ *   2. A handoff — actionable entries mean the human did something the agent is waiting for. This
+ *      outranks an unlogged disappearance: the human accepting a proposal and then closing the tab
+ *      produced both at once, and letting the departure win reported `closed / crashed_or_killed`
+ *      while the same payload carried `revision_accepted_all` + `comment_resolved` (#110). The
+ *      agent acts on the handoff; the next wait reports the closure with nothing left to lose.
+ *   3. An unlogged disappearance — presence went away with no close logged, and stayed away long
+ *      enough to be believed (see PRESENCE_GONE_GRACE_MS). `crashed_or_killed` claims only that:
+ *      the editor vanished without saying goodbye. */
+export function resolveWaitStatus(input: { closeReason: string | null; editorGone: boolean; hasActionable: boolean; locksEditor: boolean }): { status: string; reason?: string } {
+  if (input.closeReason !== null) return { status: "closed", reason: input.closeReason };
+  if (input.editorGone && !input.hasActionable) return { status: "closed", reason: "crashed_or_killed" };
+  // A locking mode means the human's editor is locked waiting for the agent (your_turn);
+  // a non-locking (live) mode means they keep editing (activity).
+  return { status: input.locksEditor ? "your_turn" : "activity" };
+}
+
 export async function waitCycle(backend: WaitBackend, explicitCursor: number | null, confirmed: Set<string>, model?: string, gate: PluginGate | null = null): Promise<WaitOutcome> {
   const { channel, store } = backend;
   const history = await backend.history();
@@ -648,19 +669,12 @@ export async function waitCycle(backend: WaitBackend, explicitCursor: number | n
     //   activity  — Instant mode: human is editing LIVE and is NOT blocked.
     //   closed    — the session ended; stop. `reason` says how: completed / window_closed
     //               / crashed_or_killed.
-    let status: string;
-    let reason: string | undefined;
-    if (closeEntry) {
-      status = "closed";
-      reason = (closeEntry.payload as { reason?: string } | undefined)?.reason ?? "completed";
-    } else if (result.editorGone) {
-      status = "closed";
-      reason = "crashed_or_killed";
-    } else {
-      // A locking mode means the human's editor is locked waiting for the agent (your_turn);
-      // a non-locking (live) mode means they keep editing (activity).
-      status = mode.locksEditor ? "your_turn" : "activity";
-    }
+    const { status, reason } = resolveWaitStatus({
+      closeReason: closeEntry ? ((closeEntry.payload as { reason?: string } | undefined)?.reason ?? "completed") : null,
+      editorGone: result.editorGone === true,
+      hasActionable: result.entries.some(isActionable),
+      locksEditor: mode.locksEditor,
+    });
     backend.logExit(`status:${status}${reason ? `/${reason}` : ""}`);
     output({
       status,

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -396,13 +396,18 @@ function logWaitExit(p: DocPaths, reason: string): void {
  *      outranks an unlogged disappearance: the human accepting a proposal and then closing the tab
  *      produced both at once, and letting the departure win reported `closed / crashed_or_killed`
  *      while the same payload carried `revision_accepted_all` + `comment_resolved` (#110). The
- *      agent acts on the handoff; the next wait reports the closure with nothing left to lose.
+ *      agent acts on the handoff — and `editorGone` comes back with it, because the departure must
+ *      not simply be dropped: a fresh `wait` starts with `sawEditorAlive` false, so an editor that
+ *      is ALREADY gone never flips it and that wait would block rather than report the closure.
+ *      Outranking the departure is right; forgetting it would strand the next turn.
  *   3. An unlogged disappearance — presence went away with no close logged, and stayed away long
  *      enough to be believed (see PRESENCE_GONE_GRACE_MS). `crashed_or_killed` claims only that:
  *      the editor vanished without saying goodbye. */
-export function resolveWaitStatus(input: { closeReason: string | null; editorGone: boolean; hasActionable: boolean; locksEditor: boolean }): { status: string; reason?: string } {
+export function resolveWaitStatus(input: { closeReason: string | null; editorGone: boolean; hasActionable: boolean; locksEditor: boolean }): { status: string; reason?: string; editorGone?: true } {
   if (input.closeReason !== null) return { status: "closed", reason: input.closeReason };
   if (input.editorGone && !input.hasActionable) return { status: "closed", reason: "crashed_or_killed" };
+  // A handoff won, but the editor really is gone — carry that fact out with the status.
+  if (input.editorGone) return { status: input.locksEditor ? "your_turn" : "activity", editorGone: true };
   // A locking mode means the human's editor is locked waiting for the agent (your_turn);
   // a non-locking (live) mode means they keep editing (activity).
   return { status: input.locksEditor ? "your_turn" : "activity" };
@@ -669,7 +674,7 @@ export async function waitCycle(backend: WaitBackend, explicitCursor: number | n
     //   activity  — Instant mode: human is editing LIVE and is NOT blocked.
     //   closed    — the session ended; stop. `reason` says how: completed / window_closed
     //               / crashed_or_killed.
-    const { status, reason } = resolveWaitStatus({
+    const { status, reason, editorGone } = resolveWaitStatus({
       closeReason: closeEntry ? ((closeEntry.payload as { reason?: string } | undefined)?.reason ?? "completed") : null,
       editorGone: result.editorGone === true,
       hasActionable: result.entries.some(isActionable),
@@ -687,6 +692,12 @@ export async function waitCycle(backend: WaitBackend, explicitCursor: number | n
       // when --model was passed), so presence + authorship stay consistent.
       agentAuthor: agentAuthorFor(model),
       ...(reason ? { reason } : {}),
+      // The human handed the turn back and THEN left. Surfaced because the handoff status
+      // deliberately outranks the departure, and dropping the departure entirely would strand the
+      // agent: a fresh `wait` starts with `sawEditorAlive` false, so an editor that is already gone
+      // never flips it and that wait would block instead of reporting the closure. Act on the
+      // handoff, then stop — do not wait again.
+      ...(editorGone ? { editorGone: true } : {}),
       // The landing signal for a parked Review-mode edit (#88): pending_review means the push
       // REACHED the store and awaits the human — the canonical is unchanged by design. Absent
       // when the turn applied directly (or made no body change).

--- a/packages/cli/src/wait.ts
+++ b/packages/cli/src/wait.ts
@@ -349,8 +349,9 @@ export function waitForActions(opts: WaitOptions): Promise<WaitResult> {
             // disappearance is strictly weaker evidence than a logged one, so it should not be
             // the one branch that concludes instantly. A genuinely dead editor still ends the
             // wait — just after the absence holds, not on the first sample.
-            goneSince ??= Date.now();
-            if (Date.now() - goneSince >= presenceGoneGraceMs) {
+            const at = now(); // injectable clock, sampled once — same shape as the failure-run budget above
+            goneSince ??= at;
+            if (at - goneSince >= presenceGoneGraceMs) {
               finish({ entries, cursor, editorGone: true });
               return;
             }

--- a/packages/cli/src/wait.ts
+++ b/packages/cli/src/wait.ts
@@ -90,6 +90,10 @@ export interface WaitOptions {
   pollTimeoutMs?: number;
   /** Watch editor presence and resolve (editorGone) if a once-alive editor dies. Default true. */
   watchEditor?: boolean;
+  /** How long presence must stay `false` before the editor counts as gone. Default
+   *  PRESENCE_GONE_GRACE_MS — a single false reading is a throttled heartbeat as often as it is a
+   *  dead editor, so the absence has to persist. Tests set this to 0 for the old instant behavior. */
+  presenceGoneGraceMs?: number;
   /** This waiter's single-waiter token; if a newer waiter supersedes it, step down. */
   token?: string;
   /** Abort the wait (e.g. on shutdown). */
@@ -119,6 +123,13 @@ export function wakePredicate(wake: "turn-end" | "any-action"): (e: LogEntry) =>
  *  editor down (which logs the close) and is typically back within seconds; ending the agent's
  *  wait on that signal alone strands the returning human with nobody attached. */
 export const REOPEN_GRACE_MS = 3 * 60_000;
+
+/** How long presence must read `false` before an UNLOGGED disappearance is believed. The signal is
+ *  a browser-timer heartbeat against a short TTL, and browsers throttle timers in hidden tabs to a
+ *  minute or more — so "no heartbeat" routinely means "the human switched tabs", not "the editor
+ *  died". Sized to outlast that throttling, and well under REOPEN_GRACE_MS above: a *logged* close
+ *  is stronger evidence than a missing heartbeat, yet it is the one that already waits 3 minutes. */
+export const PRESENCE_GONE_GRACE_MS = 90_000;
 
 /**
  * After a `window_closed` session-close: watch for the human coming BACK within `graceMs` —
@@ -242,6 +253,7 @@ export function waitForActions(opts: WaitOptions): Promise<WaitResult> {
   const pollMs = opts.pollMs ?? 200;
   const isActionable = opts.isActionable ?? defaultActionable;
   const watchEditor = opts.watchEditor ?? true;
+  const presenceGoneGraceMs = opts.presenceGoneGraceMs ?? PRESENCE_GONE_GRACE_MS;
   const errorGraceMs = opts.errorGraceMs ?? DEFAULT_ERROR_GRACE_MS;
   const pollTimeoutMs = opts.pollTimeoutMs ?? DEFAULT_POLL_TIMEOUT_MS;
   const now = opts.now ?? Date.now;
@@ -251,6 +263,7 @@ export function waitForActions(opts: WaitOptions): Promise<WaitResult> {
     let deadline: number | null = null;
     let lastCount = -1;
     let sawEditorAlive = false;
+    let goneSince: number | null = null; // start of the current unbroken presence:false run
     let busy = false;
     let done = false;
     let failingSince: number | null = null; // when the current unbroken failure run started
@@ -319,10 +332,28 @@ export function waitForActions(opts: WaitOptions): Promise<WaitResult> {
           } catch {
             /* presence unknown — keep waiting */
           }
-          if (alive === true) sawEditorAlive = true;
-          else if (alive === false && sawEditorAlive) {
-            finish({ entries, cursor, editorGone: true });
-            return;
+          if (alive === true) {
+            sawEditorAlive = true;
+            goneSince = null; // back with us — any pending "gone" run is void
+          } else if (alive === false && sawEditorAlive) {
+            // A single `false` is NOT proof the editor is gone, and treating it as proof is what
+            // reported a normal turn as `crashed_or_killed` (#110). The heartbeat behind
+            // presence() is a browser `setInterval` (cloud web app, HEARTBEAT_MS 7s) read against
+            // a 15s TTL — so it survives exactly one missed beat. Browsers throttle timers in
+            // HIDDEN tabs to a minute or more, so a human who merely switches tabs (the normal
+            // thing to do right after handing the turn back) stalls the heartbeat past the TTL
+            // while sitting right there. Same for a network blip or a slow write.
+            //
+            // So require the absence to PERSIST before believing it. This mirrors the grace the
+            // logged-close path already gets (awaitReopen / REOPEN_GRACE_MS): an unlogged
+            // disappearance is strictly weaker evidence than a logged one, so it should not be
+            // the one branch that concludes instantly. A genuinely dead editor still ends the
+            // wait — just after the absence holds, not on the first sample.
+            goneSince ??= Date.now();
+            if (Date.now() - goneSince >= presenceGoneGraceMs) {
+              finish({ entries, cursor, editorGone: true });
+              return;
+            }
           }
         }
 

--- a/packages/cli/test/resolveWaitStatus.test.ts
+++ b/packages/cli/test/resolveWaitStatus.test.ts
@@ -26,12 +26,20 @@ describe("resolveWaitStatus", () => {
   // The #110 regression. The human accepted a proposal and resolved a comment, then closed the tab:
   // `revision_accepted_all` + `comment_resolved` in `entries`, and presence gone. Reporting the
   // departure told the agent the session had crashed and threw the completed handoff away.
+  // ...and the departure is carried OUT with the handoff rather than dropped. A fresh `wait` starts
+  // with `sawEditorAlive` false, so an editor that is already gone never flips it and that wait
+  // would block instead of reporting the closure — outranking the departure is right, forgetting it
+  // would strand the next turn.
   it("a handoff OUTRANKS an unlogged disappearance — the completed turn is still reported", () => {
-    expect(resolveWaitStatus({ closeReason: null, editorGone: true, hasActionable: true, locksEditor: true })).toEqual({ status: "your_turn" });
+    expect(resolveWaitStatus({ closeReason: null, editorGone: true, hasActionable: true, locksEditor: true })).toEqual({ status: "your_turn", editorGone: true });
   });
 
   it("...and in a live (non-locking) mode that handoff reports activity, not your_turn", () => {
-    expect(resolveWaitStatus({ closeReason: null, editorGone: true, hasActionable: true, locksEditor: false })).toEqual({ status: "activity" });
+    expect(resolveWaitStatus({ closeReason: null, editorGone: true, hasActionable: true, locksEditor: false })).toEqual({ status: "activity", editorGone: true });
+  });
+
+  it("an ordinary handoff carries no editorGone flag at all (nothing to warn about)", () => {
+    expect(resolveWaitStatus({ closeReason: null, editorGone: false, hasActionable: true, locksEditor: true })).not.toHaveProperty("editorGone");
   });
 
   it("no close, no departure: the ordinary turn handoff", () => {

--- a/packages/cli/test/resolveWaitStatus.test.ts
+++ b/packages/cli/test/resolveWaitStatus.test.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// The precedence between the three wait outcomes (#110). These are combinations of signals rather
+// than whole wait cycles, which is why the decision is a pure function: driving the interesting
+// case end-to-end would need a presence heartbeat to go false mid-cycle AND the presence grace
+// short-circuited, neither of which a MemoryControlChannel run can express.
+
+import { describe, expect, it } from "vitest";
+import { resolveWaitStatus } from "../src/cli";
+
+describe("resolveWaitStatus", () => {
+  it("a logged close wins outright, and carries its own reason", () => {
+    expect(resolveWaitStatus({ closeReason: "window_closed", editorGone: true, hasActionable: true, locksEditor: true })).toEqual({
+      status: "closed",
+      reason: "window_closed",
+    });
+  });
+
+  it("an unlogged disappearance with nothing to act on is crashed_or_killed", () => {
+    expect(resolveWaitStatus({ closeReason: null, editorGone: true, hasActionable: false, locksEditor: true })).toEqual({
+      status: "closed",
+      reason: "crashed_or_killed",
+    });
+  });
+
+  // The #110 regression. The human accepted a proposal and resolved a comment, then closed the tab:
+  // `revision_accepted_all` + `comment_resolved` in `entries`, and presence gone. Reporting the
+  // departure told the agent the session had crashed and threw the completed handoff away.
+  it("a handoff OUTRANKS an unlogged disappearance — the completed turn is still reported", () => {
+    expect(resolveWaitStatus({ closeReason: null, editorGone: true, hasActionable: true, locksEditor: true })).toEqual({ status: "your_turn" });
+  });
+
+  it("...and in a live (non-locking) mode that handoff reports activity, not your_turn", () => {
+    expect(resolveWaitStatus({ closeReason: null, editorGone: true, hasActionable: true, locksEditor: false })).toEqual({ status: "activity" });
+  });
+
+  it("no close, no departure: the ordinary turn handoff", () => {
+    expect(resolveWaitStatus({ closeReason: null, editorGone: false, hasActionable: true, locksEditor: true })).toEqual({ status: "your_turn" });
+    expect(resolveWaitStatus({ closeReason: null, editorGone: false, hasActionable: true, locksEditor: false })).toEqual({ status: "activity" });
+  });
+
+  it("a close entry with no reason in its payload defaults to completed at the call site", () => {
+    // waitCycle passes "completed" when the payload carries no reason; this pins that the function
+    // reports whatever it is handed rather than second-guessing it.
+    expect(resolveWaitStatus({ closeReason: "completed", editorGone: false, hasActionable: false, locksEditor: true })).toEqual({
+      status: "closed",
+      reason: "completed",
+    });
+  });
+});

--- a/packages/cli/test/sessionResilience.test.ts
+++ b/packages/cli/test/sessionResilience.test.ts
@@ -362,15 +362,38 @@ describe("presence: unknown is not absent", () => {
   });
 
   it("a presence:false run BROKEN by a live reading resets the grace", async () => {
-    // alive, false, false, then alive again — the tab came back. The earlier absence must not carry
-    // over and end the wait once the grace elapses; only an UNBROKEN absence counts.
+    // alive, false, false, alive (the tab came back), then false again. Only an UNBROKEN absence
+    // counts, so the clock must restart at the LAST break — not carry the first run's start.
+    //
+    // Driven by the injectable clock rather than wall time, because the window that distinguishes
+    // "reset" from "not reset" is one grace wide and a real-time version would be a race. The
+    // presence reads advance the clock themselves, so the sequence and the timeline stay in step:
+    //
+    //   call 1  t=0    alive          -> sawEditorAlive
+    //   call 2  t=100  false          -> goneSince = 100
+    //   call 3  t=200  alive          -> goneSince = null   <-- the line under test
+    //   call 4  t=300  false          -> goneSince = 300
+    //   call 5+ t=400  false          -> 400-300 = 100 < grace(150): still waiting
+    //
+    // Asserted as WHEN the wait concludes, not by racing wall time: the fake clock advances 100ms
+    // per presence read, so the two behaviors separate by call count and nothing is timing-dependent.
+    //
+    //   call 1  t=100  alive   -> sawEditorAlive
+    //   call 2  t=200  false   -> goneSince = 200
+    //   call 3  t=300  alive   -> goneSince = null   <-- the line under test
+    //   call 4  t=400  false   -> goneSince = 400
+    //   call 7  t=700  false   -> 700-400 = 300 >= grace(250): editorGone, on call 7
+    //
+    // Without the reset, goneSince stays 200 and call 5 (t=500, 500-200 = 300) already concludes —
+    // so the stale timestamp shows up as concluding two reads EARLY, which is the assertion below.
     let calls = 0;
+    const clock = () => calls * 100;
     const ch = channelWithPresence(async () => {
       calls++;
-      return calls === 1 || calls > 3;
+      return calls === 1 || calls === 3; // alive, false, alive, then false for the rest
     });
-    await stillWaitingAfter(80, (signal) =>
-      waitForActions({ channel: ch, cursor: 0, pollMs: 1, watchEditor: true, presenceGoneGraceMs: 20, signal }),
-    );
+    const r = await waitForActions({ channel: ch, cursor: 0, pollMs: 1, watchEditor: true, presenceGoneGraceMs: 250, now: clock });
+    expect(r.editorGone).toBe(true); // a genuinely unbroken absence still ends the wait
+    expect(calls).toBe(7); // ...but only after the SECOND run's grace, not the first's
   });
 });

--- a/packages/cli/test/sessionResilience.test.ts
+++ b/packages/cli/test/sessionResilience.test.ts
@@ -343,7 +343,34 @@ describe("presence: unknown is not absent", () => {
   it("STILL reports editorGone when presence deterministically answers false", async () => {
     let calls = 0;
     const ch = channelWithPresence(async () => ++calls === 1); // true once, then a real false
-    const r = await waitForActions({ channel: ch, cursor: 0, pollMs: 1, watchEditor: true });
+    // graceMs 0 keeps this case about the SIGNAL, not the timing: a real `false` must still end the
+    // wait. The grace that defers that conclusion is covered by the two cases below.
+    const r = await waitForActions({ channel: ch, cursor: 0, pollMs: 1, watchEditor: true, presenceGoneGraceMs: 0 });
     expect(r.editorGone).toBe(true); // the real signal must survive the fix
+  });
+
+  // #110: presence going false is a throttled heartbeat as often as a dead editor. The heartbeat is
+  // a browser setInterval (7s) read against a 15s TTL, and browsers throttle timers in hidden tabs
+  // to a minute or more — so a human who switches tabs right after handing the turn back looked
+  // exactly like a crash, and the wait returned `closed / crashed_or_killed` while they sat there.
+  it("does NOT report editorGone while a presence:false run is still inside the grace", async () => {
+    let calls = 0;
+    const ch = channelWithPresence(async () => ++calls === 1); // alive once, then false forever
+    await stillWaitingAfter(80, (signal) =>
+      waitForActions({ channel: ch, cursor: 0, pollMs: 1, watchEditor: true, presenceGoneGraceMs: 10_000, signal }),
+    );
+  });
+
+  it("a presence:false run BROKEN by a live reading resets the grace", async () => {
+    // alive, false, false, then alive again — the tab came back. The earlier absence must not carry
+    // over and end the wait once the grace elapses; only an UNBROKEN absence counts.
+    let calls = 0;
+    const ch = channelWithPresence(async () => {
+      calls++;
+      return calls === 1 || calls > 3;
+    });
+    await stillWaitingAfter(80, (signal) =>
+      waitForActions({ channel: ch, cursor: 0, pollMs: 1, watchEditor: true, presenceGoneGraceMs: 20, signal }),
+    );
   });
 });

--- a/packages/cli/test/wait.test.ts
+++ b/packages/cli/test/wait.test.ts
@@ -43,7 +43,9 @@ describe("waitForActions", () => {
     await new Promise((r) => setTimeout(r, 10)); // let it start
     appendLog(logPath, { actor: "agent", type: LogEventType.EditorPid, payload: { pid: child.pid } });
 
-    const result = await waitForActions({ channel, cursor: 0, debounceMs: 40, pollMs: 10, watchEditor: true });
+    // graceMs 0: this case is about a dead editor being DETECTED, not about how long the absence
+    // must persist first (that grace is covered in sessionResilience.test.ts).
+    const result = await waitForActions({ channel, cursor: 0, debounceMs: 40, pollMs: 10, watchEditor: true, presenceGoneGraceMs: 0 });
     expect(result.editorGone).toBe(true);
   });
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -309,13 +309,17 @@ the plan, then call `wait`.** Do not pass `--cursor` and do not hand-manage it.
        inplan wait <name>.plan.md
 
    `your_turn` and `activity` are **not** stop conditions — you always loop back
-   and keep waiting. The **only** thing that ends the loop is `status: closed`.
+   and keep waiting. Two things end the loop: `status: closed`, or a handoff that
+   also carries `editorGone: true` (the human handed the turn back and then left —
+   finish that turn's work, then stop; see `crashed_or_killed` above for why a
+   further `wait` would block instead of reporting the closure).
 
 6. When you believe the plan is ready, signal it (the human still decides):
 
        inplan signal <name>.plan.md --done
 
-   Then wait again. Stop only on `status: closed`.
+   Then wait again, and stop on the same two conditions as step 5: `status: closed`,
+   or a handoff carrying `editorGone: true`.
 
 ## Keeping the human informed
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -268,6 +268,10 @@ the plan, then call `wait`.** Do not pass `--cursor` and do not hand-manage it.
        building what the document specifies (it's no longer a planning doc — act on it).
      - `window_closed` — they just closed the editor; **stop** and take no further action.
      - `crashed_or_killed` — the editor vanished with no close log; surface this to the human.
+       Only reported once the absence has persisted (a heartbeat that merely stalled — a
+       backgrounded tab, a network blip — is not a departure), and never in place of work you
+       were waiting for: if the human handed the turn back and *then* left, you get that
+       handoff (`your_turn` / `activity`) and learn about the closure on the next `wait`.
    - `superseded` — a newer `wait` took over this document (only one waiter runs at
      a time). This one stepped down; **do nothing** — the live waiter is in charge.
    - `navigated` — the human followed an in-window link to a **different document**;

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -271,7 +271,10 @@ the plan, then call `wait`.** Do not pass `--cursor` and do not hand-manage it.
        Only reported once the absence has persisted (a heartbeat that merely stalled — a
        backgrounded tab, a network blip — is not a departure), and never in place of work you
        were waiting for: if the human handed the turn back and *then* left, you get that
-       handoff (`your_turn` / `activity`) and learn about the closure on the next `wait`.
+       handoff (`your_turn` / `activity`) with **`editorGone: true`** alongside it. Treat that
+       flag as the closure: do the work the handoff describes, then **stop**. Do not call `wait`
+       again — the editor is already gone, so the next wait has nothing to see it leave and will
+       block rather than report it.
    - `superseded` — a newer `wait` took over this document (only one waiter runs at
      a time). This one stepped down; **do nothing** — the live waiter is in charge.
    - `navigated` — the human followed an in-window link to a **different document**;


### PR DESCRIPTION
Fixes the first item on #110.

## What was happening

`inplan wait --remote` returned `closed / crashed_or_killed` right after a normal review-mode accept, while the same response's `entries` showed the turn completing cleanly — `revision_accepted_all` then `comment_resolved`. Reconnecting closed again immediately, appending one more `agent_revised` per attempt instead of blocking for the human.

The report suspected `editorGone` detection was producing false positives, which is close. It isn't a loose read — `wait.ts` already only trusts a presence call that genuinely returned `false` (a throw or a stall is treated as unknown, per an earlier fix). The problem is what that `false` is worth.

## Cause 1: one presence:false is not proof

`presence()` reads an `editor_presence` heartbeat row against `PRESENCE_TTL_MS` (15s). The writer is a browser `setInterval` at 7s (cloud web app), so the signal survives **exactly one** missed beat — and browsers throttle timers in hidden tabs to a minute or more.

So a human who simply switched tabs after handing the turn back stalled their own heartbeat past the TTL while sitting right there, and the wait declared a crash. A network blip or a slow write did the same. That also explains the reconnect loop: one stale-but-still-fresh read sets `sawEditorAlive`, the next read is `false`, immediate close, repeat.

The absence now has to persist (`PRESENCE_GONE_GRACE_MS`, 90s) before it's believed, and any live reading resets the run. This mirrors the grace the **logged** close path already had (`awaitReopen` / `REOPEN_GRACE_MS`, 3 minutes): an *unlogged* disappearance is weaker evidence than a logged one, so it shouldn't have been the one branch concluding on a single sample. A genuinely dead editor still ends the wait.

## Cause 2: the departure outranked the handoff

Accepting a proposal and then closing the tab produces actionable entries **and** a vanished editor. The old branch order let the departure win, so the agent was told the session crashed and the work it had been waiting for was discarded.

A handoff now outranks an unlogged disappearance: the agent acts on it and learns about the closure on the next `wait`, when there's nothing left to lose. A *logged* close still wins outright — it says both that the editor left and why.

The precedence is extracted as `resolveWaitStatus` so it can be tested as the combination of signals it actually is. Driving cause 2 end-to-end would need a presence heartbeat to flip mid-cycle with the grace short-circuited, which a `MemoryControlChannel` run can't express.

## Notes for review

- **`crashed_or_killed` is unchanged and still correct.** I'd initially assumed the name was the bug, but `skill/SKILL.md` defines it as "vanished with no close log", distinct from the *logged* `window_closed` — so the vocabulary was right and only the trigger was wrong. `SKILL.md` gains a note that the reason is now confirmed over a grace and never replaces work you were waiting for.
- **Two existing tests asserted the old instant conclusion**, including one added deliberately ("the real signal must survive the fix"). Both are about the *signal*, not the timing, so they keep their original assertions and pass `presenceGoneGraceMs: 0`; the grace gets its own cases, including that a live reading resets a pending absence. I'd rather flag that than have it look like a quietly weakened guard.
- Every new test was checked by reverting its fix and confirming it fails.
- Full suite green (156 passed, 2 skipped); pre-commit coverage gate ≥95% passes.

## Companion fix worth considering separately

The 7s-heartbeat-vs-15s-TTL margin is thin on its own. This change makes the *reader* resilient, which is the right place for it, but the cloud web app could also beat on `visibilitychange` so a returning tab refreshes presence immediately rather than waiting for a throttled timer. That's an `inplan-cloud` change, not this repo's.

## Still open on #110

Untouched here: the stale sidecar after accept (2), the duplicate Yjs warning (3 — does not reproduce from source: one hoisted copy, `yjs` declared only by `packages/cli`, nothing inlined into any dist, so a leftover global install is the leading hypothesis), and the unreproduced browser-refresh report (4).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configurable grace period before an editor is considered unavailable, reducing false session interruptions.
  - Presence checks now reset correctly when the editor returns during the grace period.

- **Bug Fixes**
  - Improved wait-state reporting for editor closures and handoffs.
  - Confirmed editor departures are reported instead of causing waits to stall.
  - Handoffs are distinguished from completed or closed sessions.

- **Documentation**
  - Clarified that agents should complete handoff work and stop when an editor departure is reported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->