### PR TITLE
release: 0.2.2 — a switched tab is no longer a crashed editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5335,7 +5335,7 @@
     },
     "packages/cli": {
       "name": "@inplan/cli",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@hocuspocus/provider": "^2.15.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inplan/cli",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "description": "inplan CLI: open / wait / signal orchestration over the document core.",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
Patch release for #111. Version lives only in `packages/cli/package.json`; `package-lock.json` synced per `scripts/check-lockfile-sync.mjs`.

**Why this shouldn't wait:** the bug is in the loop the CLI exists for. `inplan wait --remote` returned `closed / crashed_or_killed` right after a normal review-mode accept — while the same response's `entries` showed the turn completing cleanly — and reconnecting closed again immediately, appending one `agent_revised` per attempt instead of blocking for the human. So the collaboration loop ended itself and then spun. Everyone on 0.2.1 is exposed.

## The cause

Treating a single `presence:false` as proof. The heartbeat is a browser `setInterval` at 7s against a 15s TTL, so the signal survives exactly one missed beat — and browsers throttle timers in hidden tabs to a minute or more. A human who switched tabs after handing the turn back stalled their own heartbeat and was declared crashed while sitting right there. A network blip or a slow write did the same.

An absence now has to persist through a grace period, and an editor returning during it resets the count. Handoff also outranks completed/closed when both could describe one response, so the two are no longer conflated. `skill/SKILL.md` carries the matching guidance.

## Verification

156 tests pass, 2 skipped; pre-commit coverage gate ≥95% green on this commit.

## After merge

Publishing is a GitHub Release tagged `v0.2.2`, which triggers `release.yml` (npm OIDC trusted publishing, provenance attached). npm versions are immutable, so the tag must be new.

## Not in this release

Still open on #110: the stale sidecar after accept, the duplicate Yjs warning (does not reproduce from source — a leftover global install is the leading hypothesis), and the unreproduced browser-refresh report. The companion presence fix — beating on `visibilitychange` so a returning tab refreshes immediately — belongs to `inplan-cloud`, not here.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

