### PR TITLE
images: upload the same bytes once, not once per reference

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -2564,11 +2564,24 @@ export async function doAssetUploadForDoc(cloudDocId: string, args: string[]): P
   }
   const requestedExt = (getFlag(args, "ext") ?? "png").toLowerCase();
   const bytes = readFileSync(bytesFile);
+  // uploadAssetBytes falls back to png for an unrecognized extension, so hash under the extension
+  // it will ACTUALLY store — otherwise a `.bmp` paste registers under 'bmp' and never matches the
+  // 'png' object it produced, and every repeat paste uploads again.
+  const storedExt = Object.prototype.hasOwnProperty.call(ASSET_MIME_BY_EXT, requestedExt) ? requestedExt : "png";
+  const sha256 = createHash("sha256").update(bytes).digest("hex");
+  // Pasting the same screenshot twice is the common case this catches — the editor hands us bytes,
+  // not a path, so there's nothing else that could recognize it as a repeat.
+  const known = await assetPathByContent(s.db, cloudDocId, sha256, storedExt);
+  if (known) {
+    output({ status: "uploaded", relPath: s.db.storage.from(ASSET_BUCKET).getPublicUrl(known).data.publicUrl, reused: true });
+    return;
+  }
   const uploaded = await uploadAssetBytes(s.db, orgId, cloudDocId, bytes, requestedExt);
   if (!uploaded) {
     process.stderr.write("inplan asset-upload: upload failed\n");
     process.exit(1);
   }
+  await rememberAsset(s.db, cloudDocId, sha256, storedExt, uploaded.path);
   output({ status: "uploaded", relPath: uploaded.url });
 }
 
@@ -2632,6 +2645,43 @@ function inRange(ranges: Array<[number, number]>, index: number): boolean {
   return ranges.some(([start, end]) => index >= start && index < end);
 }
 
+/** The doc-images content registry (`doc_assets`): which bytes this document already holds, and
+ *  under which object. Object names are random by design — the bucket is public, so a
+ *  content-derived name would let anyone with a candidate file probe whether it's in a given
+ *  doc — so "do you already have these bytes?" can't be asked of storage itself. It's asked here.
+ *
+ *  Both helpers FAIL OPEN. A cloud that predates the table, a denied select, any error at all:
+ *  the caller uploads, exactly as it did before this existed. Reusing an object is an
+ *  optimization; uploading a second copy is only waste. Treating a lookup failure as fatal would
+ *  trade a duplicate object for a failed promote, which is much worse. */
+async function assetPathByContent(db: SupabaseClient, docId: string, sha256: string, ext: string): Promise<string | null> {
+  try {
+    const { data, error } = await db
+      .from("doc_assets")
+      .select("object_path")
+      .eq("doc_id", docId)
+      .eq("sha256", sha256)
+      .eq("ext", ext)
+      .maybeSingle();
+    if (error) return null;
+    const path = (data as { object_path?: string } | null)?.object_path;
+    return typeof path === "string" && path.length > 0 ? path : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Record an upload so a later sync can reuse it. Best-effort for the same reason: a doc whose
+ *  registry write failed still has a correct body pointing at a real object — it just won't get
+ *  the reuse next time. Never let this failure surface as a promote failure. */
+async function rememberAsset(db: SupabaseClient, docId: string, sha256: string, ext: string, objectPath: string): Promise<void> {
+  try {
+    await db.from("doc_assets").insert({ doc_id: docId, sha256, ext, object_path: objectPath });
+  } catch {
+    // best-effort — swallow
+  }
+}
+
 /**
  * Scan `body` for local relative image links, upload each referenced file (resolved against
  * `docDir`) to the cloud `doc-images` bucket, and rewrite the links to the resulting public URLs.
@@ -2654,6 +2704,13 @@ async function migrateLocalImages(
   // happens to name the exact same path as a real, migrated image elsewhere in the doc.
   const migrations = new Map<number, { dest: string; url: string }>();
   const uploadedByDest = new Map<string, { path: string; url: string }>(); // dest → upload, so a repeated real ref reuses one
+  // content hash → upload. `uploadedByDest` only catches the SAME spelling twice; two different
+  // links to byte-identical files (a screenshot copied into two folders, or the same asset
+  // referenced by both a relative and a `./`-prefixed path) would each upload their own object,
+  // leaving the bucket holding duplicate bytes under unrelated random names with no way to tell
+  // afterwards that they're the same image. Keying the second cache on the bytes collapses those
+  // to one upload and one URL.
+  const uploadedByHash = new Map<string, { path: string; url: string }>();
   const uploadedPaths: string[] = []; // every bucket object actually created — the caller cleans these up on a failed body commit
   // A doc body isn't trusted-solely-authored input (cloned repos, collaborators, agents write
   // it), so a crafted `../../.ssh/id_ed25519`-style link must not let this read a file outside
@@ -2699,9 +2756,34 @@ async function migrateLocalImages(
     } catch {
       continue;
     }
+    // Extension is part of the key, not just the bytes: the same bytes served as `.png` and as
+    // `.jpg` need their own objects, because the stored Content-Type comes from the extension and
+    // reusing one object would hand back a URL that serves the wrong type for the other link.
+    const sha256 = createHash("sha256").update(bytes).digest("hex");
+    const contentKey = `${ext}:${sha256}`;
+    const byHash = uploadedByHash.get(contentKey);
+    if (byHash) {
+      uploadedByDest.set(dest, byHash); // so a third ref to this same dest short-circuits earlier
+      migrations.set(m.index, { dest, url: byHash.url });
+      continue;
+    }
+    // Already uploaded by an earlier sync of this same doc (a demote → edit → promote cycle):
+    // reuse that object instead of publishing a second copy of identical bytes under a new name.
+    // NOT added to uploadedPaths — this run didn't create it, and the failed-commit cleanup must
+    // never delete an object that earlier, still-referenced bodies resolve through.
+    const known = await assetPathByContent(db, docId, sha256, ext);
+    if (known) {
+      const reused = { path: known, url: db.storage.from(ASSET_BUCKET).getPublicUrl(known).data.publicUrl };
+      uploadedByDest.set(dest, reused);
+      uploadedByHash.set(contentKey, reused);
+      migrations.set(m.index, { dest, url: reused.url });
+      continue;
+    }
     const uploaded = await uploadAssetBytes(db, orgId, docId, bytes, ext);
     if (!uploaded) continue;
+    await rememberAsset(db, docId, sha256, ext, uploaded.path);
     uploadedByDest.set(dest, uploaded);
+    uploadedByHash.set(contentKey, uploaded);
     uploadedPaths.push(uploaded.path);
     migrations.set(m.index, { dest, url: uploaded.url });
   }

--- a/packages/cli/test/assetUpload.test.ts
+++ b/packages/cli/test/assetUpload.test.ts
@@ -8,10 +8,11 @@
 // a hard storage failure, and the unknown-extension → png fallback — all over a mocked authed
 // session, no network.
 
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createHash } from "node:crypto";
 import { docPaths, writeStatus } from "@inplan/core/node";
 
 let uploadResult: { error: { status: number; message: string } | null } = { error: null };
@@ -20,13 +21,41 @@ let sessionPresent = true;
 const upload = vi.fn(async (_path: string, _bytes: unknown, _opts: unknown) => uploadResult);
 const getPublicUrl = vi.fn((path: string) => ({ data: { publicUrl: `https://cdn.test/doc-images/${path}` } }));
 
+// The `doc_assets` content registry (sha256+ext → object_path) that lets a repeat paste of the
+// same bytes reuse the object already in the bucket. `assetRegistryError` stands in for a cloud
+// without the table, which must fail open to a normal upload.
+let assetRegistry: Map<string, string>;
+let assetRegistryError: { message: string } | null = null;
+let assetInserts: Array<Record<string, unknown>>;
+
+function docAssetsQuery() {
+  const seen: Record<string, unknown> = {};
+  const q: Record<string, unknown> = {};
+  q.select = () => q;
+  q.eq = (column: string, value: unknown) => {
+    seen[column] = value;
+    return q;
+  };
+  q.maybeSingle = () => {
+    if (assetRegistryError) return Promise.resolve({ data: null, error: assetRegistryError });
+    const hit = assetRegistry.get(`${seen.sha256}|${seen.ext}`);
+    return Promise.resolve({ data: hit ? { object_path: hit } : null, error: null });
+  };
+  q.insert = (row: Record<string, unknown>) => {
+    assetInserts.push(row);
+    assetRegistry.set(`${row.sha256}|${row.ext}`, String(row.object_path));
+    return Promise.resolve({ data: null, error: null });
+  };
+  return q;
+}
+
 function fakeDb() {
   const q: Record<string, unknown> = {};
   q.select = () => q;
   q.eq = () => q;
   q.maybeSingle = () => Promise.resolve(orgLookup);
   return {
-    from: () => q,
+    from: (table: string) => (table === "doc_assets" ? docAssetsQuery() : q),
     storage: { from: () => ({ upload, getPublicUrl }) },
   };
 }
@@ -53,6 +82,9 @@ beforeEach(() => {
   writeFileSync(bytesFile, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
   out = [];
   stderr = [];
+  assetRegistry = new Map();
+  assetRegistryError = null;
+  assetInserts = [];
   exitCode = null;
   vi.spyOn(process.stdout, "write").mockImplementation((s: string | Uint8Array) => {
     out.push(String(s));
@@ -205,5 +237,57 @@ describe("argv dispatch: asset-upload --remote", () => {
     // uploaded envelope is the discriminator between the two routes.
     expect(lastJson()).toMatchObject({ status: "uploaded" });
     expect(stderr.join("")).not.toContain("live-collab");
+  });
+});
+
+// The editor hands over raw bytes, not a path, so nothing else in the pipeline can recognise that
+// a paste is a repeat of one already in the doc. Without the registry, pasting the same screenshot
+// twice publishes two objects with identical content under unrelated random names.
+describe("asset-upload content reuse", () => {
+  it("reuses the registered object on a repeat paste of identical bytes", async () => {
+    const bytes = readFileSync(bytesFile);
+    const sha = createHash("sha256").update(bytes).digest("hex");
+    assetRegistry.set(`${sha}|png`, "org-1/doc-9/image-20260101000000-deadbeef.png");
+
+    await doAssetUploadForDoc("doc-9", ["--bytes-file", bytesFile, "--ext", "png"]);
+
+    expect(upload).not.toHaveBeenCalled();
+    expect(lastJson()).toEqual({
+      status: "uploaded",
+      relPath: "https://cdn.test/doc-images/org-1/doc-9/image-20260101000000-deadbeef.png",
+      reused: true,
+    });
+  });
+
+  it("registers a fresh upload, so the next identical paste reuses it", async () => {
+    await doAssetUploadForDoc("doc-9", ["--bytes-file", bytesFile, "--ext", "png"]);
+    expect(upload).toHaveBeenCalledTimes(1);
+    expect(assetInserts).toEqual([
+      expect.objectContaining({ doc_id: "doc-9", ext: "png", object_path: upload.mock.calls[0]![0] }),
+    ]);
+
+    await doAssetUploadForDoc("doc-9", ["--bytes-file", bytesFile, "--ext", "png"]);
+    expect(upload).toHaveBeenCalledTimes(1); // still one — the second paste reused
+    expect(lastJson()).toMatchObject({ reused: true });
+  });
+
+  it("keys on the extension actually stored, so an unrecognized one still reuses", async () => {
+    // uploadAssetBytes rewrites an unknown extension to png. Registering under the REQUESTED
+    // extension would never match the object it produced, so every repeat paste of a .bmp would
+    // upload again — the exact duplication this is meant to prevent.
+    await doAssetUploadForDoc("doc-9", ["--bytes-file", bytesFile, "--ext", "bmp"]);
+    expect(upload).toHaveBeenCalledTimes(1);
+    expect(assetInserts[0]).toMatchObject({ ext: "png" });
+
+    await doAssetUploadForDoc("doc-9", ["--bytes-file", bytesFile, "--ext", "bmp"]);
+    expect(upload).toHaveBeenCalledTimes(1);
+    expect(lastJson()).toMatchObject({ reused: true });
+  });
+
+  it("uploads normally when the registry is unavailable", async () => {
+    assetRegistryError = { message: 'relation "doc_assets" does not exist' };
+    await doAssetUploadForDoc("doc-9", ["--bytes-file", bytesFile, "--ext", "png"]);
+    expect(upload).toHaveBeenCalledTimes(1);
+    expect(lastJson()).toMatchObject({ status: "uploaded" });
   });
 });

--- a/packages/cli/test/uploadImageMigration.test.ts
+++ b/packages/cli/test/uploadImageMigration.test.ts
@@ -11,6 +11,7 @@
 import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, relative } from "node:path";
+import { createHash } from "node:crypto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { docPaths, hashBody, readStatus } from "@inplan/core/node";
 
@@ -47,6 +48,34 @@ const update = vi.fn((_patch: Record<string, unknown>) => {
   return chain;
 });
 
+// The `doc_assets` content registry: sha256+ext → object_path, for the doc being promoted.
+// `assetRegistryError` simulates a cloud that predates the table (or a denied select), which the
+// production code must treat as "unknown" and upload through, never as a failure.
+let assetRegistry: Map<string, string>;
+let assetRegistryError: { message: string } | null = null;
+let assetInserts: Array<Record<string, unknown>>;
+
+function docAssetsQuery() {
+  const seen: Record<string, unknown> = {};
+  const q: Record<string, unknown> = {};
+  q.select = () => q;
+  q.eq = (column: string, value: unknown) => {
+    seen[column] = value;
+    return q;
+  };
+  q.maybeSingle = () => {
+    if (assetRegistryError) return Promise.resolve({ data: null, error: assetRegistryError });
+    const hit = assetRegistry.get(`${seen.sha256}|${seen.ext}`);
+    return Promise.resolve({ data: hit ? { object_path: hit } : null, error: null });
+  };
+  q.insert = (row: Record<string, unknown>) => {
+    assetInserts.push(row);
+    assetRegistry.set(`${row.sha256}|${row.ext}`, String(row.object_path));
+    return Promise.resolve({ data: null, error: null });
+  };
+  return q;
+}
+
 function fakeDb() {
   const membershipsQ: Record<string, unknown> = {};
   membershipsQ.select = () => membershipsQ;
@@ -59,7 +88,7 @@ function fakeDb() {
   documentsQ.update = update;
 
   return {
-    from: (table: string) => (table === "memberships" ? membershipsQ : documentsQ),
+    from: (table: string) => (table === "memberships" ? membershipsQ : table === "doc_assets" ? docAssetsQuery() : documentsQ),
     rpc,
     storage: { from: () => ({ upload, getPublicUrl, remove }) },
   };
@@ -100,6 +129,9 @@ let exitCode: number | null;
 let errOut: string[];
 
 beforeEach(() => {
+  assetRegistry = new Map();
+  assetRegistryError = null;
+  assetInserts = [];
   home = mkdtempSync(join(tmpdir(), "inplan-upload-migrate-"));
   process.env.INPLAN_SIDECAR_DIR = join(home, "sidecars");
   file = join(home, "PLAN.md");
@@ -157,6 +189,139 @@ describe("inplan upload → local image migration", () => {
     expect(readFileSync(file, "utf8")).not.toContain("PLAN.assets");
 
     expect(update).toHaveBeenCalledWith(expect.objectContaining({ body: expect.stringContaining(url) }));
+    expect(lastJson()).toMatchObject({ status: "uploaded", cloudDocId: "doc-new" });
+  });
+
+  it("uploads once for two different paths holding byte-identical images", async () => {
+    // The object name is timestamp + random, so nothing about it is derived from the bytes: two
+    // uploads of the same screenshot become two unrelated objects that no later pass can tell
+    // apart. Collapsing them here is the only point at which the duplication is still visible.
+    mkdirSync(join(home, "a"), { recursive: true });
+    mkdirSync(join(home, "b"), { recursive: true });
+    const bytes = Buffer.from([9, 9, 9, 9]);
+    writeFileSync(join(home, "a", "shot.png"), bytes);
+    writeFileSync(join(home, "b", "shot.png"), bytes);
+    writeFileSync(file, "# My Plan\n\n![one](<a/shot.png>)\n\n![two](<b/shot.png>)\n");
+
+    await doUpload(file, []);
+
+    expect(upload).toHaveBeenCalledTimes(1);
+    const url = `https://cdn.test/doc-images/${upload.mock.calls[0]![0]}`;
+    const written = readFileSync(file, "utf8");
+    // Both links resolve to the one uploaded object, and each keeps its own alt text.
+    expect(written).toContain(`![one](${url})`);
+    expect(written).toContain(`![two](${url})`);
+    expect(written).not.toContain("a/shot.png");
+    expect(written).not.toContain("b/shot.png");
+  });
+
+  it("uploads separately for two paths whose bytes differ", async () => {
+    mkdirSync(join(home, "a"), { recursive: true });
+    mkdirSync(join(home, "b"), { recursive: true });
+    writeFileSync(join(home, "a", "shot.png"), Buffer.from([1, 1, 1]));
+    writeFileSync(join(home, "b", "shot.png"), Buffer.from([2, 2, 2]));
+    writeFileSync(file, "# My Plan\n\n![](<a/shot.png>)\n\n![](<b/shot.png>)\n");
+
+    await doUpload(file, []);
+
+    expect(upload).toHaveBeenCalledTimes(2);
+    expect(upload.mock.calls[0]![0]).not.toBe(upload.mock.calls[1]![0]);
+  });
+
+  it("uploads separately for identical bytes under different extensions", async () => {
+    // The stored Content-Type is derived from the extension, so one object can't back both links
+    // — reusing it would serve image/png bytes as image/jpeg (or vice versa) for the other ref.
+    const bytes = Buffer.from([7, 7, 7]);
+    writeFileSync(join(home, "same.png"), bytes);
+    writeFileSync(join(home, "same.jpg"), bytes);
+    writeFileSync(file, "# My Plan\n\n![](<same.png>)\n\n![](<same.jpg>)\n");
+
+    await doUpload(file, []);
+
+    expect(upload).toHaveBeenCalledTimes(2);
+    const types = upload.mock.calls.map((c) => (c[2] as { contentType: string }).contentType).sort();
+    expect(types).toEqual(["image/jpeg", "image/png"]);
+  });
+
+  it("counts a deduplicated object once for orphan cleanup", async () => {
+    // uploadedPaths feeds cleanupOrphanedUploads on a failed body commit. A dedup that pushed the
+    // same path twice would ask storage to remove it twice — harmless here, but it would also
+    // mean the count reported for a successful promote overstated what was actually created.
+    mkdirSync(join(home, "a"), { recursive: true });
+    mkdirSync(join(home, "b"), { recursive: true });
+    const bytes = Buffer.from([4, 4, 4]);
+    writeFileSync(join(home, "a", "s.png"), bytes);
+    writeFileSync(join(home, "b", "s.png"), bytes);
+    writeFileSync(file, "# My Plan\n\n![](<a/s.png>)\n\n![](<b/s.png>)\n");
+    updateMatches = false; // lose the CAS race so the cleanup path runs
+
+    await doUpload(file, []);
+
+    expect(remove).toHaveBeenCalledTimes(1);
+    expect(remove.mock.calls[0]![0]).toHaveLength(1);
+  });
+
+  it("reuses a registered object instead of re-uploading identical bytes", async () => {
+    // The demote → edit → promote cycle. Object names carry no content, so without the registry
+    // "unchanged" is inexpressible and every re-promote publishes a fresh copy and orphans the
+    // previous one.
+    const bytes = Buffer.from([5, 5, 5, 5]);
+    const sha = createHash("sha256").update(bytes).digest("hex");
+    assetRegistry.set(`${sha}|png`, "org-1/doc-new/image-20260101000000-deadbeef.png");
+    writeFileSync(join(home, "shot.png"), bytes);
+    writeFileSync(file, "# My Plan\n\n![](<shot.png>)\n");
+
+    await doUpload(file, []);
+
+    expect(upload).not.toHaveBeenCalled();
+    expect(readFileSync(file, "utf8")).toContain("https://cdn.test/doc-images/org-1/doc-new/image-20260101000000-deadbeef.png");
+    expect(assetInserts).toHaveLength(0); // already known — nothing new to record
+  });
+
+  it("never deletes a reused object when the body commit fails", async () => {
+    // The safety invariant. A reused object was created by an EARLIER sync, and older
+    // doc_versions bodies still resolve through its URL — so the failed-commit cleanup, which
+    // exists to remove what THIS run stranded, must not touch it.
+    const bytes = Buffer.from([6, 6, 6, 6]);
+    const sha = createHash("sha256").update(bytes).digest("hex");
+    assetRegistry.set(`${sha}|png`, "org-1/doc-new/image-20260101000000-cafebabe.png");
+    writeFileSync(join(home, "shot.png"), bytes);
+    writeFileSync(file, "# My Plan\n\n![](<shot.png>)\n");
+    updateMatches = false; // lose the CAS race → cleanup path runs
+
+    await doUpload(file, []);
+
+    expect(upload).not.toHaveBeenCalled();
+    expect(remove).not.toHaveBeenCalled();
+  });
+
+  it("records each upload in the registry, keyed by content and stored extension", async () => {
+    writeFileSync(join(home, "a.png"), Buffer.from([1, 2]));
+    writeFileSync(join(home, "b.jpg"), Buffer.from([3, 4]));
+    writeFileSync(file, "# My Plan\n\n![](<a.png>)\n\n![](<b.jpg>)\n");
+
+    await doUpload(file, []);
+
+    expect(upload).toHaveBeenCalledTimes(2);
+    expect(assetInserts).toHaveLength(2);
+    expect(assetInserts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ doc_id: "doc-new", sha256: createHash("sha256").update(Buffer.from([1, 2])).digest("hex"), ext: "png" }),
+        expect.objectContaining({ doc_id: "doc-new", sha256: createHash("sha256").update(Buffer.from([3, 4])).digest("hex"), ext: "jpg" }),
+      ]),
+    );
+  });
+
+  it("uploads normally when the registry is unavailable (older cloud, or denied select)", async () => {
+    // Fail open: a missing table must cost a duplicate object, never the promote.
+    assetRegistryError = { message: 'relation "doc_assets" does not exist' };
+    writeFileSync(join(home, "shot.png"), Buffer.from([8, 8]));
+    writeFileSync(file, "# My Plan\n\n![](<shot.png>)\n");
+
+    await doUpload(file, []);
+
+    expect(upload).toHaveBeenCalledTimes(1);
+    expect(readFileSync(file, "utf8")).toContain("https://cdn.test/doc-images/org-1/doc-new/image-");
     expect(lastJson()).toMatchObject({ status: "uploaded", cloudDocId: "doc-new" });
   });
 


### PR DESCRIPTION
> **Stacked on #114** (it extends `doAssetUploadForDoc`, added there). Base retargets to `main` automatically when #114 merges. Cloud counterpart: [inplan-cloud#244](https://github.com/Crazy-Idea-Studio/inplan-cloud/pull/244).

## The question this answers

*When syncing a local doc to the cloud, how do you know which image already exists as-is and which needs uploading?*

Today: by the **link's shape**, never the bytes. `migrateLocalImages` asks only whether a destination is a local relative path — local means upload, `https://` means skip. And the object name is `image-<timestamp>-<random>`, so nothing about it derives from the content. There is no name you could derive from a local file to ask "is this already up there?"

Two duplications follow, both invisible afterwards.

**Within one promote.** `uploadedByDest` was keyed by the destination *string*, so two links to byte-identical files each uploaded their own object. Measured on a real doc — 49 objects, 48 distinct contents:

```
sha256 f047f540ca7f  (29218 bytes) x2
    image-20260810085021.jpg   ← orphan, referenced by nothing
    image-20260810085412.jpg   ← the live one
```

**Across syncs.** Nothing could recognize a repeat at all. `demote` → edit → `upload` re-uploaded every image under fresh names and orphaned the previous set, because "unchanged" was inexpressible.

## What changed

- **Hash-keyed dedup** inside a promote. Extension stays part of the key — `Content-Type` is derived from it, so the same bytes as `.png` and `.jpg` genuinely need separate objects.
- **A registry lookup** (`doc_assets`, cloud #244) before uploading, and a record after. A re-sync reuses the object and the body keeps the same URLs.
- **The paste path too** (`asset-upload`). The editor hands over bytes, not a path, so nothing else could spot a repeat there; the result carries `reused: true` when it does.

Names stay random on purpose. Content-addressed *names* would answer this without a table, but the bucket is public and any shared image URL leaks `org_id`/`doc_id` — so a hash-derived name lets anyone holding a candidate file confirm whether it's in that doc. The registry keeps the lookup and drops the oracle; reasoning is in #244.

## Two invariants worth reviewing closely

**A reused object is not added to `uploadedPaths`.** That list feeds `cleanupOrphanedUploads` on a failed body commit. This run didn't create a reused object, and older `doc_versions` bodies still resolve through its URL — deleting it would break history. Test: `never deletes a reused object when the body commit fails`.

**The paste path hashes under the extension that will actually be stored.** `uploadAssetBytes` rewrites an unrecognized extension to `png`; registering under the *requested* one would never match the object it produced, so every repeat paste of a `.bmp` would upload again. Test: `keys on the extension actually stored, so an unrecognized one still reuses`.

## Fails open, always

Every registry call swallows its error and returns "unknown". A cloud predating the table, a denied select, anything: the caller uploads exactly as it does today. Trading a duplicate object for a failed promote would be much worse than the duplicate. This is why the two PRs can land in either order, and why an older CLI against a migrated cloud is fine too.

## Tests

8 new (4 dedup, 4 registry), full suite **1404 passed**, coverage **95.52%** (gate 95%).

Verified non-vacuous by disabling the hash cache: the two dedup assertions fail, the other 19 pass — including the two guards that dedup must *not* over-collapse (differing bytes, differing extensions), which pass either way by design.

## What this does not do

Dedups **bytes, not images** — re-export or re-compress the same screenshot and you get a new object. And dedup is per-doc by design: the path is `<org>/<doc>/…` because the bucket policy validates those segments, and sharing objects across docs would mean deleting one doc breaks another's images.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate cloud asset uploads when identical image content already exists.
  * Added extension-aware reuse while keeping different formats and image contents separate.
  * Improved document asset migration to reuse existing files and clean up only newly created objects.
  * Uploads continue normally when asset registry services are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->