### PR TITLE
release: 0.3.0 — an agent can put an image in a cloud doc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5335,7 +5335,7 @@
     },
     "packages/cli": {
       "name": "@inplan/cli",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@hocuspocus/provider": "^2.15.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inplan/cli",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "private": true,
   "description": "inplan CLI: open / wait / signal orchestration over the document core.",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
Minor bump. Adds a capability agents didn't have and changes what the skill tells them to do, so it shouldn't sit unreleased behind a patch number.

Bumps `packages/cli/package.json` only — the CLI reads `--version` from it at runtime, so that's the single place, per `release.yml`. Lockfile re-synced (`check-lockfile-sync` ✓).

## What ships

**[#114] `asset-upload` reaches the docs agents actually attach to.** It resolved its doc id from the status sidecar, which only a promoted local file has. A doc attached by `wait --remote <docId>` has no status file, and `--remote` wasn't a recognized route either — it fell through to the generic remote handler and ran a *sync* instead of an upload. So the only command for putting an image into a cloud document couldn't be called for the docs agents work on. The visible result was plan bodies carrying image **filenames** as placeholders for a human to attach by hand.

**[#114] SKILL.md gains an Images section.** It previously said nothing about images at all — no mention of assets, uploads, or attachments anywhere. That silence is why the command went unused despite being listed in the bare `inplan` usage text.

**[#115] Images upload once, not once per reference.** Within a promote the cache keyed on the destination *string*, so two links to byte-identical files each published their own object; it keys on the bytes now. Across syncs nothing could recognize a repeat at all, so `demote` → edit → `upload` re-uploaded every image under fresh random names and orphaned the previous set. The `doc_assets` registry makes that reuse instead.

## Cloud prerequisite — already done

`doc_assets` ([inplan-cloud#244](https://github.com/Crazy-Idea-Studio/inplan-cloud/pull/244)) is applied to **both dev and prod**, verified non-vacuously on each (a row present: service-role sees it, anon sees zero, anon insert 401, non-hex sha256 rejected 400; both left clean).

Nothing here depends on that landing, though — every registry call fails open, so an older cloud behaves exactly as 0.2.2 did.

## After merge

Publishing a GitHub Release tagged `v0.3.0` triggers `release.yml` → npm via OIDC trusted publishing, with provenance. Say the word and I'll cut it, or take it yourself.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

