### PR TITLE
fix(deps): linkify-it 5.0.1 → 5.0.2 (CVE-2026-59887)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5335,7 +5335,7 @@
     },
     "packages/cli": {
       "name": "@inplan/cli",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@hocuspocus/provider": "^2.15.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3395,9 +3395,9 @@
       "license": "MIT"
     },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "funding": [
         {
           "type": "github",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inplan/cli",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "private": true,
   "description": "inplan CLI: open / wait / signal orchestration over the document core.",
   "license": "AGPL-3.0-or-later",


### PR DESCRIPTION
Closes #113.

Lockfile only — `markdown-it` asks for `^5.0.1`, so 5.0.2 satisfies the existing range and nothing in any `package.json` needs to move.

```
-  "version": "5.0.1"
+  "version": "5.0.2"
```

## Why it's worth taking, not just noise

The ReDoS is in the `mailto:` schema validator, which runs an O(n²) scan per occurrence. That path is genuinely reachable here:

- `linkify-it` is a **prod** dependency, not dev — it comes in via `markdown-it`, which renders the plan body.
- Plan bodies are **not trusted-solely-authored input**. Cloned repos, collaborators, and agents all write them — the same reasoning already written into `migrateLocalImages`' path-traversal guard.

So a body carrying crafted `mailto:` text is attacker-controlled input reaching a quadratic scan in the renderer.

## Verification

Full suite passes unchanged — **1404 passed**, coverage 95.52% — so the markdown-it render path is unaffected by the bump. `check-lockfile-sync` ✓. `npm audit` no longer reports `linkify-it`.

## What this does *not* fix

Being straight about the audit output: 10 advisories remain, including 4 high and 2 critical. All are in the **dev toolchain**, unrelated to this CVE:

| | |
|---|---|
| critical | `vitest`, `@vitest/coverage-v8` |
| high | `vite`, `postcss`, `nanoid`, `brace-expansion` |

Worth a separate pass — the vitest/vite ones would want a major bump and their own PR — but out of scope here, and none of them ship to users.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/melly-lgtm/inplan/pull/117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

